### PR TITLE
Xcode 12.2 compat

### DIFF
--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-webview.git", :tag => "v#{s.version}" }
   s.source_files  = "apple/**/*.{h,m}"
 
-  s.dependency 'React-Core'
+  s.dependency 'React/Core'
 end

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-webview.git", :tag => "v#{s.version}" }
   s.source_files  = "apple/**/*.{h,m}"
 
-  s.dependency 'React/Core'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Similar to https://github.com/react-native-webview/react-native-webview/pull/1643, but on Xcode 12.2 I needed to change to `React/Core` as per [this advice](https://github.com/facebook/react-native/issues/30018#issuecomment-716041423) to get the build working.

![image](https://user-images.githubusercontent.com/509837/101520677-6fbdb980-394a-11eb-9ae4-d7bfcad1bbd6.png)
