### PR TITLE
[Android] Sends cookies with resource requests

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -110,6 +110,8 @@ import javax.annotation.Nullable;
  */
 @ReactModule(name = RNCWebViewManager.REACT_CLASS)
 public class RNCWebViewManager extends SimpleViewManager<WebView> {
+  
+  private static final Map<String, String> COOKIE_MAP = new HashMap<>();
 
   public static final int COMMAND_GO_BACK = 1;
   public static final int COMMAND_GO_FORWARD = 2;
@@ -797,6 +799,20 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
       final String url = request.getUrl().toString();
       return this.shouldOverrideUrlLoading(view, url);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+      String cookie = request.getRequestHeaders() == null ? null : request.getRequestHeaders().get("cookie");
+      if (null == cookie || cookie.length() == 0) {
+        if (COOKIE_MAP.containsKey(request.getUrl().getAuthority())) {
+          CookieManager.getInstance().setCookie(request.getUrl().toString(), COOKIE_MAP.get(request.getUrl().getAuthority()));
+        }
+      } else {
+        COOKIE_MAP.put(request.getUrl().getAuthority(), cookie);
+      }
+      return super.shouldInterceptRequest(view, request);
     }
 
     @Override


### PR DESCRIPTION
To attach cookie with all resource requests for the page loaded
# Summary
* This PR solves this feature request [#1532 ](https://github.com/react-native-community/react-native-webview/issues/1532)

* How did you implement the solution?
I implemented this solution by adding a map for storing cookies for authority name and overriding the shouldInterceptRequest callback in RNCWebViewClient.

* What areas of the library does it impact?
RNCWebViewManager, RNCWebViewClient

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| Android |✅|

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
