### PR TITLE
Add react-native.config.js to npm Publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lib",
     "index.js",
     "index.d.ts",
-    "react-native-webview.podspec"
+    "react-native-webview.podspec",
+    "react-native.config.js"
   ]
 }


### PR DESCRIPTION
Need to add react-native.config.js to files list in root package.json in order for file to be published and thus for autolinking for Windows to work.

Resolves microsoft/react-native-windows#7758