### PR TITLE
Introduce mitigations for CVE-2020-6506

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -252,6 +252,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
 
+  @ReactProp(name = "setSupportMultipleWindows")
+  public void setSupportMultipleWindows(WebView view, boolean enabled){
+    view.getSettings().setSupportMultipleWindows(enabled);
+  }
+
   @ReactProp(name = "showsHorizontalScrollIndicator")
   public void setShowsHorizontalScrollIndicator(WebView view, boolean enabled) {
     view.setHorizontalScrollBarEnabled(enabled);

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -13,6 +13,7 @@ import android.net.http.SslError;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
+import android.os.Message;
 import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.Log;
@@ -1076,6 +1077,17 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     public RNCWebChromeClient(ReactContext reactContext, WebView webView) {
       this.mReactContext = reactContext;
       this.mWebView = webView;
+    }
+
+    @Override
+    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+
+      final WebView newWebView = new WebView(view.getContext());
+      final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
+      transport.setWebView(newWebView);
+      resultMsg.sendToTarget();
+
+      return true;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -188,6 +188,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     settings.setBuiltInZoomControls(true);
     settings.setDisplayZoomControls(false);
     settings.setDomStorageEnabled(true);
+    settings.setSupportMultipleWindows(true);
 
     settings.setAllowFileAccess(false);
     settings.setAllowContentAccess(false);
@@ -881,7 +882,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         // This is desired behavior. We later use these values to determine whether the request is a top-level navigation or a subresource request.
         String topWindowUrl = webView.getUrl();
         String failingUrl = error.getUrl();
-        
+
         // Cancel request after obtaining top-level URL.
         // If request is cancelled before obtaining top-level URL, undesired behavior may occur.
         // Undesired behavior: Return value of WebView.getUrl() may be the current URL instead of the failing URL.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -72,6 +72,7 @@ This document lays out the current public properties and methods for the React N
 - [`ignoreSilentHardwareSwitch`](Reference.md#ignoreSilentHardwareSwitch)
 - [`onFileDownload`](Reference.md#onFileDownload)
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
+- [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows)
 
 ## Methods Index
 
@@ -782,7 +783,7 @@ A Boolean value indicating whether JavaScript can open windows without user inte
 
 ### `androidHardwareAccelerationDisabled`[⬆](#props-index)<!-- Link generated with jump2header -->
 
-**Deprecated.** Use the `androidLayerType` prop instead. 
+**Deprecated.** Use the `androidLayerType` prop instead.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -792,7 +793,7 @@ A Boolean value indicating whether JavaScript can open windows without user inte
 
 ### `androidLayerType`[⬆](#props-index)<!-- Link generated with jump2header -->
 
-Specifies the layer type. 
+Specifies the layer type.
 
 Possible values for `androidLayerType` are:
 
@@ -1280,6 +1281,21 @@ Example:
 
 ```javascript
 <WebView autoManageStatusBarEnabled={false} />
+```
+
+### `setSupportMultipleWindows`
+
+Sets whether the WebView supports multiple windows. See [Android documentation]('https://developer.android.com/reference/android/webkit/WebSettings#setSupportMultipleWindows(boolean)') for more information.
+Setting this to false can expose the application to this [vulnerability](https://alesandroortiz.com/articles/uxss-android-webview-cve-2020-6506/) allowing a malicious iframe to escape into the top layer DOM.
+
+| Type    | Required | Default | Platform |
+| ------- | -------- | ------- | -------- |
+| boolean | No       | true    | Android  |
+
+Example:
+
+```javascript
+<WebView setSupportMultipleWindows={false} />
 ```
 
 ## Methods

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,7 @@ import Uploads from './examples/Uploads';
 import Injection from './examples/Injection';
 import LocalPageLoad from './examples/LocalPageLoad';
 import Messaging from './examples/Messaging';
+import NativeWebpage from './examples/NativeWebpage';
 
 const TESTS = {
   Messaging: {
@@ -82,6 +83,14 @@ const TESTS = {
     description: 'Local Page load test',
     render() {
       return <LocalPageLoad />;
+    },
+  },
+  NativeWebpage: {
+    title: 'NativeWebpage',
+    testId: 'NativeWebpage',
+    description: 'Test to open a new webview with a link',
+    render() {
+      return <NativeWebpage />;
     },
   },
 };
@@ -165,6 +174,11 @@ export default class App extends Component<Props, State> {
             testID="testType_messaging"
             title="Messaging"
             onPress={() => this._changeTest('Messaging')}
+          />
+          <Button
+            testID="testType_nativeWebpage"
+            title="NativeWebpage"
+            onPress={() => this._changeTest('NativeWebpage')}
           />
         </View>
 

--- a/example/examples/NativeWebpage.tsx
+++ b/example/examples/NativeWebpage.tsx
@@ -15,6 +15,7 @@ export default class NativeWebpage extends Component<Props, State> {
         <WebView
           source={{uri: 'https://infinite.red'}}
           style={{width: '100%', height: '100%'}}
+          // setSupportMultipleWindows={false}
         />
       </View>
     );

--- a/example/examples/NativeWebpage.tsx
+++ b/example/examples/NativeWebpage.tsx
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {View} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+type Props = {};
+type State = {};
+
+export default class NativeWebpage extends Component<Props, State> {
+  state = {};
+
+  render() {
+    return (
+      <View style={{height: 400}}>
+        <WebView
+          source={{uri: 'https://infinite.red'}}
+          style={{width: '100%', height: '100%'}}
+        />
+      </View>
+    );
+  }
+}

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -63,6 +63,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     androidHardwareAccelerationDisabled: false,
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
+    setSupportMultipleWindows: true,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -295,6 +295,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   onRenderProcessGone?: (event: WebViewRenderProcessGoneEvent) => void;
   overScrollMode?: OverScrollModeType;
   saveFormDataDisabled?: boolean;
+  setSupportMultipleWindows?: boolean;
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
@@ -798,6 +799,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   saveFormDataDisabled?: boolean;
+
+  /**
+   * Boolean value to set whether the WebView supports multiple windows. Used on Android only
+   * The default value is `true`.
+   * @platform android
+   */
+  setSupportMultipleWindows?: boolean;
 
   /**
    * Used on Android only, controls whether the given list of URL prefixes should


### PR DESCRIPTION
Hey folks 👋

This PR wants to introduce the recommended mitigation for CVE-2020-6506 as indicated [in the blogpost](https://alesandroortiz.com/articles/uxss-android-webview-cve-2020-6506#potential-mitigations) by the security researcher who disclosed it.

> Enable multiwindow support. If needed, implementation options exist to mimic single-window behavior and minimize breaking changes. Does not require multi-tab UI. Suitable for browsers and frameworks.

## The details

The final code that you see here is, basically, a mix my brain plus the following links:
* https://github.com/react-native-webview/react-native-webview/pull/1663
* https://github.com/flutter/plugins/pull/2991
* [setSupportMultipleWindows](https://developer.android.com/reference/android/webkit/WebSettings#setSupportMultipleWindows(boolean))
  * in particular this needed to override [onCreateWindow]( https://developer.android.com/reference/android/webkit/WebChromeClient#onCreateWindow(android.webkit.WebView,%20boolean,%20boolean,%20android.os.Message))
* https://stackoverflow.com/questions/48040319/setsupportmultiplewindows-and-setjavascriptcanopenwindowsautomatically-not-allow
* https://stackoverflow.com/questions/8817485/open-javascript-window-into-alertdialog

All of this to say, I haven't been doing Android for a while so I'm not entirely sure this implementation is the best ever.

That said, it actually works as expected: now, when...

...flag is set to true:
<img width="281" alt="Screenshot 2020-11-17 at 17 49 32" src="https://user-images.githubusercontent.com/16104054/99429291-ac743300-28ff-11eb-8189-0c22bab5148f.png">

...flag is set to false:
<img width="278" alt="Screenshot 2020-11-17 at 17 51 15" src="https://user-images.githubusercontent.com/16104054/99429296-ae3df680-28ff-11eb-8828-8d6e20b1ecc8.png">

## Testing and stuff

Basically, as you'll quickly notice, I've added to the Examples folder a new example which is literally just the snippet @jamonholmgren used in the other PR to test if the code was working.
That way, you can easily test this PR by checkout-ing it, and doing yarn then yarn start:android and toggling the flag.

That's all, let me know if there's anything else I need to do to make it ready for release 👍 

PS: I don't think this should be treated as a breaking change, from the perspective of releases. But as long as it get released, I'm happy either way :D