### PR TITLE
chore(docs): Clarify that navigationType and isTopFrame is iOS only

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -550,7 +550,7 @@ The `navState` object includes these properties:
 canGoBack
 canGoForward
 loading
-navigationType
+navigationType (iOS only)
 target
 title
 url
@@ -729,8 +729,8 @@ canGoBack
 canGoForward
 lockIdentifier
 mainDocumentURL (iOS only)
-navigationType
-isTopFrame
+navigationType (iOS only)
+isTopFrame (iOS only)
 ```
 
 ---


### PR DESCRIPTION
These properties are either wrong or undefined for Android. I'll make a separate PR to try to include the [`hasGesture`](https://developer.android.com/reference/android/webkit/WebResourceRequest#hasGesture()) property which is similar to `navigationType == click` for Android.