### PR TITLE
fix(ios): build failing in Xcode 12

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -149,7 +149,9 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     _savedAutomaticallyAdjustsScrollIndicatorInsets = NO;
 #endif
     _enableApplePay = NO;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
+#endif
   }
 
 #if !TARGET_OS_OSX


### PR DESCRIPTION
Add version check around `_mediaCapturePermissionGrantType`.

Fixes #2262 and #2270