### PR TITLE
Bugfix for Unknown URL Scheme in Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -142,7 +142,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   // Use `webView.loadUrl("about:blank")` to reliably reset the view
   // state and release page resources (including any running JavaScript).
   protected static final String BLANK_URL = "about:blank";
-  protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 250;
+  protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 1500;
   protected WebViewConfig mWebViewConfig;
 
   protected RNCWebChromeClient mWebChromeClient = null;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -61,7 +61,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       DO_NOT_OVERRIDE,
     }
 
-    private int nextLockIdentifier = 0;
+    private int nextLockIdentifier = 1;
     private final HashMap<Integer, AtomicReference<ShouldOverrideCallbackState>> shouldOverrideLocks = new HashMap<>();
 
     public synchronized Pair<Integer, AtomicReference<ShouldOverrideCallbackState>> getNewLock() {


### PR DESCRIPTION
**Bugfix for "Unknown URL Scheme" error in Android.**

In the demo code below, I'm using the **nativejstn** scheme as an example, it could be anything. The custom URL scheme must be added into the **originWhitelist** array in order to work.

````javascript
const _onShouldStartLoadWithRequest = (request) => {
    if (request.url.indexOf('http') === 0) {
        return true
        } else if (request.url.indexOf('nativejstn') === 0) {
        console.log(request.url)
        }
    return false
}

return (
    <View style={{width:'100%',height:'100%'}}>
        <WebView
            source={{ uri: 'https://www.example.com' }}
            onShouldStartLoadWithRequest={_onShouldStartLoadWithRequest.bind(this)}
            originWhitelist={[
                    'https://*',
                    'http://*',
                    'nativejstn://*',
                    'about:*',
                ]}
            />
        </View>
    )
````