### PR TITLE
Implement a way to see if `shouldStartLoadWithRequest` was initiated by user gesture on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -847,6 +847,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      return shouldOverrideUrlLoading(view, url, null);
+    }
+
+    public boolean shouldOverrideUrlLoading(WebView view, String url, @Nullable WebResourceRequest request) {
       final RNCWebView rncWebView = (RNCWebView) view;
       final boolean isJsDebugging = ((ReactContext) view.getContext()).getJavaScriptContextHolder().get() == 0;
 
@@ -857,6 +861,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         final WritableMap event = createWebViewEvent(view, url);
         event.putInt("lockIdentifier", lockIdentifier);
+        if (request != null) {
+          event.putBoolean("hasGesture", request.hasGesture());
+          event.putBoolean("isTopFrame", request.isForMainFrame());
+        }
         rncWebView.sendDirectMessage("onShouldStartLoadWithRequest", event);
 
         try {
@@ -898,7 +906,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
       final String url = request.getUrl().toString();
-      return this.shouldOverrideUrlLoading(view, url);
+      return this.shouldOverrideUrlLoading(view, url, request);
     }
 
     @Override

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -731,6 +731,7 @@ lockIdentifier
 mainDocumentURL (iOS only)
 navigationType (iOS only)
 isTopFrame (iOS only)
+hasGesture (Android only, API 21+)
 ```
 
 ---

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -103,7 +103,7 @@ export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
 }
 
 export interface WebViewNavigation extends WebViewNativeEvent {
-  navigationType:
+  navigationType?:
     | 'click'
     | 'formsubmit'
     | 'backforward'
@@ -115,6 +115,7 @@ export interface WebViewNavigation extends WebViewNativeEvent {
 
 export interface ShouldStartLoadRequest extends WebViewNavigation {
   isTopFrame: boolean;
+  hasGesture?: boolean;
 }
 
 export interface FileDownload {


### PR DESCRIPTION
`navigationType` is an iOS attribute that can't be replicated on Android. One idea was to just use `if hasGesture then navigationType = click`, but as a user of this library I would use it assuming it would work the same on both Android and iOS.  `navigationType` has a lot of different values for different scenarios on iOS that Android doesnt provide. That's why I propose documenting it as such, and using the Android-ism `hasGesture` for this case.

Fixes https://github.com/react-native-webview/react-native-webview/issues/1869
Fixes https://github.com/react-native-webview/react-native-webview/issues/1785