### PR TITLE
Fix / in react-native.config.js for non windows platforms.

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -54,11 +54,11 @@ module.exports.dependency = {
       solutionFile: 'ReactNativeWebView.sln',
       projects: [
         {
-          projectFile: 'ReactNativeWebView\\ReactNativeWebView.vcxproj',
+          projectFile: 'ReactNativeWebView/ReactNativeWebView.vcxproj',
           directDependency: true,
         },
         {
-          projectFile: 'WebViewBridgeComponent\\WebViewBridgeComponent.vcxproj',
+          projectFile: 'WebViewBridgeComponent/WebViewBridgeComponent.vcxproj',
           directDependency: false,
         }
       ],


### PR DESCRIPTION
Fix an issue for non windows, such as on mac for ios or android builds.

When doing a `pod install` on mac, the error below occurs.
When building for android, the same error occurs.

This is because the way react-native-cli still reads/parses the react-native.config.js file EVEN if it's not actually going to do anything with it. In other words, it doesn't do a lazy read.

I've let the other appropriate teams know for longer term. But in interim, this will fix it for non windows, and it doesn't break windows since windows is perfectly happy with / or \ or \\\

The underlying error.

```
error ENOENT: no such file or directory, open '/Users/namrog84/MyRepo/src/apps/MyApp/node_modules/react-native-webview/windows/ReactNativeWebView\ReactNativeWebView.vcxproj'. Run CLI with --verbose flag for more details.
[!] Invalid `Podfile` file: 767: unexpected token at 'Error: ENOENT: no such file or directory, open '/Users/namrog84/MyRepo/src/apps/MyApp/node_modules/react-native-webview/windows/ReactNativeWebView\ReactNativeWebView.vcxproj'
```
