### PR TITLE
Added explicit camera/mic permission request on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/events/TopPermissionRequestEvent.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/TopPermissionRequestEvent.kt
@@ -1,0 +1,24 @@
+package com.reactnativecommunity.webview.events
+
+ import com.facebook.react.bridge.WritableMap
+ import com.facebook.react.uimanager.events.Event
+ import com.facebook.react.uimanager.events.RCTEventEmitter
+
+ /**
+  * Event emitted when there is an error in loading.
+  */
+ class TopPermissionRequestEvent(viewId: Int, private val mEventData: WritableMap) : Event<TopPermissionRequestEvent>(viewId) {
+   companion object {
+     const val EVENT_NAME = "topPermissionRequest"
+   }
+
+   override fun getEventName(): String = EVENT_NAME
+
+   override fun canCoalesce(): Boolean = false
+
+   override fun getCoalescingKey(): Short = 0
+
+   override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+     rctEventEmitter.receiveEvent(viewTag, EVENT_NAME, mEventData)
+   }
+ }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 
+import Permission from './examples/Permission';
 import Alerts from './examples/Alerts';
 import Scrolling from './examples/Scrolling';
 import Background from './examples/Background';
@@ -19,6 +20,14 @@ import Injection from './examples/Injection';
 import LocalPageLoad from './examples/LocalPageLoad';
 
 const TESTS = {
+  Permission: {
+    title: 'Permission',
+    testId: 'permission',
+    description: 'Permission tests',
+    render() {
+      return <Permission />;
+    },
+  },
   Alerts: {
     title: 'Alerts',
     testId: 'alerts',
@@ -113,6 +122,11 @@ export default class App extends Component<Props, State> {
         </TouchableOpacity>
 
         <View style={styles.testPickerContainer}>
+          <Button
+            testID="testType_permission"
+            title="Permission"
+            onPress={() => this._changeTest('Permission')}
+          />
           <Button
             testID="testType_alerts"
             title="Alerts"

--- a/example/examples/Permission.tsx
+++ b/example/examples/Permission.tsx
@@ -1,0 +1,27 @@
+import React, {Component} from 'react';
+ import {Text, View} from 'react-native';
+
+ import WebView from 'react-native-webview';
+
+ type Props = {};
+ type State = {};
+
+ export default class Permission extends Component<Props, State> {
+   state = {};
+
+   render() {
+     return (
+       <View style={{ height: "100%" }}>
+         <WebView
+           ref={(ref) => (this.webview = ref)}
+           onPermissionRequest={(event) => {
+               console.log("!!! JS: onPermissionRequest, event: ", event.nativeEvent);
+               this.webview.answerPermissionRequest(true, event.nativeEvent.resources );
+           }}
+             source={{uri: 'https://fatal0.netlify.app/android/webviewvideo.html'}}
+           automaticallyAdjustContentInsets={false}
+         />
+       </View>
+     );
+   }
+ }

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -27,6 +27,7 @@ import {
   WebViewMessageEvent,
   WebViewNavigationEvent,
   WebViewProgressEvent,
+  WebViewPermissionEvent,
   AndroidWebViewProps,
   NativeWebViewAndroid,
   State,
@@ -178,6 +179,14 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     );
   };
 
+  answerPermissionRequest = (allow: boolean, resources: string[]) => {
+    UIManager.dispatchViewManagerCommand(
+      this.getWebViewHandle(),
+      this.getCommands().answerPermissionRequest,
+      [allow, ...(resources || [])],
+    );
+  }
+
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
@@ -261,6 +270,13 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
       onMessage(event);
     }
   };
+
+  onPermissionRequest = (event: WebViewPermissionEvent) => {
+    const { onPermissionRequest } = this.props;
+    if (onPermissionRequest) {
+      onPermissionRequest(event);
+    }
+  }
 
   onLoadingProgress = (event: WebViewProgressEvent) => {
     const { onLoadProgress } = this.props;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -14,7 +14,7 @@ import {
 
 type WebViewCommands = 'goForward' | 'goBack' | 'reload' | 'stopLoading' | 'postMessage' | 'injectJavaScript' | 'loadUrl' | 'requestFocus';
 
-type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
+type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData' | 'answerPermissionRequest';
 
 
 
@@ -102,6 +102,10 @@ export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
   progress: number;
 }
 
+export interface WebViewNativePermissionEvent extends WebViewNativeEvent {
+  resources: string[];
+}
+
 export interface WebViewNavigation extends WebViewNativeEvent {
   navigationType:
     | 'click'
@@ -149,6 +153,10 @@ export type WebViewEvent = NativeSyntheticEvent<WebViewNativeEvent>;
 
 export type WebViewProgressEvent = NativeSyntheticEvent<
   WebViewNativeProgressEvent
+>;
+
+export type WebViewPermissionEvent = NativeSyntheticEvent<
+  WebViewNativePermissionEvent
 >;
 
 export type WebViewNavigationEvent = NativeSyntheticEvent<WebViewNavigation>;
@@ -292,6 +300,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   javaScriptEnabled?: boolean;
   mixedContentMode?: 'never' | 'always' | 'compatibility';
   onContentSizeChange?: (event: WebViewEvent) => void;
+  onPermissionRequest?: (event: WebViewPermissionEvent) => void;
   onRenderProcessGone?: (event: WebViewRenderProcessGoneEvent) => void;
   overScrollMode?: OverScrollModeType;
   saveFormDataDisabled?: boolean;
@@ -725,6 +734,7 @@ export interface MacOSWebViewProps extends WebViewSharedProps {
 export interface AndroidWebViewProps extends WebViewSharedProps {
   onNavigationStateChange?: (event: WebViewNavigation) => void;
   onContentSizeChange?: (event: WebViewEvent) => void;
+  onPermissionRequest?: (event: WebViewPermissionEvent) => void;
 
   /**
    * Function that is invoked when the `WebView` process crashes or is killed by the OS.


### PR DESCRIPTION
Fixes #1685. Originally these changes were created and tested within [status-react repo](https://github.com/status-im/status-react). We have a local fork of `react-native-webview` but would be glad to get rid of it and place this fix in a main repo.
 
**Problem:**
On android webview automatically gives access to camera for any page if camera access granted for the app itself. On ios it doesn't.

**Solution**
Added functionality to explicitly notify user that some page requests mic/camera access.
Event `onPermissionRequest` sends when page request access. User can detect it and call `answerPermissionRequest` function to grant or deny access.

**Testing**
Simple example added that loads `https://fatal0.netlify.app/android/webviewvideo.html` page. 
(make sure you granted app a Camera permission in Android settings). With these changes example doesn't automatically allow camera access for the page. You can play with `this.webview.answerPermissionRequest(true, event.nativeEvent.resources );` string to see how behavior changes

Platform: Android