### PR TITLE
fix path for iOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
 // eslint-disable-next-line
-import { IOSWebViewProps, AndroidWebViewProps } from './lib/WebViewTypes';
+import { IOSWebViewProps, AndroidWebViewProps } from './src/WebViewTypes';
 
-export { FileDownload, WebViewMessageEvent, WebViewNavigation } from "./lib/WebViewTypes";
+export { FileDownload, WebViewMessageEvent, WebViewNavigation } from "./src/WebViewTypes";
 
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import WebView from './lib/WebView';
+import WebView from './src/WebView';
 
 export { WebView };
 export default WebView;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Trying to use this with iOS, i found that it doesn't work because of wrong path 
I changed it to ./src

## Test Plan
react-native run-ios


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
