### PR TITLE
Support dark mode on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,9 +131,11 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
+def webkit_version = getExtOrDefault('webkitVersion')
 
 dependencies {
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "androidx.webkit:webkit:$webkit_version"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,5 @@
 ReactNativeWebView_kotlinVersion=1.3.50
+ReactNativeWebView_webkitVersion=1.4.0
 ReactNativeWebView_compileSdkVersion=29
 ReactNativeWebView_buildToolsVersion=29.0.3
 ReactNativeWebView_targetSdkVersion=28

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -45,6 +45,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
+import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewFeature;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.modules.core.PermissionAwareActivity;
@@ -591,6 +593,27 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "onScroll")
   public void setOnScroll(WebView view, boolean hasScrollEvent) {
     ((RNCWebView) view).setHasScrollEvent(hasScrollEvent);
+  }
+
+  @ReactProp(name = "forceDarkOn")
+  public void setForceDarkOn(WebView view, boolean enabled) {
+    // Only Android 10+ support dark mode
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+      // Switch WebView dark mode
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+        int forceDarkMode = enabled ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF;
+        WebSettingsCompat.setForceDark(view.getSettings(), forceDarkMode);
+      }
+
+      // Set how WebView content should be darkened.
+      // PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING:  checks for the "color-scheme" <meta> tag.
+      // If present, it uses media queries. If absent, it applies user-agent (automatic)
+      // More information about Force Dark Strategy can be found here:
+      // https://developer.android.com/reference/androidx/webkit/WebSettingsCompat#setForceDarkStrategy(android.webkit.WebSettings)
+      if (enabled && WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+        WebSettingsCompat.setForceDarkStrategy(view.getSettings(), WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING);
+      }
+    }
   }
 
   @Override

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -77,6 +77,7 @@ This document lays out the current public properties and methods for the React N
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
 - [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows)
 - [`enableApplePay`](Reference.md#enableApplePay)
+- [`forceDarkOn`](Reference.md#forceDarkOn)
 
 ## Methods Index
 
@@ -1383,6 +1384,23 @@ Example:
 
 ```javascript
 <WebView enableApplePay={true} />
+```
+
+### `forceDarkOn`
+
+Configuring Dark Theme
+*NOTE* : The force dark setting is not persistent. You must call the static method every time your app process is started.
+
+*NOTE* : The change from day<->night mode is a configuration change so by default the activity will be restarted and pickup the new values to apply the theme. Take care when overriding this default behavior to ensure this method is still called when changes are made.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Android  |
+
+Example:
+
+```javascript
+<WebView forceDarkOn={false} />
 ```
 
 ## Methods

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -302,6 +302,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
   readonly urlPrefixesForDefaultIntent?: string[];
+  forceDarkOn?: boolean;
 }
 
 export declare type ContentInsetAdjustmentBehavior = 'automatic' | 'scrollableAxes' | 'never' | 'always';
@@ -951,6 +952,19 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Sets ability to open fullscreen videos on Android devices.
    */
   allowsFullscreenVideo?: boolean;
+
+  /**
+   * Configuring Dark Theme
+   * 
+   * *NOTE* : The force dark setting is not persistent. You must call the static method every time your app process is started.
+   *  
+   * *NOTE* : The change from day<->night mode is a configuration change so by default the activity will be restarted
+   * and pickup the new values to apply the theme. 
+   * Take care when overriding this default behavior to ensure this method is still called when changes are made.
+   * 
+   * @platform android
+   */
+  forceDarkOn?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
On iOS the WebView automatically uses the dark-theme if the system appearance is set to dark. On Android this is not happening.

This PR adds support for dark-theme, and fixes #1677 (this issue was closed because stale).