### PR TITLE
Add support for iOS-specific prop `limitsNavigationsToAppBoundDomains`

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -72,6 +72,10 @@
 @property (nonatomic, assign) WKContentMode contentMode;
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 /* iOS 14 */
+@property (nonatomic, assign) BOOL limitsNavigationsToAppBoundDomains;
+#endif
+
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;
 - (void)postMessage:(NSString *_Nullable)message;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -235,6 +235,14 @@ static NSDictionary* customCertificatesForHost;
   }
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 /* iOS 14 */
+  if (@available(iOS 14.0, *)) {
+    if (_limitsNavigationsToAppBoundDomains) {
+      wkWebViewConfig.limitsNavigationsToAppBoundDomains = YES;
+    }
+  }
+#endif
+
   // Shim the HTML5 history API:
   [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
                                                             name:HistoryShimName];

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -237,8 +237,10 @@ static NSDictionary* customCertificatesForHost;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 /* iOS 14 */
   if (@available(iOS 14.0, *)) {
-    if (_limitsNavigationsToAppBoundDomains) {
-      wkWebViewConfig.limitsNavigationsToAppBoundDomains = YES;
+    if ([wkWebViewConfig respondsToSelector:@selector(limitsNavigationsToAppBoundDomains)]) {
+      if (_limitsNavigationsToAppBoundDomains) {
+        wkWebViewConfig.limitsNavigationsToAppBoundDomains = YES;
+      }
     }
   }
 #endif

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -85,6 +85,10 @@ RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInse
 RCT_EXPORT_VIEW_PROPERTY(contentMode, WKContentMode)
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 /* iOS 14 */
+RCT_EXPORT_VIEW_PROPERTY(limitsNavigationsToAppBoundDomains, BOOL)
+#endif
+
 /**
  * Expose methods to enable messaging the webview.
  */

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -71,6 +71,7 @@ This document lays out the current public properties and methods for the React N
 - [`pullToRefreshEnabled`](Reference.md#pullToRefreshEnabled)
 - [`ignoreSilentHardwareSwitch`](Reference.md#ignoreSilentHardwareSwitch)
 - [`onFileDownload`](Reference.md#onFileDownload)
+- [`limitsNavigationsToAppBoundDomains`](Reference.md#limitsNavigationsToAppBoundDomains)
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
 
 ## Methods Index
@@ -1265,6 +1266,25 @@ Example:
 | Type     | Required | Platform |
 | -------- | -------- | -------- |
 | function | No       | iOS      |
+
+---
+
+### `limitsNavigationsToAppBoundDomains`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+If true indicates to WebKit that a WKWebView will only navigate to app-bound domains. Only applicable for iOS 14 or greater.
+
+Once set, any attempt to navigate away from an app-bound domain will fail with the error “App-bound domain failure.”
+Applications can specify up to 10 “app-bound” domains using a new Info.plist key `WKAppBoundDomains`. For more information see [App-Bound Domains](https://webkit.org/blog/10882/app-bound-domains/).
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
+Example:
+
+```jsx
+<WebView limitsNavigationsToAppBoundDomains={true} />
+```
 
 ---
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -327,6 +327,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   injectedJavaScriptForMainFrameOnly?: boolean;
   injectedJavaScriptBeforeContentLoadedForMainFrameOnly?: boolean;
   onFileDownload?: (event: FileDownloadEvent) => void;
+  limitsNavigationsToAppBoundDomains?: boolean;
 }
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -583,6 +584,17 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * If not provided, the default is to let the webview try to render the file.
    */
   onFileDownload?: (event: FileDownloadEvent) => void;
+
+  /**
+   * A Boolean value which, when set to `true`, indicates to WebKit that a WKWebView
+   * will only navigate to app-bound domains. Once set, any attempt to navigate away
+   * from an app-bound domain will fail with the error: “App-bound domain failure.”
+   * 
+   * Applications can specify up to 10 “app-bound” domains using a new
+   * Info.plist key — `WKAppBoundDomains`.
+   * @platform ios
+   */
+  limitsNavigationsToAppBoundDomains?: boolean;
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -588,10 +588,10 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   /**
    * A Boolean value which, when set to `true`, indicates to WebKit that a WKWebView
    * will only navigate to app-bound domains. Once set, any attempt to navigate away
-   * from an app-bound domain will fail with the error: “App-bound domain failure.”
+   * from an app-bound domain will fail with the error “App-bound domain failure.”
    * 
    * Applications can specify up to 10 “app-bound” domains using a new
-   * Info.plist key — `WKAppBoundDomains`.
+   * Info.plist key `WKAppBoundDomains`.
    * @platform ios
    */
   limitsNavigationsToAppBoundDomains?: boolean;


### PR DESCRIPTION
# Summary
iOS 14 introduces the support for App Bound Domains, which are necessary to access several privacy- and security-related features.
I would like to add the support for `limitsNavigationsToAppBoundDomains` prop.

Context: https://webkit.org/blog/10882/app-bound-domains/

## Compatibility
OS | Implemented
-- | :--:
iOS | ✅
Android | ❌

## Checklist
* [x]  I have tested this on a device and a simulator
* [x]  I updated the typed files (TS and Flow)
* [ ]  I added a sample use of the API in the example project (`example/App.js`)
