### PR TITLE
implement android mic and camera permission flags

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -323,6 +323,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "androidMicrophoneAccessDisabled")
+  public void setMicrophoneAccessDisabled(WebView view, boolean disabled) {
+    ((RNCWebView) view).getCustomSettings().setMicrophoneAccessDisabled(disabled);
+  }
+
+  @ReactProp(name = "androidCameraAccessDisabled")
+  public void setCameraAccessDisabled(WebView view, boolean disabled) {
+    ((RNCWebView) view).getCustomSettings().setCameraAccessDisabled(disabled);
+  }
+
   @ReactProp(name = "androidLayerType")
   public void setLayerType(WebView view, String layerTypeString) {
     int layerType = View.LAYER_TYPE_NONE;
@@ -1229,6 +1239,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         if (androidPermission != null) {
           if (ContextCompat.checkSelfPermission(mReactContext, androidPermission) == PackageManager.PERMISSION_GRANTED) {
+            if ((androidPermission.equals(Manifest.permission.RECORD_AUDIO) && ((RNCWebView) mWebView).getCustomSettings().getMicrophoneAccessDisabled()) ||
+                (androidPermission.equals(Manifest.permission.CAMERA) && ((RNCWebView) mWebView).getCustomSettings().getCameraAccessDisabled())) {
+              continue;
+            }
             grantedPermissions.add(requestedResource);
           } else {
             requestedAndroidPermissions.add(androidPermission);
@@ -1446,6 +1460,17 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     protected boolean hasScrollEvent = false;
     protected boolean nestedScrollEnabled = false;
     protected ProgressChangedFilter progressChangedFilter;
+
+    /**
+     *  It is impossibile to override WebView getSettings(), so RNCWebView has getCustomSettings()
+     */
+    private CustomWebSettings customWebSettings;
+    public CustomWebSettings getCustomSettings() {
+      if (customWebSettings == null) {
+        customWebSettings = new CustomWebSettings();
+      }
+      return customWebSettings;
+    }
 
     /**
      * WebView must be created with an context of the current activity
@@ -1733,6 +1758,27 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
       public boolean isWaitingForCommandLoadUrl() {
         return waitingForCommandLoadUrl;
+      }
+    }
+
+    private class CustomWebSettings {
+      private boolean microphoneAccess = true;
+      private boolean cameraAccess = true;
+
+      private boolean getMicrophoneAccessDisabled() {
+        return !microphoneAccess;
+      }
+
+      private boolean getCameraAccessDisabled() {
+        return !cameraAccess;
+      }
+
+      private void setMicrophoneAccessDisabled(boolean b) {
+        cameraAccess = !b;
+      }
+
+      private void setCameraAccessDisabled(boolean b) {
+        microphoneAccess = !b;
       }
     }
   }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1774,11 +1774,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
 
       private void setMicrophoneAccessDisabled(boolean b) {
-        cameraAccess = !b;
+        microphoneAccess = !b;
       }
 
       private void setCameraAccessDisabled(boolean b) {
-        microphoneAccess = !b;
+        cameraAccess = !b;
       }
     }
   }

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -61,6 +61,8 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     saveFormDataDisabled: false,
     cacheEnabled: true,
     androidHardwareAccelerationDisabled: false,
+    androidMicrophoneAccessDisabled: false,
+    androidCameraAccessDisabled: false,
     androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
     setSupportMultipleWindows: true,

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -900,7 +900,21 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    */
   androidHardwareAccelerationDisabled?: boolean;
 
-    /**
+  /**
+   * Boolean value to always forbid access to the microphone in the `WebView`, even if the app
+   * was granted the necessary Android permission. The default value is `false` for backward-compatibility.
+   * @platform android
+   */
+  androidMicrophoneAccessDisabled?: boolean;
+
+  /**
+   * Boolean value to always forbid access to the camera in the `WebView`, even if the app
+   * was granted the necessary Android permission. The default value is `false` for backward-compatibility.
+   * @platform android
+   */
+  androidCameraAccessDisabled?: boolean;
+
+  /**
    * https://developer.android.com/reference/android/webkit/WebView#setLayerType(int,%20android.graphics.Paint)
    * Sets the layerType. Possible values are:
    *


### PR DESCRIPTION
Simple implementation of two platform specific flags: androidMicrophoneAccessDenied and androidCameraAccessDenied
They control the ability of a domain to access the device camera and/or the microphone, if the relevant Android permissions were already granted by the user.

Seems to work to address the concerns shared in #2136