### PR TITLE
fix(android): add null-pointer check for `activity` before creating `RNCWebChromeClient` (closes #1406, #2190)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -759,8 +759,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   protected void setupWebChromeClient(ReactContext reactContext, WebView webView) {
-    if (mAllowsFullscreenVideo) {
-      int initialRequestedOrientation = reactContext.getCurrentActivity().getRequestedOrientation();
+    Activity activity = mReactContext.getCurrentActivity();
+
+    if (mAllowsFullscreenVideo && activity != null) {
+      int initialRequestedOrientation = activity.getRequestedOrientation();
+
       mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
         @Override
         public Bitmap getDefaultVideoPoster() {
@@ -777,31 +780,32 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           mVideoView = view;
           mCustomViewCallback = callback;
 
-          mReactContext.getCurrentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+          activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mVideoView.setSystemUiVisibility(FULLSCREEN_SYSTEM_UI_VISIBILITY);
-            mReactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+            activity.getWindow().setFlags(
+              WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+              WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+            );
           }
 
           mVideoView.setBackgroundColor(Color.BLACK);
 
-          // since RN's Modals interfere with the View hierarchy
-          // we will decide which View to Hide if the hierarchy
-          // does not match (i.e., the webview is within a Modal)
-          // NOTE: We could use mWebView.getRootView() instead of getRootView()
+          // Since RN's Modals interfere with the View hierarchy
+          // we will decide which View to hide if the hierarchy
+          // does not match (i.e., the WebView is within a Modal)
+          // NOTE: We could use `mWebView.getRootView()` instead of `getRootView()`
           // but that breaks the Modal's styles and layout, so we need this to render
-          // in the main View hierarchy regardless.
+          // in the main View hierarchy regardless
           ViewGroup rootView = getRootView();
           rootView.addView(mVideoView, FULLSCREEN_LAYOUT_PARAMS);
 
           // Different root views, we are in a Modal
-          if(rootView.getRootView() != mWebView.getRootView()){
+          if (rootView.getRootView() != mWebView.getRootView()) {
             mWebView.getRootView().setVisibility(View.GONE);
-          }
-
-          // Same view hierarchy (no Modal), just hide the webview then
-          else{
+          } else {
+            // Same view hierarchy (no Modal), just hide the WebView then
             mWebView.setVisibility(View.GONE);
           }
 
@@ -814,20 +818,18 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
             return;
           }
 
-          // same logic as above
+          // Same logic as above
           ViewGroup rootView = getRootView();
 
-          if(rootView.getRootView() !=  mWebView.getRootView()){
+          if (rootView.getRootView() != mWebView.getRootView()) {
             mWebView.getRootView().setVisibility(View.VISIBLE);
-          }
-
-          // Same view hierarchy (no Modal)
-          else{
+          } else {
+            // Same view hierarchy (no Modal)
             mWebView.setVisibility(View.VISIBLE);
           }
 
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            mReactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+            activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
           }
 
           rootView.removeView(mVideoView);
@@ -836,22 +838,25 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           mVideoView = null;
           mCustomViewCallback = null;
 
-          mReactContext.getCurrentActivity().setRequestedOrientation(initialRequestedOrientation);
+          activity.setRequestedOrientation(initialRequestedOrientation);
 
           mReactContext.removeLifecycleEventListener(this);
         }
       };
+
       webView.setWebChromeClient(mWebChromeClient);
     } else {
       if (mWebChromeClient != null) {
         mWebChromeClient.onHideCustomView();
       }
+
       mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
         @Override
         public Bitmap getDefaultVideoPoster() {
           return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
         }
       };
+
       webView.setWebChromeClient(mWebChromeClient);
     }
   }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -759,7 +759,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   protected void setupWebChromeClient(ReactContext reactContext, WebView webView) {
-    Activity activity = mReactContext.getCurrentActivity();
+    Activity activity = reactContext.getCurrentActivity();
 
     if (mAllowsFullscreenVideo && activity != null) {
       int initialRequestedOrientation = activity.getRequestedOrientation();


### PR DESCRIPTION
This PR adds a null-pointer check for `reactContext.getCurrentActivity()` before creating the `RNCWebChromeClient` with full-screen video support.

When `reactContext.getCurrentActivity()` is `null`, the `RNCWebChromeClient` will be initialized without full-screen video support.

Closes #1406.
Closes #2190.