### PR TITLE
Allow custom menu items for selection menu

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -69,6 +69,8 @@
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL enableApplePay;
+@property (nonatomic, copy) NSArray<NSString *> * _Nullable menuItems;
+@property (nonatomic, copy) RCTDirectEventBlock onSelection;
 #if !TARGET_OS_OSX
 @property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
 #endif

--- a/apple/RNCWebViewManager.h
+++ b/apple/RNCWebViewManager.h
@@ -8,4 +8,6 @@
 #import <React/RCTViewManager.h>
 
 @interface RNCWebViewManager : RCTViewManager
+  @property (nonatomic, copy) NSArray<NSString *> * _Nullable menuItems;
+  @property (nonatomic, copy) RCTDirectEventBlock onSelection;
 @end

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -100,6 +100,8 @@ RCT_EXPORT_VIEW_PROPERTY(messagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(enableApplePay, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(menuItems, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(onSelection, RCTDirectEventBlock)
 
 RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag message:(NSString *)message)
 {


### PR DESCRIPTION
## What's in this PR?

Adds the ability for users to specify custom context menu items on iOS.

<img width="476" alt="Screen Shot 2021-07-21 at 5 10 04 PM" src="https://user-images.githubusercontent.com/881981/126560575-1712b4f3-366b-4ff6-95c3-ff0256dfd1b2.png">

Addresses some older issues
- https://github.com/react-native-webview/react-native-webview/issues/647
- https://github.com/facebook/react-native/issues/3414

This adds two params to the WebView component:
- `menuItems` -- Array of strings, specifying the custom menu items you want to appear
- `onSelection` -- Callback function called when an item is clicked (currently, it only passes the string of the menu item)

```
<WebView 
  source={source} 
  menuItems={['Foo', 'Bar']}
  onSelection={({ nativeEvent }) => console.log(nativeEvent.customMenuKey)} />
```

## How to test

With the example above, can you add custom menu items and seem the logged when you click


### Android?

The project I'm on is iOS only, so I'm not sure about porting this to Android/Java.  Open to any suggestions!