### PR TITLE
fix: Did not receive response to shouldStartLoad in time, defaulting to YES

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1091,6 +1091,17 @@ Example:
 
 `<WebView textZoom={100} />`
 
+---
+### `blockMainThreadEnabled`
+
+The default value is true. If the value of this property is false, iOS main thread will not be blocked for a maximum of 250ms until the JS thread returns. 
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
+---
+
 ## Methods
 
 ### `extraNativeComponentConfig()`

--- a/ios/RNCWebView.h
+++ b/ios/RNCWebView.h
@@ -58,6 +58,7 @@
 @property (nonatomic, assign) BOOL showsVerticalScrollIndicator;
 @property (nonatomic, assign) BOOL directionalLockEnabled;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
+@property (nonatomic, assign) BOOL blockMainThreadEnabled;
 
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -60,6 +60,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     cacheEnabled: true,
     originWhitelist: defaultOriginWhitelist,
     useSharedProcessPool: true,
+    blockMainThreadEnabled: true
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -279,6 +279,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   scrollEnabled?: boolean;
   useSharedProcessPool?: boolean;
   onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
+  blockMainThreadEnabled?: boolean;
 }
 
 export interface IOSWebViewProps extends WebViewSharedProps {
@@ -458,6 +459,12 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
+  /**
+   * Boolean value to enable block main thread in the `WebView`. 
+   * The default value is `true`.
+   * * @platform ios
+   */
+  blockMainThreadEnabled?: boolean;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
I've created a prop **blockMainThreadEnabled** for iOS only to disable the action blocking main thread for 250ms by default. User should be able to enable/disable this action to prevent the warning message.

This issue has reported at: https://github.com/react-native-webview/react-native-webview/issues/124
