### PR TITLE
chore(android): Bump minSDK version to match RN 0.64

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 28
     }


### PR DESCRIPTION
Bumps `minSdkVersion` on Android to API 21.

This brings `react-native-webview` in line with the `minSdkVersion` in [React Native 0.64](https://raw.githubusercontent.com/react-native-community/rn-diff-purge/release/0.64.0/RnDiffApp/android/build.gradle).

This was failing my Detox builds when running `assembleAndroidTest` which is how I discovered it 👍 

```
node_modules/react-native-webview/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger8537026088749233402.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.0] /Users/me/.gradle/caches/transforms-2/files-2.1/b6f7edcb35fd97b099ddfe438d86d13c/jetified-react-native-0.64.0/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```