### PR TITLE
Fixing commands with custom RNCWebView subclass

### DIFF
--- a/docs/Custom-Android.md
+++ b/docs/Custom-Android.md
@@ -183,7 +183,10 @@ export default class CustomWebView extends Component {
 
   render() {
     return (
-      <WebView {...this.props} nativeConfig={{ component: RCTCustomWebView }} />
+      <WebView {...this.props} nativeConfig={{
+        component: RCTCustomWebView,
+        viewName: 'RCTCustomWebView'
+      }} />
     );
   }
 }

--- a/docs/Custom-iOS.md
+++ b/docs/Custom-iOS.md
@@ -195,6 +195,7 @@ export default class CustomWebView extends Component {
         nativeConfig={{
           component: RCTCustomWebView,
           viewManager: CustomWebViewManager,
+          viewName: 'RCTCustomWebView'
         }}
       />
     );

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -17,6 +17,7 @@ import Downloads from './examples/Downloads';
 import Uploads from './examples/Uploads';
 import Injection from './examples/Injection';
 import LocalPageLoad from './examples/LocalPageLoad';
+import Custom from './examples/Custom';
 
 const TESTS = {
   Alerts: {
@@ -75,6 +76,14 @@ const TESTS = {
       return <LocalPageLoad />;
     },
   },
+  Custom: {
+    title: 'Custom',
+    testId: 'Custom',
+    description: 'Custom Subclass test',
+    render() {
+      return <Custom />;
+    }
+  }
 };
 
 type Props = {};
@@ -147,6 +156,11 @@ export default class App extends Component<Props, State> {
             testID="testType_uploads"
             title="Uploads"
             onPress={() => this._changeTest('Uploads')}
+          />}
+          {Platform.OS == "ios" && <Button
+            testID="testType_custom"
+            title="Custom"
+            onPress={() => this._changeTest('Custom')}
           />}
         </View>
 

--- a/example/examples/Custom.tsx
+++ b/example/examples/Custom.tsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { View, Button, NativeModules, requireNativeComponent, UIManager } from 'react-native';
+import WebView from 'react-native-webview';
+import { alertIsPresent } from 'selenium-webdriver/lib/until';
+
+const CustomViewName = 'CustomWebView';
+const { CustomWebViewManager } = NativeModules;
+const CustomWebView = requireNativeComponent(CustomViewName);
+
+type Props = {};
+type State = {};
+
+export default class Custom extends Component<Props, State> {
+    webview = null;
+
+    reload = () => this.webview.reload();
+
+    showCommands = () => {
+        const commands = this.webview.getCommands();
+        alert(JSON.stringify(commands));
+    }
+
+    injectAlert = () => {
+        this.webview.injectJavaScript("alert('Hi from WebView')");
+    }
+
+    render() {
+        return (
+            <View>
+                <View style={{ width: '100%', height: '100%' }}>
+                    <Button title={"Inject Alert"} onPress={this.injectAlert} />
+                    <Button title={"Show commands"} onPress={this.showCommands} />
+                    <WebView
+                      ref={ref => {this.webview = ref}}
+                      source={{uri: "https://archive.org"}}
+                      nativeConfig={{
+                         component: CustomWebView,
+                         viewManager: CustomWebViewManager,
+                         viewName: CustomViewName
+                      }}
+                    />
+                </View>
+            </View>
+        );
+    }
+}

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
 		646BD8E8CDDF5A464B5419B3 /* libPods-example-tvOS-example-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4830F7139A954350DD22DE4A /* libPods-example-tvOS-example-tvOSTests.a */; };
+		9498A3072491794E002473B0 /* CustomWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9498A3062491794E002473B0 /* CustomWebView.m */; };
+		9498A30A24917962002473B0 /* CustomWebViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9498A30924917962002473B0 /* CustomWebViewManager.m */; };
 		C7D826CF866C25BE421302B6 /* libPods-example-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A8A9F158876EC099CFA57A /* libPods-example-tvOS.a */; };
 		D0E3313DFCE78BFCB650F812 /* libPods-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB301596D47BBAD9E9C0A45A /* libPods-exampleTests.a */; };
 		E719A6E171791CD8906B3D55 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 917A19FC1EBE6E8B85FE404D /* libPods-example.a */; };
