### PR TITLE
feat: add prop to allow nested scroll on android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -19,6 +19,7 @@ import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
@@ -341,6 +342,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         break;
     }
     view.setOverScrollMode(overScrollMode);
+  }
+
+  @ReactProp(name = "nestedScrollEnabled")
+  public void setNestedScrollEnabled(WebView view, boolean enabled) {
+    ((RNCWebView) view).setNestedScrollEnabled(enabled);
   }
 
   @ReactProp(name = "thirdPartyCookiesEnabled")
@@ -1405,6 +1411,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     protected boolean sendContentSizeChangeEvents = false;
     private OnScrollDispatchHelper mOnScrollDispatchHelper;
     protected boolean hasScrollEvent = false;
+    protected boolean nestedScrollEnabled = false;
     protected ProgressChangedFilter progressChangedFilter;
 
     /**
@@ -1431,6 +1438,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       this.hasScrollEvent = hasScrollEvent;
     }
 
+    public void setNestedScrollEnabled(boolean nestedScrollEnabled) {
+      this.nestedScrollEnabled = nestedScrollEnabled;
+    }
+
     @Override
     public void onHostResume() {
       // do nothing
@@ -1444,6 +1455,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     @Override
     public void onHostDestroy() {
       cleanupCallbacksAndDestroy();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+      if (this.nestedScrollEnabled) {
+        requestDisallowInterceptTouchEvent(true);
+      }
+      return super.onTouchEvent(event);
     }
 
     @Override

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -51,6 +51,7 @@ This document lays out the current public properties and methods for the React N
 - [`contentMode`](Reference.md#contentMode)
 - [`dataDetectorTypes`](Reference.md#datadetectortypes)
 - [`scrollEnabled`](Reference.md#scrollenabled)
+- [`nestedScrollEnabled`](Reference.md#nestedscrollenabled)
 - [`directionalLockEnabled`](Reference.md#directionalLockEnabled)
 - [`geolocationEnabled`](Reference.md#geolocationenabled)
 - [`allowFileAccessFromFileURLs`](Reference.md#allowFileAccessFromFileURLs)
@@ -1037,6 +1038,18 @@ Boolean value that determines whether scrolling is enabled in the `WebView`. The
 | Type | Required | Platform      |
 | ---- | -------- | ------------- |
 | bool | No       | iOS and macOS |
+
+---
+
+### `nestedScrollEnabled`[⬆](#props-index)
+
+Boolean value that determines whether scrolling is possible in the `WebView` when used inside a `ScrollView` on Android. The default value is `false`. 
+
+Setting this to `true` will prevent the `ScrollView` to scroll when scrolling from inside the `WebView`.
+
+| Type | Required | Platform      |
+| ---- | -------- | ------------- |
+| bool | No       | Android       |
 
 ---
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -64,6 +64,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
     setSupportMultipleWindows: true,
+    nestedScrollEnabled: false,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -301,6 +301,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
+  nestedScrollEnabled?: boolean;
   readonly urlPrefixesForDefaultIntent?: string[];
 }
 
@@ -951,6 +952,15 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Sets ability to open fullscreen videos on Android devices.
    */
   allowsFullscreenVideo?: boolean;
+
+  /**
+   * Allows to scroll inside the webview when used inside a scrollview.
+   * Behaviour already existing on iOS.
+   * Default to false
+   *
+   * @platform android
+   */
+  nestedScrollEnabled?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
Currently, on Android, it is not possible to scroll inside a webview when the webview is itself placed inside a scrollview.

This behaviour is documented in this issue : https://github.com/react-native-webview/react-native-webview/issues/1568

On iOS, this behaviour is already handled.

The purpose of this PR is to add an android prop that enable the "nested" scroll inside the webview. 

There is a counterpart though : when the prop is set to `true`, the user has to scroll outside the webview to effectively scroll the scrollview, since the native event is now handled by the webview.