### PR TITLE
Avoid null pointer exception in RNCWebViewManager

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -791,6 +791,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         };
         webView.setWebChromeClient(mWebChromeClient);
       }
+      else {
+        Log.w("RNCWebViewManager", "Unable to get current activity thus could not set web chrome client with full screen video.");
+      }
     } else {
       if (mWebChromeClient != null) {
         mWebChromeClient.onHideCustomView();


### PR DESCRIPTION
There is a rare case when getCurrentActivity() is returning null and causing NullPointerException which leads to crash. Added check to avoid NullPointerException in RNCWebViewManager and added warning log in else block. 