@@ -62,6 +64,10 @@
 		775F6B7492793F5DB7ECE95B /* Pods-example-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-example-tvOS/Pods-example-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8A20011E75A0AD2EC5C6EAE9 /* Pods-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-exampleTests/Pods-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		917A19FC1EBE6E8B85FE404D /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9498A3052491794E002473B0 /* CustomWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CustomWebView.h; path = example/CustomWebView.h; sourceTree = "<group>"; };
+		9498A3062491794E002473B0 /* CustomWebView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CustomWebView.m; path = example/CustomWebView.m; sourceTree = "<group>"; };
+		9498A30824917962002473B0 /* CustomWebViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CustomWebViewManager.h; path = example/CustomWebViewManager.h; sourceTree = "<group>"; };
+		9498A30924917962002473B0 /* CustomWebViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CustomWebViewManager.m; path = example/CustomWebViewManager.m; sourceTree = "<group>"; };
 		CB301596D47BBAD9E9C0A45A /* libPods-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
@@ -134,6 +140,10 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				9498A3052491794E002473B0 /* CustomWebView.h */,
+				9498A3062491794E002473B0 /* CustomWebView.m */,
+				9498A30824917962002473B0 /* CustomWebViewManager.h */,
+				9498A30924917962002473B0 /* CustomWebViewManager.m */,
 			);
 			name = example;
 			sourceTree = "<group>";
@@ -532,6 +542,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9498A30A24917962002473B0 /* CustomWebViewManager.m in Sources */,
+				9498A3072491794E002473B0 /* CustomWebView.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);

--- a/example/ios/example/CustomWebView.h
+++ b/example/ios/example/CustomWebView.h
@@ -1,0 +1,8 @@
+#import <react-native-webview/RNCWebView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CustomWebView : RNCWebView
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/example/CustomWebView.m
+++ b/example/ios/example/CustomWebView.m
@@ -1,0 +1,5 @@
+#import "CustomWebView.h"
+
+@implementation CustomWebView
+
+@end

--- a/example/ios/example/CustomWebViewManager.h
+++ b/example/ios/example/CustomWebViewManager.h
@@ -1,0 +1,9 @@
+#import <react-native-webview/RNCWebViewManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CustomWebViewManager : RNCWebViewManager
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/example/CustomWebViewManager.m
+++ b/example/ios/example/CustomWebViewManager.m
@@ -1,0 +1,24 @@
+#import "CustomWebViewManager.h"
+
+#import "CustomWebView.h"
+
+#import <React/RCTDefines.h>
+#import <React/RCTUIManager.h>
+
+@implementation CustomWebViewManager
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(exampleCommand:(nonnull NSNumber *)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, CustomWebView *> *viewRegistry) {
+    CustomWebView *view = [viewRegistry objectForKey:reactTag];
+    if (![view isKindOfClass:[CustomWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting CustomWebView, got: %@", view);
+    } else {
+      [view reload];
+    }
+  }];
+}
+
+@end

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -84,7 +84,12 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     BatchedBridge.registerCallableModule(this.messagingModuleName, this);
   };
 
-  getCommands = () => UIManager.getViewManagerConfig('RNCWebView').Commands;
+  getCommands = () => {
+    const viewName
+      = (this.props.nativeConfig && this.props.nativeConfig.viewName)
+      || 'RNCWebView';
+    return UIManager.getViewManagerConfig(viewName).Commands;
+  };
 
   goForward = () => {
     UIManager.dispatchViewManagerCommand(

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -75,7 +75,12 @@ class WebView extends React.Component<IOSWebViewProps, State> {
   webViewRef = React.createRef<NativeWebViewIOS>();
 
   // eslint-disable-next-line react/sort-comp
-  getCommands = () => UIManager.getViewManagerConfig('RNCWebView').Commands;
+  getCommands = () => {
+    const viewName
+      = (this.props.nativeConfig && this.props.nativeConfig.viewName)
+      || 'RNCWebView';
+    return UIManager.getViewManagerConfig(viewName).Commands;
+  };
 
   /**
    * Go forward one page in the web view's history.

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -63,7 +63,12 @@ class WebView extends React.Component<MacOSWebViewProps, State> {
   webViewRef = React.createRef<NativeWebViewMacOS>();
 
   // eslint-disable-next-line react/sort-comp
-  getCommands = () => UIManager.getViewManagerConfig('RNCWebView').Commands;
+  getCommands = () => {
+    const viewName
+      = (this.props.nativeConfig && this.props.nativeConfig.viewName)
+      || 'RNCWebView';
+    return UIManager.getViewManagerConfig(viewName).Commands;
+  };
 
   /**
    * Go forward one page in the web view's history.

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -72,10 +72,17 @@ export default class WebView extends React.Component<WebViewSharedProps, State> 
 
   webViewRef = React.createRef<NativeWebViewWindows>();
 
+  getCommands = () => {
+    const viewName
+      = (this.props.nativeConfig && this.props.nativeConfig.viewName)
+      || 'RNCWebView';
+    return UIManager.getViewManagerConfig(viewName).Commands;
+  };
+
   goForward = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
-      UIManager.getViewManagerConfig('RCTWebView').Commands.goForward,
+      this.getCommands().goForward,
       undefined,
     );
   }
@@ -83,7 +90,7 @@ export default class WebView extends React.Component<WebViewSharedProps, State> 
   goBack = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
-      UIManager.getViewManagerConfig('RCTWebView').Commands.goBack,
+      this.getCommands().goBack,
       undefined,
     );
   }
@@ -91,7 +98,7 @@ export default class WebView extends React.Component<WebViewSharedProps, State> 
   reload = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
-      UIManager.getViewManagerConfig('RCTWebView').Commands.reload,
+      this.getCommands().reload,
       undefined,
     );
   }
@@ -99,7 +106,7 @@ export default class WebView extends React.Component<WebViewSharedProps, State> 
   injectJavaScript = (data: string) => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
-      UIManager.getViewManagerConfig('RCTWebView').Commands.injectJavaScript,
+      this.getCommands().injectJavaScript,
       [data],
     );
   }
@@ -107,7 +114,7 @@ export default class WebView extends React.Component<WebViewSharedProps, State> 
   postMessage = (data: string) => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
-      UIManager.getViewManagerConfig('RCTWebView').Commands.postMessage,
+      this.getCommands().postMessage,
       [String(data)],
     );
   };

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -229,6 +229,11 @@ export interface WebViewNativeConfig {
    * @platform ios, macos
    */
   viewManager?: ViewManager;
