### PR TITLE
fix(types): add missing ignoreSilentHardwareSwitch prop

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -520,6 +520,13 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   sharedCookiesEnabled?: boolean;
 
   /**
+   * When set to true the hardware silent switch is ignored.
+   * The default value is `false`.
+   * @platform ios
+   */
+  ignoreSilentHardwareSwitch?: boolean;
+
+  /**
    * Set true if StatusBar should be light when user watch video fullscreen.
    * The default value is `true`.
    * @platform ios


### PR DESCRIPTION
It seems we have missing types for [ignoreSilentHardwareSwitch](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#ignoreSilentHardwareSwitch). Added it in

https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#ignoreSilentHardwareSwitch
https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#hardware-silence-switch