### PR TITLE
[Android] Sends cookies with resource requests (replace PR 1534)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -119,6 +119,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class RNCWebViewManager extends SimpleViewManager<WebView> {
   private static final String TAG = "RNCWebViewManager";
 
+  private static final Map<String, String> COOKIE_MAP = new HashMap<>();
+
   public static final int COMMAND_GO_BACK = 1;
   public static final int COMMAND_GO_FORWARD = 2;
   public static final int COMMAND_RELOAD = 3;
@@ -864,6 +866,20 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
       final String url = request.getUrl().toString();
       return this.shouldOverrideUrlLoading(view, url);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+      String cookie = request.getRequestHeaders() == null ? null : request.getRequestHeaders().get("cookie");
+      if (null == cookie || cookie.length() == 0) {
+        if (COOKIE_MAP.containsKey(request.getUrl().getAuthority())) {
+          CookieManager.getInstance().setCookie(request.getUrl().toString(), COOKIE_MAP.get(request.getUrl().getAuthority()));
+        }
+      } else {
+        COOKIE_MAP.put(request.getUrl().getAuthority(), cookie);
+      }
+      return super.shouldInterceptRequest(view, request);
     }
 
     @Override

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -541,6 +541,7 @@ const App = () => {
 ```
 
 Note that these cookies will only be sent on the first request unless you use the technique above for [setting custom headers on each page load](#Setting-Custom-Headers).
+On Android, `RNCWebViewManager` maintains a map of Cookies. For any request, it retrieves the stored cookie for the authority and sets it using the `CookieManager`.
 
 ### Hardware Silence Switch
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -541,6 +541,9 @@ const App = () => {
 ```
 
 Note that these cookies will only be sent on the first request unless you use the technique above for [setting custom headers on each page load](#Setting-Custom-Headers).
+
+##### Android
+
 On Android, `RNCWebViewManager` maintains a map of Cookies. For any request, it retrieves the stored cookie for the authority and sets it using the `CookieManager`.
 
 ### Hardware Silence Switch

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "10.9.1",
+  "version": "10.9.2",
   "homepage": "https://github.com/react-native-community/react-native-webview#readme",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
[**Replacing PR 1534**](https://github.com/react-native-webview/react-native-webview/pull/1534)
To attach cookie with all resource requests for the page loaded

# Summary

- This PR solves this feature request #1532

- How did you implement the solution?
I implemented this solution by adding a map for storing cookies for authority name and overriding the shouldInterceptRequest callback in RNCWebViewClient.

- What areas of the library does it impact?
RNCWebViewManager, RNCWebViewClient

## Test Plan
### What's required for testing (prerequisites)?
### What are the steps to reproduce (after prerequisites)?

## Compatibility
| OS | Implemented |
| Android |✅|

## Checklist
- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in README.md
- [ ] I mentioned this change in CHANGELOG.md
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (example/App.js)