### PR TITLE
fix(android): update navigation state on loading progress reaches 1

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -265,7 +265,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
 
   onLoadingProgress = (event: WebViewProgressEvent) => {
     const { onLoadProgress } = this.props;
-    const { nativeEvent: { progress } } = event;
+    const { nativeEvent: { progress, ...rest } } = event;
     if (progress === 1) {
       this.setState((state) => {
         if (state.viewState === 'LOADING') {
@@ -273,6 +273,12 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
         }
         return null;
       });
+      this.updateNavigationState({
+        nativeEvent: {
+          ...rest,
+          loading: false,
+        },
+      } as WebViewNavigationEvent)
     }
     if (onLoadProgress) {
       onLoadProgress(event);


### PR DESCRIPTION
In redirect case, the navigation state (loading/canGoBack) may not get updated.  #548 updates `viewState` to `IDLE` on progress reaches 1 to address `renderLoading` issue, this PR is trying to get the navigate state updated as well in this case. It may create redundant `onNavigationStateChange` for the normal case - once in `onLoadingFinish()` and once in `onLoadingProgress() + process == 1`, but it shouldn't break client side logic as the both the events are the same for loading finished.