### PR TITLE
Remove upper bound on React Native peerdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "type": "Component"
   },
   "peerDependencies": {
-    "react-native": ">=0.60 <=0.64"
+    "react-native": ">=0.60"
   },
   "dependencies": {
     "escape-string-regexp": "2.0.0",


### PR DESCRIPTION
Fixes #1935

I've tested and it works just fine on 0.64.x