### PR TITLE
feat(android): add props to control pinch to zoom and internal zoom controls

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -252,6 +252,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
 
+  @ReactProp(name = "setBuiltInZoomControls")
+  public void setBuiltInZoomControls(WebView view, boolean enabled) {
+    view.getSettings().setBuiltInZoomControls(enabled);
+  }
+
+  @ReactProp(name = "setDisplayZoomControls")
+  public void setDisplayZoomControls(WebView view, boolean enabled) {
+    view.getSettings().setDisplayZoomControls(enabled);
+  }
+
   @ReactProp(name = "setSupportMultipleWindows")
   public void setSupportMultipleWindows(WebView view, boolean enabled){
     view.getSettings().setSupportMultipleWindows(enabled);

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -51,6 +51,8 @@ This document lays out the current public properties and methods for the React N
 - [`contentMode`](Reference.md#contentMode)
 - [`dataDetectorTypes`](Reference.md#datadetectortypes)
 - [`scrollEnabled`](Reference.md#scrollenabled)
+- [`setBuiltInZoomControls`](Reference.md#setBuiltInZoomControls)
+- [`setDisplayZoomControls`](Reference.md#setDisplayZoomControls)
 - [`directionalLockEnabled`](Reference.md#directionalLockEnabled)
 - [`geolocationEnabled`](Reference.md#geolocationenabled)
 - [`allowFileAccessFromFileURLs`](Reference.md#allowFileAccessFromFileURLs)
@@ -1037,6 +1039,27 @@ Boolean value that determines whether scrolling is enabled in the `WebView`. The
 | Type | Required | Platform      |
 | ---- | -------- | ------------- |
 | bool | No       | iOS and macOS |
+
+---
+
+
+### `setBuiltInZoomControls`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Sets whether the WebView should use its built-in zoom mechanisms. The default value is `true`. Setting this to `false` will prevent the use of a pinch gesture to control zooming.
+
+| Type | Required | Platform      |
+| ---- | -------- | ------------- |
+| bool | No       | Android       |
+
+---
+
+### `setDisplayZoomControls`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Sets whether the WebView should display on-screen zoom controls when using the built-in zoom mechanisms (see `setBuiltInZoomControls`). The default value is `false`. 
+
+| Type | Required | Platform      |
+| ---- | -------- | ------------- |
+| bool | No       | Android       |
 
 ---
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -64,6 +64,8 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
     setSupportMultipleWindows: true,
+    setBuiltInZoomControls: true,
+    setDisplayZoomControls: false,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -301,6 +301,8 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
+  setBuiltInZoomControls?: boolean,
+  setDisplayZoomControls?: boolean,
   readonly urlPrefixesForDefaultIntent?: string[];
 }
 
@@ -951,6 +953,24 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Sets ability to open fullscreen videos on Android devices.
    */
   allowsFullscreenVideo?: boolean;
+
+  /**
+   * Boolean value to control whether pinch zoom is enabled. Used only in Android.
+   * Default to true
+   *
+   * @platform android
+   */
+   setBuiltInZoomControls?: boolean;
+
+   
+   /**
+   * Boolean value to control whether built-in zooms controls are displayed. Used only in Android.
+   * Default to false
+   * Controls will always be hidden if setBuiltInZoomControls is set to `false`
+   * 
+   * @platform android
+   */
+    setDisplayZoomControls?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
Enables props to control pinch to zoom, a required feature for kiosk environments.

Mentions #1649
