### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -15,6 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-webview.git", :tag => "v#{s.version}" }
   s.source_files  = "apple/**/*.{h,m}"
 
-  s.dependency 'React'
   s.dependency 'React-Core'
 end

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "apple/**/*.{h,m}"
 
   s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116


## Test Plan

Use this branch to install with an app running on Xcode 12.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
