### PR TITLE
WebViewAssetLoader support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,4 +134,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation 'androidx.webkit:webkit:1.2.0'
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -43,6 +43,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
+import androidx.webkit.WebViewAssetLoader;
+import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler;
+import androidx.webkit.WebViewAssetLoader.AssetsPathHandler;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.views.scroll.ScrollEvent;
@@ -149,6 +152,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
 
+  private static WebViewAssetLoader assetLoader;
+
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
       public void configWebView(WebView webView) {
@@ -195,6 +200,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       setAllowUniversalAccessFromFileURLs(webView, false);
     }
     setMixedContentMode(webView, "never");
+
+    if (assetLoader == null) {
+      assetLoader = new WebViewAssetLoader.Builder()
+        .addPathHandler("/assets/", new AssetsPathHandler(reactContext))
+        .addPathHandler("/res/", new ResourcesPathHandler(reactContext))
+        .build();
+    }
 
     // Fixes broken full-screen modals/galleries due to body height being 0.
     webView.setLayoutParams(
@@ -777,6 +789,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     ReadableArray mUrlPrefixesForDefaultIntent;
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
     protected @Nullable String ignoreErrFailedForThisURL = null;
+
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view,
+                                                      WebResourceRequest request) {
+      return assetLoader.shouldInterceptRequest(request.getUrl());
+    }
 
     public void setIgnoreErrFailedForThisURL(@Nullable String url) {
       ignoreErrFailedForThisURL = url;

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -97,15 +97,8 @@ For example:
 
 ```tsx
 <WebView
-  ref={webViewRef}
-  originWhitelist={['*']}
   source={{
     uri: 'https://appassets.androidplatform.net/assets/index.html',
-  }}
-  onLoadEnd={sendRequests}
-  onMessage={(event) => {
-    console.log('resolve', event);
-    resolve(event.nativeEvent.data);
   }}
 />
 ```

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -89,6 +89,27 @@ class MyWeb extends Component {
 }
 ```
 
+**Access local assets by WebViewAssetLoader on android x**
+
+Android x provide a new way to access assets, by using WebViewAssetLoader. now we can access assets via uri **https://appassets.androidplatform.net/assets/some-assets**
+
+For example:
+
+```tsx
+<WebView
+  ref={webViewRef}
+  originWhitelist={['*']}
+  source={{
+    uri: 'https://appassets.androidplatform.net/assets/index.html',
+  }}
+  onLoadEnd={sendRequests}
+  onMessage={(event) => {
+    console.log('resolve', event);
+    resolve(event.nativeEvent.data);
+  }}
+/>
+```
+
 </details>
 
 ### Controlling navigation state changes


### PR DESCRIPTION
# Summary

i need to access my local asset, a html file, over https. because some of my js code require [Secure_Contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), so i can't access that html by **file:///** protocol.

android x provide a new lib **WebViewAssetLoader** to achieve this goal. [more detail](https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader).

there is a [example](https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/webkit/integration-tests/testapp/src/main/java/com/example/androidx/webkit/AssetLoaderAjaxActivity.java) code on android source code to show how we can use WebViewAssetLoader.

---

according to androidx.webkit's [doc](https://developer.android.com/reference/androidx/webkit/package-summary), the **minimum sdk version** to use this library is 14. react-native-webview is 16, so the requirement is fit.

finally we need to add an dependency for build.gradle

```
dependencies {
    implementation 'androidx.webkit:webkit:1.2.0'
}
```

## Test Plan

according to this [doc](https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader), after apply WebViewAssetLoader, we can access assets by **https://appassets.androidplatform.net/assets/some-assets** now.

## Compatibility

there is nothing need to do with other platforms

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
