### PR TITLE
feat(apple): userAgent can be changed at runtime

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -311,9 +311,7 @@ static NSDictionary* customCertificatesForHost;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 
-    if (_userAgent) {
-      _webView.customUserAgent = _userAgent;
-    }
+    _webView.customUserAgent = _userAgent;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
       _webView.scrollView.contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
@@ -700,6 +698,12 @@ static NSDictionary* customCertificatesForHost;
   scrollView.decelerationRate = _decelerationRate;
 }
 #endif // !TARGET_OS_OSX
+
+- (void)setUserAgent:(NSString*)userAgent
+{
+  _userAgent = userAgent;
+  _webView.customUserAgent = userAgent;
+}
 
 - (void)setScrollEnabled:(BOOL)scrollEnabled
 {

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -72,7 +72,6 @@ RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(incognito, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(pagingEnabled, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
@@ -123,6 +122,10 @@ RCT_CUSTOM_VIEW_PROPERTY(bounces, BOOL, RNCWebView) {
 
 RCT_CUSTOM_VIEW_PROPERTY(useSharedProcessPool, BOOL, RNCWebView) {
   view.useSharedProcessPool = json == nil ? true : [RCTConvert BOOL: json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(userAgent, NSString, RNCWebView) {
+  view.userAgent = [RCTConvert NSString: json];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(scrollEnabled, BOOL, RNCWebView) {


### PR DESCRIPTION
Make it so that if you change the userAgent prop, this change is propagated to
the native webview on iOS/macOS. Android already has this functionality.

Sometimes it is useful for WebView apps to be able to change their user agent
dynamically to communicate custom things to the web app they are hosting.
Since we can't add custom headers to every single request made by the webview,
the user agent can be used to send things like feature flags to the web app, so
it can have the appropriate behavior depending on what state the mobile app is
in.