### PR TITLE
fix(macOS): Don't include iOS pull-to-refresh control

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -63,7 +63,9 @@
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
+#if !TARGET_OS_OSX
 @property (nonatomic, weak) UIRefreshControl * refreshControl;
+#endif
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
 @property (nonatomic, assign) WKContentMode contentMode;
@@ -77,7 +79,9 @@
 - (void)goBack;
 - (void)reload;
 - (void)stopLoading;
+#if !TARGET_OS_OSX
 - (void)addPullToRefreshControl;
 - (void)pullToRefresh:(UIRefreshControl *)refreshControl;
+#endif
 
 @end

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1127,7 +1127,7 @@ static NSDictionary* customCertificatesForHost;
     [_webView reload];
   }
 }
-
+#if !TARGET_OS_OSX
 - (void)addPullToRefreshControl
 {
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
@@ -1142,7 +1142,7 @@ static NSDictionary* customCertificatesForHost;
     [refreshControl endRefreshing];
 }
 
-#if !TARGET_OS_OSX
+
 - (void)setPullToRefreshEnabled:(BOOL)pullToRefreshEnabled
 {
     _pullToRefreshEnabled = pullToRefreshEnabled;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
In the past couple weeks, a new feature was added to allow for pull to refresh support. This was implemented using a UIRefreshControl which breaks the support for react-native-macos as macOS does not have access to that library. I have moved functions relating to pull to refresh to be inside an if the target is not macOS so that it can compile on macOS.

## Test Plan

Nothing has changed to the library except it now can compile again in a react-native-macos project. I created a project, added the dependency, fixed these things and it worked again. No code was added, just platform conditionals were added.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| macOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
