### PR TITLE
feat(android): add minimum font size

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -646,6 +646,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "minimumFontSize")
+  public void setMinimumFontSize(WebView view, int fontSize) {
+    view.getSettings().setMinimumFontSize(fontSize);
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -83,6 +83,7 @@ This document lays out the current public properties and methods for the React N
 - [`basicAuthCredential`](Reference.md#basicAuthCredential)
 - [`enableApplePay`](Reference.md#enableApplePay)
 - [`forceDarkOn`](Reference.md#forceDarkOn)
+- [`minimumFontSize`](Reference.md#minimumFontSize)
 
 ## Methods Index
 
@@ -1502,6 +1503,18 @@ An object that specifies the credentials of a user to be used for basic authenti
 | Type   | Required |
 | ------ | -------- |
 | object | No       |
+
+### `minimumFontSize`
+
+Android enforces a minimum font size based on this value. A non-negative integer between 1 and 72. Any number outside the specified range will be pinned. Default value is 8. If you are using smaller font sizes and are having trouble fitting the whole window onto one screen, try setting this to a smaller value.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
+
+Example:
+
+`<WebView minimumFontSize={1} />`
 
 ## Methods
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -331,6 +331,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   nestedScrollEnabled?: boolean;
   readonly urlPrefixesForDefaultIntent?: string[];
   forceDarkOn?: boolean;
+  minimumFontSize?: number;
 }
 
 export declare type ContentInsetAdjustmentBehavior = 'automatic' | 'scrollableAxes' | 'never' | 'always';
@@ -1055,6 +1056,14 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   nestedScrollEnabled?: boolean;
+  
+  /**
+   * Sets the minimum font size.
+   * A non-negative integer between 1 and 72. Any number outside the specified range will be pinned.
+   * Default is 8.
+   * @platform android
+   */
+  minimumFontSize?: number;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
# Summary
Android WebView enforces a default minimum font size of 8 (see https://developer.android.com/reference/android/webkit/WebSettings#setMinimumFontSize(int)), causing scaling issues when using smaller font sizes. Content that may be deliberately scaled down to fit 100% width of the device may overflow. This property allows for customizing the minimum font size so scaling appears similar as on iOS.

In cases where grids of content/text are displayed (such as a seating chart), font size may need to be scaled down to fit the entire grid onto one screen width.

Previous Pull Request : https://github.com/react-native-webview/react-native-webview/pull/986

## Test plan
### What's required for testing (prerequisites)?
Running on Android.

### What are the steps to reproduce (after prerequisites)?
Reference HTML code that uses font sizes < 8. 

For example:
`<WebView source={{ html: '<html><body><span style="font-size: 4px;">Font size 4</span></body></html>' }} minimumFontSize={1} />`

## Compatibility

OS | Implemented
-- | --
iOS | ❌
Android | ✅

## Checklist
- [x] I have tested this on a device and a simulator
- [x] I added the documentation in Reference.md
- [x] I updated the typed files (TS and Flow)
