### PR TITLE
Fix onScroll event type

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -598,8 +598,16 @@ Example:
 />
 ```
 
-Function will receive event object of `NativeSyntheticEvent<NativeScrollEvent>`
-type as an argument.
+Function passed to `onScroll` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+```
+contentInset
+contentOffset
+contentSize
+layoutMeasurement
+velocity
+zoomScale
+```
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -22,6 +22,7 @@ This document lays out the current public properties and methods for the React N
 - [`onMessage`](Reference.md#onmessage)
 - [`onNavigationStateChange`](Reference.md#onnavigationstatechange)
 - [`onContentProcessDidTerminate`](Reference.md#oncontentprocessdidterminate)
+- [`onScroll`](Reference.md#onscroll)
 - [`originWhitelist`](Reference.md#originwhitelist)
 - [`renderError`](Reference.md#rendererror)
 - [`renderLoading`](Reference.md#renderloading)
@@ -574,6 +575,31 @@ target
 title
 url
 ```
+
+---
+
+### `onScroll`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Function that is invoked when the scroll event is fired in the `WebView`.
+
+| Type     | Required | Platform                |
+| -------- | -------- | ----------------------- |
+| function | No       | iOS, macOS, Android, Windows |
+
+Example:
+
+```jsx
+<Webview
+  source={{ uri: 'https://reactnative.dev' }}
+  onScroll={syntheticEvent => {
+    const { contentOffset } = syntheticEvent.nativeEvent
+    console.table(contentOffset)
+  }}
+/>
+```
+
+Function will receive event object of `NativeSyntheticEvent<NativeScrollEvent>`
+type as an argument.
 
 ---
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -167,6 +167,8 @@ export type WebViewHttpErrorEvent = NativeSyntheticEvent<WebViewHttpError>;
 
 export type WebViewRenderProcessGoneEvent = NativeSyntheticEvent<WebViewRenderProcessGoneDetail>;
 
+export type WebViewScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
+
 export type DataDetectorTypes =
   | 'phoneNumber'
   | 'link'
@@ -259,7 +261,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
   javaScriptCanOpenWindowsAutomatically?: boolean;
   mediaPlaybackRequiresUserAction?: boolean;
   messagingEnabled: boolean;
-  onScroll?: (event: NativeScrollEvent) => void;
+  onScroll?: (event: WebViewScrollEvent) => void;
   onLoadingError: (event: WebViewErrorEvent) => void;
   onLoadingFinish: (event: WebViewNavigationEvent) => void;
   onLoadingProgress: (event: WebViewProgressEvent) => void;
@@ -905,7 +907,7 @@ export interface WebViewSharedProps extends ViewProps {
   /**
    * Function that is invoked when the `WebView` scrolls.
    */
-  onScroll?: (event: NativeScrollEvent) => void;
+  onScroll?: (event: WebViewScrollEvent) => void;
 
   /**
    * Function that is invoked when the `WebView` has finished loading.


### PR DESCRIPTION
# Summary

Fixes type of the event of the `onScroll` function.

Issue: #1627

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` **(Didn't find `CHANGELOG.md` in the repo)**
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`) **(Example already existed)**
