### PR TITLE
fix(ios): Add missing nullability specifiers; fix if block warning

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -20,8 +20,11 @@
 @end
 
 @interface RNCWeakScriptMessageDelegate : NSObject<WKScriptMessageHandler>
-@property (nonatomic, weak) id<WKScriptMessageHandler> scriptDelegate;
-- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate;
+
+@property (nonatomic, weak, nullable) id<WKScriptMessageHandler> scriptDelegate;
+
+- (nullable instancetype)initWithDelegate:(id<WKScriptMessageHandler> _Nullable)scriptDelegate;
+
 @end
 
 @interface RNCWebView : RCTView
@@ -66,7 +69,7 @@
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 #if !TARGET_OS_OSX
-@property (nonatomic, weak) UIRefreshControl * refreshControl;
+@property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
 #endif
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
@@ -83,7 +86,7 @@
 - (void)stopLoading;
 #if !TARGET_OS_OSX
 - (void)addPullToRefreshControl;
-- (void)pullToRefresh:(UIRefreshControl *)refreshControl;
+- (void)pullToRefresh:(UIRefreshControl *_Nonnull)refreshControl;
 #endif
 
 @end

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1053,7 +1053,8 @@ static NSDictionary* customCertificatesForHost;
       return;
     }
 
-    if ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102 || [error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 101) {
+    if ([error.domain isEqualToString:@"WebKitErrorDomain"] &&
+        (error.code == 102 || error.code == 101)) {
       // Error code 102 "Frame load interrupted" is raised by the WKWebView
       // when the URL is from an http redirect. This is a common pattern when
       // implementing OAuth with a WebView.


### PR DESCRIPTION
When compiling pods for my app, I get the following warnings:
```
/my_project/node_modules/react-native-webview/apple/RNCWebView.h:23:29: Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)
my_project/node_modules/react-native-webview/apple/RNCWebView.h:24:4: Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)

/my_project/node_modules/react-native-webview/apple/RNCWebView.m:1031:61: '&&' within '||'
```

I've added the missing nullability specifiers to silence the warnings, and I updated the error code test to test the domain only once.
