### PR TITLE
Expose the setSupportMultipleWindows in Android to fix CVE-2020-6506

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -252,6 +252,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
 
+  @ReactProp(name = "setSupportMultipleWindows")
+  public void setSupportMultipleWindows(WebView view, boolean enabled){
+    view.getSettings().setSupportMultipleWindows(enabled);
+  }
+
   @ReactProp(name = "showsHorizontalScrollIndicator")
   public void setShowsHorizontalScrollIndicator(WebView view, boolean enabled) {
     view.setHorizontalScrollBarEnabled(enabled);

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1285,6 +1285,7 @@ Example:
 ### `setSupportMultipleWindows`
 
 Sets whether the WebView supports multiple windows. See [Android documentation]('https://developer.android.com/reference/android/webkit/WebSettings#setSupportMultipleWindows(boolean)') for more information. 
+Setting this to false can expose the application to this vulnerability https://alesandroortiz.com/articles/uxss-android-webview-cve-2020-6506/ allowing a malicious iframe to escape into the top layer DOM. 
 
 | Type    | Required | Default | Platform |
 | ------- | -------- | ------- | -------- |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1285,7 +1285,7 @@ Example:
 ### `setSupportMultipleWindows`
 
 Sets whether the WebView supports multiple windows. See [Android documentation]('https://developer.android.com/reference/android/webkit/WebSettings#setSupportMultipleWindows(boolean)') for more information. 
-Setting this to false can expose the application to this vulnerability https://alesandroortiz.com/articles/uxss-android-webview-cve-2020-6506/ allowing a malicious iframe to escape into the top layer DOM. 
+Setting this to false can expose the application to this [vulnerability](https://alesandroortiz.com/articles/uxss-android-webview-cve-2020-6506/) allowing a malicious iframe to escape into the top layer DOM. 
 
 | Type    | Required | Default | Platform |
 | ------- | -------- | ------- | -------- |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -72,6 +72,7 @@ This document lays out the current public properties and methods for the React N
 - [`ignoreSilentHardwareSwitch`](Reference.md#ignoreSilentHardwareSwitch)
 - [`onFileDownload`](Reference.md#onFileDownload)
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
+- [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows)
 
 ## Methods Index
 
@@ -1279,6 +1280,20 @@ Example:
 
 ```javascript
 <WebView autoManageStatusBarEnabled={false} />
+```
+
+### `setSupportMultipleWindows`
+
+Sets whether the WebView supports multiple windows. See [Android documentation]('https://developer.android.com/reference/android/webkit/WebSettings#setSupportMultipleWindows(boolean)') for more information. 
+
+| Type    | Required | Default | Platform |
+| ------- | -------- | ------- | -------- |
+| boolean | No       | true    | Android  |
+
+Example:
+
+```javascript
+<WebView setSupportMultipleWindows={false} />
 ```
 
 ## Methods

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -63,6 +63,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     androidHardwareAccelerationDisabled: false,
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
+    setSupportMultipleWindowsDisabled: true,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -63,7 +63,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     androidHardwareAccelerationDisabled: false,
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
-    setSupportMultipleWindowsDisabled: true,
+    setSupportMultipleWindows: true,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -295,6 +295,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   onRenderProcessGone?: (event: WebViewRenderProcessGoneEvent) => void;
   overScrollMode?: OverScrollModeType;
   saveFormDataDisabled?: boolean;
+  setSupportMultipleWindows?: boolean;
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
@@ -798,6 +799,14 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   saveFormDataDisabled?: boolean;
+
+  /**
+   * Boolean value to set whether the WebView supports multiple windows. Used on Android only
+   * The default value is `true`.
+   * @platform android
+   */
+  setSupportMultipleWindows?: boolean;
+
 
   /**
    * Used on Android only, controls whether the given list of URL prefixes should


### PR DESCRIPTION
This PR exposes the setSupportMultipleWindows setting in Android to fix CVE-2020-6506. Let me know if there is anything missing from this PR. I suspect this may cause strange behavior in applications that assumed that this would be false by default. 