### PR TITLE
add prop allowsOnlyLandscapeInFullscreen android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -156,6 +156,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected RNCWebChromeClient mWebChromeClient = null;
   protected boolean mAllowsFullscreenVideo = false;
+  protected boolean mAllowsOnlyLandscapeInFullscreen = false;
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
 
@@ -606,6 +607,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     setupWebChromeClient((ReactContext)view.getContext(), view);
   }
 
+  @ReactProp(name = "allowsOnlyLandscapeInFullscreen")
+  public void setAllowsOnlyLandscapeInFullscreen(
+    WebView view,
+    @Nullable Boolean allowsOnlyLandscapeInFullscreen) {
+    mAllowsOnlyLandscapeInFullscreen = allowsOnlyLandscapeInFullscreen != null && allowsOnlyLandscapeInFullscreen;
+    setupWebChromeClient((ReactContext)view.getContext(), view);
+  }
+
   @ReactProp(name = "allowFileAccess")
   public void setAllowFileAccess(
     WebView view,
@@ -777,7 +786,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           mVideoView = view;
           mCustomViewCallback = callback;
 
-          mReactContext.getCurrentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+          int activityInfo = mAllowsOnlyLandscapeInFullscreen ?
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE :
+            ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+
+          mReactContext.getCurrentActivity().setRequestedOrientation(activityInfo);
 
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mVideoView.setSystemUiVisibility(FULLSCREEN_SYSTEM_UI_VISIBILITY);

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -43,6 +43,7 @@ This document lays out the current public properties and methods for the React N
 - [`userAgent`](Reference.md#useragent)
 - [`applicationNameForUserAgent`](Reference.md#applicationNameForUserAgent)
 - [`allowsFullscreenVideo`](Reference.md#allowsfullscreenvideo)
+- [`allowsOnlyLandscapeInFullscreen`](Reference.md#allowsOnlyLandscapeInFullscreen)
 - [`allowsInlineMediaPlayback`](Reference.md#allowsinlinemediaplayback)
 - [`bounces`](Reference.md#bounces)
 - [`overScrollMode`](Reference.md#overscrollmode)
@@ -921,6 +922,16 @@ Append to the existing user-agent. Setting `userAgent` will override this.
 ### `allowsFullscreenVideo`[⬆](#props-index)<!-- Link generated with jump2header -->
 
 Boolean that determines whether videos are allowed to be played in fullscreen. The default value is `false`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `allowsOnlyLandscapeInFullscreen`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Boolean value to force landscape mode when open videos in fullscreen on Android devices. The default value is `false`.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -57,6 +57,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     thirdPartyCookiesEnabled: true,
     scalesPageToFit: true,
     allowsFullscreenVideo: false,
+    allowsOnlyLandscapeInFullscreen: false,
     allowFileAccess: false,
     saveFormDataDisabled: false,
     cacheEnabled: true,

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -644,7 +644,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * A Boolean value which, when set to `true`, indicates to WebKit that a WKWebView
    * will only navigate to app-bound domains. Once set, any attempt to navigate away
    * from an app-bound domain will fail with the error “App-bound domain failure.”
-   * 
+   *
    * Applications can specify up to 10 “app-bound” domains using a new
    * Info.plist key `WKAppBoundDomains`.
    * @platform ios
@@ -977,14 +977,21 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   allowsFullscreenVideo?: boolean;
 
   /**
+   * Boolean value to force landscape mode when open videos in fullscreen on Android devices.
+   * The default value is `false`.
+   * @platform android
+   */
+  allowsOnlyLandscapeInFullscreen?: boolean;
+
+  /**
    * Configuring Dark Theme
-   * 
+   *
    * *NOTE* : The force dark setting is not persistent. You must call the static method every time your app process is started.
-   *  
+   *
    * *NOTE* : The change from day<->night mode is a configuration change so by default the activity will be restarted
-   * and pickup the new values to apply the theme. 
+   * and pickup the new values to apply the theme.
    * Take care when overriding this default behavior to ensure this method is still called when changes are made.
-   * 
+   *
    * @platform android
    */
   forceDarkOn?: boolean;
@@ -996,16 +1003,16 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   setBuiltInZoomControls?: boolean;
-   
+
   /**
    * Boolean value to control whether built-in zooms controls are displayed. Used only in Android.
    * Default to false
    * Controls will always be hidden if setBuiltInZoomControls is set to `false`
-   * 
+   *
    * @platform android
    */
   setDisplayZoomControls?: boolean;
-  
+
   /**
    * Allows to scroll inside the webview when used inside a scrollview.
    * Behaviour already existing on iOS.


### PR DESCRIPTION
Due to some visual errors during rotate the phone while webview playing a video in fullscreen, I add a new android props called: allowsOnlyLandscapeInFullscreen.
The property sets device automatically to landscape when user puts video in fullscreen.