### PR TITLE
fix(android): handle IllegalArgumentException creating DownloadManage…

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -86,6 +86,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -211,7 +212,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         RNCWebViewModule module = getModule(reactContext);
 
-        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+        DownloadManager.Request request;
+        try {
+          request = new DownloadManager.Request(Uri.parse(url));
+        } catch (IllegalArgumentException ex) {
+          FLog.w(TAG, "Unable to create DownloadManager.Request for URL: " + url, ex);
+          return;
+        }
 
         String fileName = URLUtil.guessFileName(url, contentDisposition, mimetype);
         String downloadMessage = "Downloading " + fileName;


### PR DESCRIPTION
…r.Request (#1546)

This PR is pretty much the same as https://github.com/react-native-webview/react-native-webview/pull/1546, but addresses the comments requested. Namely, it reduces the scope of the Try/Catch block to just where it's needed

It addresses issue https://github.com/react-native-webview/react-native-webview/issues/1090.