### PR TITLE
Update cacheEnabled doc

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1231,11 +1231,11 @@ Sets whether the WebView should disable saving form data. The default value is `
 
 ### `cacheEnabled`[⬆](#props-index)<!-- Link generated with jump2header -->
 
-Sets whether WebView should use browser caching.
+Sets whether WebView should use browser caching. Note that this doesn't work on iOS, use `incognito={true}` instead.
 
 | Type    | Required | Default | Platform            |
 | ------- | -------- | ------- | ------------------- |
-| boolean | No       | true    | iOS, Android, macOS |
+| boolean | No       | true    | Android, macOS |
 
 ---
 


### PR DESCRIPTION
`cacheEnabled` doesn't actually work on iOS, the closest one can get is setting `incognito={true}`.

Ref: https://github.com/react-native-webview/react-native-webview/issues/1979