### PR TITLE
Fixes onShouldStartLoadWithRequest not called on first load on Android.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -61,7 +61,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       DO_NOT_OVERRIDE,
     }
 
-    private int nextLockIdentifier = 0;
+    private int nextLockIdentifier = 1;
     private final HashMap<Integer, AtomicReference<ShouldOverrideCallbackState>> shouldOverrideLocks = new HashMap<>();
 
     public synchronized Pair<Integer, AtomicReference<ShouldOverrideCallbackState>> getNewLock() {


### PR DESCRIPTION
# Summary

Fix for issue https://github.com/react-native-webview/react-native-webview/issues/1661. onShouldStartLoadWithRequest is not called on first load on Android because the first lockIdentifier value is 0, but the callback is only invoked if lockIdentifier is truthy.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)