### PR TITLE
Basic Authentication Support

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -67,6 +67,7 @@
 @property (nonatomic, assign) BOOL directionalLockEnabled;
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
+@property (nonatomic, copy) NSDictionary * _Nullable basicAuthCredential;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL enableApplePay;
 #if !TARGET_OS_OSX

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -840,6 +840,15 @@ static NSDictionary* customCertificatesForHost;
             }
         }
     }
+    if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic) {
+        NSString *username = [_basicAuthCredential valueForKey:@"username"];
+        NSString *password = [_basicAuthCredential valueForKey:@"password"];
+        if (username && password) {
+            NSURLCredential *credential = [NSURLCredential credentialWithUser:username password:password persistence:NSURLCredentialPersistenceNone];
+            completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+            return;
+        }
+    }
     completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
 }
 

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -76,6 +76,7 @@ RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
+RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -79,6 +79,7 @@ This document lays out the current public properties and methods for the React N
 - [`limitsNavigationsToAppBoundDomains`](Reference.md#limitsNavigationsToAppBoundDomains)
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
 - [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows)
+- [`basicAuthCredential`](Reference.md#basicAuthCredential)
 - [`enableApplePay`](Reference.md#enableApplePay)
 - [`forceDarkOn`](Reference.md#forceDarkOn)
 
@@ -1439,6 +1440,17 @@ Example:
 ```javascript
 <WebView forceDarkOn={false} />
 ```
+
+### `basicAuthCredential`
+
+An object that specifies the credentials of a user to be used for basic authentication.
+
+- `username` (string) - A username used for basic authentication.
+- `password` (string) - A password used for basic authentication.
+
+| Type   | Required |
+| ------ | -------- |
+| object | No       |
 
 ## Methods
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -251,6 +251,18 @@ export type OnShouldStartLoadWithRequest = (
   event: ShouldStartLoadRequest,
 ) => boolean;
 
+export interface BasicAuthCredential {
+  /**
+   * A username used for basic authentication.
+   */
+  username: string;
+
+  /**
+   * A password used for basic authentication.
+   */
+  password: string;
+}
+
 export interface CommonNativeWebViewProps extends ViewProps {
   cacheEnabled?: boolean;
   incognito?: boolean;
@@ -279,6 +291,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
    * Append to the existing user-agent. Overridden if `userAgent` is set.
    */
   applicationNameForUserAgent?: string;
+  basicAuthCredential?: BasicAuthCredential;
 }
 
 export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
@@ -1163,4 +1176,9 @@ export interface WebViewSharedProps extends ViewProps {
    * Append to the existing user-agent. Overridden if `userAgent` is set.
    */
   applicationNameForUserAgent?: string;
+
+  /**
+   * An object that specifies the credentials of a user to be used for basic authentication.
+   */
+  basicAuthCredential?: BasicAuthCredential;
 }


### PR DESCRIPTION
# Summary

I have created a PR that supports basic authentication. This allows to use the `basicAuthCredential` property to pass in a `username` and `password` to use for basic authentication.

**Related Issues**

#18

**Solution**

On iOS, within the existing `didReceiveAuthenticationChallenge` delegate method, I added handling for the type `NSURLAuthenticationMethodHTTPBasic`.

On Android, I have overridden the `onReceivedHttpAuthRequest` callback method.

**Impact**

Since I added new code, I think it will have little impact on existing code.

## Test Plan

I checked the operation on iPhone 7 (iOS 13.5.1) and Pixel 3a (Android 11-beta1).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device
- [X] I added the documentation in `REFERENCE.md`
- [X] I updated the typed files (TS)