### PR TITLE
fix #1353 

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1036,7 +1036,7 @@ static NSDictionary* customCertificatesForHost;
       }
 
       NSString *disposition = nil;
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */ 
       if (@available(iOS 13, *)) {
         disposition = [response valueForHTTPHeaderField:@"Content-Disposition"];
       }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1036,9 +1036,11 @@ static NSDictionary* customCertificatesForHost;
       }
 
       NSString *disposition = nil;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13, *)) {
         disposition = [response valueForHTTPHeaderField:@"Content-Disposition"];
       }
+#endif
       BOOL isAttachment = disposition != nil && [disposition hasPrefix:@"attachment"];
       if (isAttachment || !navigationResponse.canShowMIMEType) {
         if (_onFileDownload) {


### PR DESCRIPTION
making sure that older xcode would compile by using pre-prcessor checks as @available(iOS 13, *) is not sufficient at compile time.

This fix also is consistent with the rest of the code where pre-processor checks are built in.