### PR TITLE
 [iOS] Send cookies with resource requests

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -511,6 +511,7 @@ static NSDictionary* customCertificatesForHost;
 {
     // Check for a static html source first
     NSString *html = [RCTConvert NSString:_source[@"html"]];
+    NSString *headerCookie = [RCTConvert NSString:_source[@"headers"][@"cookie"]]; 
     if (html) {
         NSURL *baseURL = [RCTConvert NSURL:_source[@"baseUrl"]];
         if (!baseURL) {
@@ -518,6 +519,12 @@ static NSDictionary* customCertificatesForHost;
         }
         [_webView loadHTMLString:html baseURL:baseURL];
         return;
+    } else if(headerCookie) {
+        NSDictionary *headers = [NSDictionary dictionaryWithObjectsAndKeys:headerCookie,@"Set-Cookie",nil];
+        NSURL *urlString = [NSURL URLWithString:_source[@"uri"]];
+        NSArray *httpCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headers forURL:urlString ];
+        for (NSHTTPCookie *httpCookie in httpCookies) {
+            [_webView.configuration.websiteDataStore.httpCookieStore setCookie:httpCookie completionHandler:nil];
     }
 
     NSURLRequest *request = [self requestForSource:_source];

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -536,7 +536,6 @@ static NSDictionary* customCertificatesForHost;
 {
     // Check for a static html source first
     NSString *html = [RCTConvert NSString:_source[@"html"]];
-    NSString *headerCookie = [RCTConvert NSString:_source[@"headers"][@"cookie"]]; 
     if (html) {
         NSURL *baseURL = [RCTConvert NSURL:_source[@"baseUrl"]];
         if (!baseURL) {
@@ -544,12 +543,16 @@ static NSDictionary* customCertificatesForHost;
         }
         [_webView loadHTMLString:html baseURL:baseURL];
         return;
-    } else if(headerCookie) {
-        NSDictionary *headers = [NSDictionary dictionaryWithObjectsAndKeys:headerCookie,@"Set-Cookie",nil];
-        NSURL *urlString = [NSURL URLWithString:_source[@"uri"]];
-        NSArray *httpCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headers forURL:urlString ];
-        for (NSHTTPCookie *httpCookie in httpCookies) {
-            [_webView.configuration.websiteDataStore.httpCookieStore setCookie:httpCookie completionHandler:nil];
+    } 
+    //Add cookie for subsequent resource requests sent by page itself, if cookie was set in headers on WebView
+    NSString *headerCookie = [RCTConvert NSString:_source[@"headers"][@"cookie"]]; 
+    if(headerCookie) {
+      NSDictionary *headers = [NSDictionary dictionaryWithObjectsAndKeys:headerCookie,@"Set-Cookie",nil];
+      NSURL *urlString = [NSURL URLWithString:_source[@"uri"]];
+      NSArray *httpCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headers forURL:urlString];
+      for (NSHTTPCookie *httpCookie in httpCookies) {
+          [_webView.configuration.websiteDataStore.httpCookieStore setCookie:httpCookie completionHandler:nil];
+      }
     }
 
     NSURLRequest *request = [self requestForSource:_source];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "homepage": "https://github.com/react-native-community/react-native-webview#readme",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
To attach cookie with all resource requests for the page loaded

**Summary**

- This PR solves this feature request #1875
- Issue: Currently, the cookies are added for page load request if custom cookies are passed in the webview source headers but they are not added for resource requests.
- How did you implement the solution?
I implemented this solution by adding cookies in webview configuration so that cookies will be send in resource requests as well.
- What areas of the library does it impact?
RNCWebView


