### PR TITLE
Fix Cookie not set before load url in Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -522,6 +522,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
                 view.getSettings().setUserAgentString(headers.getString(key));
               }
             } else {
+              if (key.equalsIgnoreCase("Cookie")) {
+                CookieManager.getInstance().setCookie(url, headers.getString(key));
+              }
               headerMap.put(key, headers.getString(key));
             }
           }


### PR DESCRIPTION
## Summary

Fix the issue of React Native WebView in Android not setting the `Cookie` before load the url.
The proposed solution is to set the `Cookie` using `CookieManager` when iterating the headers key.

Impacted File:
- RNCWebViewManager.java