### PR TITLE
fix(android): Update SSL error handling

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -17,6 +17,7 @@ import android.os.Environment;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -801,8 +802,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
+        // onReceivedSslError is called for most requests, per Android docs: https://developer.android.com/reference/android/webkit/WebViewClient#onReceivedSslError(android.webkit.WebView,%2520android.webkit.SslErrorHandler,%2520android.net.http.SslError)
         // WebView.getUrl() will return the top-level window URL.
-        // If a top-level navigation triggers this error handler, the top-level URL will be the failing URL (not the current URL).
+        // If a top-level navigation triggers this error handler, the top-level URL will be the failing URL (not the URL of the currently-rendered page).
         // This is desired behavior. We later use these values to determine whether the request is a top-level navigation or a subresource request.
         String topWindowUrl = webView.getUrl();
         String failingUrl = error.getUrl();
@@ -814,6 +816,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         if (!topWindowUrl.equalsIgnoreCase(failingUrl)) {
           // If error is not due to top-level navigation, then do not call onReceivedError()
+          Log.w("RNCWebViewManager", "Resource blocked from loading due to SSL error. Blocked URL: "+failingUrl);
           return;
         }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -801,10 +801,23 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
+        // WebView.getUrl() will return the top-level window URL.
+        // If a top-level navigation triggers this error handler, the top-level URL will be the failing URL (not the current URL).
+        // This is desired behavior. We later use these values to determine whether the request is a top-level navigation or a subresource request.
+        String topWindowUrl = webView.getUrl();
+        String failingUrl = error.getUrl();
+        
+        // Cancel request after obtaining top-level URL.
+        // If request is cancelled before obtaining top-level URL, undesired behavior may occur.
+        // Undesired behavior: Return value of WebView.getUrl() may be the current URL instead of the failing URL.
         handler.cancel();
 
+        if (!topWindowUrl.equalsIgnoreCase(failingUrl)) {
+          // If error is not due to top-level navigation, then do not call onReceivedError()
+          return;
+        }
+
         int code = error.getPrimaryError();
-        String failingUrl = error.getUrl();
         String description = "";
         String descriptionPrefix = "SSL error: ";
 


### PR DESCRIPTION
# Summary

Fixes issue introduced in PR #1450.

This PR updates the SSL error handling to call onReceivedError() only on top-level navigations.

This prevents iframes and other subresources from causing user-visible SSL error messages. The desired behavior is only to have top-level navigations show user-visible error messages. All other requests should be cancelled automatically with no user-visible error message.

## Test Plan

### What's required for testing (prerequisites)?
Use any basic React Native WebView app (I have a PoC app I use to generally test RNWV behavior.)

### What are the steps to reproduce (after prerequisites)?

#### iframe navigations
1. Navigate the top-level window to https://aogarantiza.com/react/webview-ssl-error-test.html
2. Tap the link in the iframe.

Observed behavior due to #1450: iframe navigation is cancelled but user-visible error is shown which covers the full page, making it seem like a top-level navigation issue.

Expected behavior, introduced with this PR: iframe navigation is cancelled and no user-visible error is shown.

#### Top-level navigations
1. Navigate the top-level window to https://aogarantiza.com/react/webview-ssl-error-test.html
2. Tap the link in the top document.

Observed behavior due to #1450: top-level window is cancelled and user-visible error is shown which covers the full page.

Expected behavior: Unchanged from #1450. (Desired behavior.)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [`N/A`] I added the documentation in `README.md`
- [`N/A`] I mentioned this change in `CHANGELOG.md`
- [`N/A`] I updated the typed files (TS and Flow)
- [`N/A`] I added a sample use of the API in the example project (`example/App.js`)
