### PR TITLE
Ensure WebChromeClient reference cleared on destroy to fix memory leak

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -693,6 +693,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     super.onDropViewInstance(webView);
     ((ThemedReactContext) webView.getContext()).removeLifecycleEventListener((RNCWebView) webView);
     ((RNCWebView) webView).cleanupCallbacksAndDestroy();
+    mWebChromeClient = null;
   }
 
   public static RNCWebViewModule getModule(ReactContext reactContext) {


### PR DESCRIPTION
Fixes memory leak reported in #1047 

`RNCWebViewManager` holds a reference to `RNCWebChromeClient`, which maintains a reference to `ReactContext`. PR clears the reference to `RNCWebChromeClient` on cleanup/destroy, to ensure the reference is not retained.

Leak canary report:
![Screenshot_1603749337](https://user-images.githubusercontent.com/10136407/97232940-564a1f00-179b-11eb-89e1-44b35072f55a.png)