+  /**
+   * Set the ViewName you also use with `requireNativeComponent` to create a custom web view.
+   * @platform ios, macos
+   */
+  viewName?: string;
 }
 
 export type OnShouldStartLoadWithRequest = (


### PR DESCRIPTION
# Summary

This adds the `viewName` prop to `nativeConfig` and uses it when looking up commands that are going to get performed on a custom web view.

This solves a bug that occurs with custom subclasses of `RNCWebView`. I didn't report the bug yet, but I added an example that demonstrates it to this PR.

## The issue

The short version is: The implementation of `getCommands` always checked the original `RNCWebView`, and therefore did never consider commands added to a custom subclass of `RNCWebViewManager`. Therefore we would use the wrong command indexes when executing a command. I.e. `injectJavascript` would usually be at index `1`. If a custom view manager subclass added a new command that alphabetically would come before `injectJavascript` it would push that command back by one. Without the fix we would still use the old index `1` even though points to another command now.

## Test Plan

I extended the iOS example with a case for a custom web view. There are two buttons in the example:

- "Inject Alert" that triggers an alert inside the webview via a call to `injectJavascript`
- "Show commands" that logs out the map of commands. It should contain `exampleCommand` that has been added to `CustomWebViewManager`.

To reproduce the original bug it's enough to simply not pass the `nativeConfig.viewName` prop in `Custom.tsx`. This will still render the webview, but `injectJavascript` won't work (side note: calling `webView.injectJavascript` will actually have the same effect as calling `webView.postMessage`).

### What's required for testing (prerequisites)?

Just the iOS example app.

### What are the steps to reproduce (after prerequisites)?

- Checkout this PR
- `yarn install`
- `pod install --project-directory=example/ios`
- `open example/ios/example.xcworkspace` and run in Xcode (I wasn't personably able to run it from `yarn start:ios` like mentioned in Contribution.md)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| macOS     |    ✅     |
| windows     |    ✅     |

I only implemented the example for iOS though.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` << **Where is this?**
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)

I also updated `docs/Custom-iOS.md` but just the `nativeConfig` part. The whole file needs a revamp, but that's a know issue I guess.