### PR TITLE
Fix Android onLoadingFinish url comparison to compare using lowercases to solve infinite loading

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -230,7 +230,6 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
 
   onLoadingFinish = (event: WebViewNavigationEvent) => {
     const { onLoad, onLoadEnd } = this.props;
-    const { nativeEvent: { url } } = event;
     if (onLoad) {
       onLoad(event);
     }

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -230,15 +230,18 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
 
   onLoadingFinish = (event: WebViewNavigationEvent) => {
     const { onLoad, onLoadEnd } = this.props;
+    const { nativeEvent: { url } } = event;
     if (onLoad) {
       onLoad(event);
     }
     if (onLoadEnd) {
       onLoadEnd(event);
     }
-    this.setState({
-      viewState: 'IDLE',
-    });
+    if (url && this.startUrl && url.toLowerCase() === this.startUrl.toLowerCase()) {
+      this.setState({
+          viewState: 'IDLE',
+      });
+    }
     this.updateNavigationState(event);
   };
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -237,11 +237,9 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     if (onLoadEnd) {
       onLoadEnd(event);
     }
-    if (url === this.startUrl) {
-      this.setState({
-        viewState: 'IDLE',
-      });
-    }
+    this.setState({
+      viewState: 'IDLE',
+    });
     this.updateNavigationState(event);
   };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This pull request resolves the problem where in Android, the Webview will end up in a state of infinite loading when the navigation state changes to a similar URL but with some letters capitalised.

Example:
current: _www.google.com_
next url: _www.Google.com_

This changes compares the current and next url in lower cases, so that the state of the webview can be set back to "IDLE" and not forever stuck in "LOADING".
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

1. Have a redirection where the next url is similar but with capital letters.

### What are the steps to reproduce (after prerequisites)?

1. Pull the changes & rebuild android.

## Compatibility

Issue only appears in **Android** due to a different way of checking.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
