### PR TITLE
Add iOS content blocking to WKWebView

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -83,6 +83,7 @@ typedef enum RNCWebViewPermissionGrantType : NSUInteger {
 #if !TARGET_OS_OSX
 @property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
 #endif
+@property (nonatomic, copy) NSString * _Nullable contentRuleList;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
 @property (nonatomic, assign) WKContentMode contentMode;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -88,6 +88,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 @property (nonatomic, strong) WKUserScript *postMessageScript;
 @property (nonatomic, strong) WKUserScript *atStartScript;
 @property (nonatomic, strong) WKUserScript *atEndScript;
+@property (nonatomic, strong) NSString *contentRuleListIdentifier;
 @end
 
 @implementation RNCWebView
@@ -151,6 +152,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     _enableApplePay = NO;
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
     _contentRuleList = nil;
+    _contentRuleListIdentifier = [[NSUUID UUID] UUIDString];
   }
 
 #if !TARGET_OS_OSX
@@ -1575,7 +1577,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   }
     
   if (_contentRuleList) {
-    [WKContentRuleListStore.defaultStore compileContentRuleListForIdentifier: @"react-native-webview" encodedContentRuleList: _contentRuleList completionHandler: ^(WKContentRuleList *contentRuleList, NSError *err) {
+    [WKContentRuleListStore.defaultStore compileContentRuleListForIdentifier: _contentRuleListIdentifier encodedContentRuleList: _contentRuleList completionHandler: ^(WKContentRuleList *contentRuleList, NSError *err) {
       if (err != nil) {
         NSLog(@"Error on content rule list compiled");
         return;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1574,19 +1574,18 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     [wkWebViewConfig.userContentController addUserScript:self.atStartScript];
   }
     
-    if (_contentRuleList) {
-        [WKContentRuleListStore.defaultStore compileContentRuleListForIdentifier: @"RN" encodedContentRuleList: _contentRuleList completionHandler: ^(WKContentRuleList *contentRuleList, NSError *err) {
+  if (_contentRuleList) {
+    [WKContentRuleListStore.defaultStore compileContentRuleListForIdentifier: @"react-native-webview" encodedContentRuleList: _contentRuleList completionHandler: ^(WKContentRuleList *contentRuleList, NSError *err) {
+      if (err != nil) {
+        NSLog(@"Error on content rule list compiled");
+        return;
+      }
 
-            if (err != nil) {
-                NSLog(@"Error on content rule list compiled");
-                return;
-            }
-
-            if (contentRuleList) {
-                [wkWebViewConfig.userContentController addContentRuleList: contentRuleList];
-            }
-        }];
-    }
+      if (contentRuleList) {
+        [wkWebViewConfig.userContentController addContentRuleList: contentRuleList];
+      }
+    }];
+  }
 }
 
 - (NSURLRequest *)requestForSource:(id)json {

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -87,6 +87,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(contentRuleList, NSString)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -359,6 +359,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
         // TODO: find a better way to type this.
         source={resolveAssetSource(this.props.source as ImageSourcePropType)}
         style={webViewStyles}
+        contentRuleList={this.props.contentRuleList}
         {...nativeConfig.props}
       />
     );

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -359,7 +359,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
         // TODO: find a better way to type this.
         source={resolveAssetSource(this.props.source as ImageSourcePropType)}
         style={webViewStyles}
-        contentRuleList={this.props.contentRuleList}
+        contentRuleList={JSON.stringify(this.props.contentRuleList)}
         {...nativeConfig.props}
       />
     );

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -370,6 +370,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   onFileDownload?: (event: FileDownloadEvent) => void;
   limitsNavigationsToAppBoundDomains?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
+  contentRuleList?: string;
 }
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -706,6 +707,12 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * `selectedText`: the text selected on the document
    */
   onCustomMenuSelection?: (event: WebViewEvent) => void;
+
+  /**
+   * Takes a JSON string for and passes it to WKContentRuleList
+   * https://developer.apple.com/documentation/safariservices/creating_a_content_blocker?language=objc
+   */
+  contentRuleList?: string;
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -736,8 +736,11 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   onCustomMenuSelection?: (event: WebViewEvent) => void;
 
   /**
-   * Takes a JSON string for and passes it to WKContentRuleList
-   * https://developer.apple.com/documentation/safariservices/creating_a_content_blocker?language=objc
+   * `WKWebView` on iOS supports content blocking. This is defined via a JSON string 
+   * that is passed to the native side and then compiled into bytecode. It takes a set of
+   * rules that are used to block content.
+   * More info: https://developer.apple.com/documentation/safariservices/creating_a_content_blocker
+   * @platform ios
    */
   contentRuleList?: IOSContentRule[];
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -344,6 +344,33 @@ export declare type MediaCapturePermissionGrantType =
 
 export declare type ContentMode = 'recommended' | 'mobile' | 'desktop';
 
+export interface IOSContentRule {
+  action: IOSContentBlockerAction;
+  trigger: IOSContentBlockerTrigger;
+}
+
+export interface IOSContentBlockerAction {
+  type:
+    | 'block'
+    | 'block-cookies'
+    | 'css-display-none'
+    | 'ignore-previous-rules'
+    | 'make-https';
+  selector?: string;
+}
+
+export interface IOSContentBlockerTrigger {
+  'url-filter': string;
+  'resource-type'?: string[];
+  'load-type'?: string[];
+  'unless-domain'?: string[];
+  'if-domain'?: string[];
+  'if-top-url'?: string[];
+  'unless-top-url'?: string[];
+  'load-context'?: string[];
+  'url-filter-is-case-sensitive'?: boolean;
+}
+
 export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowingReadAccessToURL?: string;
   allowsBackForwardNavigationGestures?: boolean;
@@ -370,7 +397,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   onFileDownload?: (event: FileDownloadEvent) => void;
   limitsNavigationsToAppBoundDomains?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
-  contentRuleList?: string;
+  contentRuleList?: IOSContentRule[];
 }
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -397,7 +397,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   onFileDownload?: (event: FileDownloadEvent) => void;
   limitsNavigationsToAppBoundDomains?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
-  contentRuleList?: IOSContentRule[];
+  contentRuleList?: string;
 }
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -739,7 +739,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * Takes a JSON string for and passes it to WKContentRuleList
    * https://developer.apple.com/documentation/safariservices/creating_a_content_blocker?language=objc
    */
-  contentRuleList?: string;
+  contentRuleList?: IOSContentRule[];
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
`WKWebView` on iOS supports [content blocking](https://developer.apple.com/documentation/safariservices/creating_a_content_blocker). This is defined via a JSON string that is passed to the native side and then compiled into bytecode. It takes a set of rules that are used to block content. I created types for the rules based on Apple's doc. That way the rule can be written in Typescript and then stringified before being passed to the native side.

```typescript
const CONTENT_BLOCK: IOSContentRule[] = [
  {
    trigger: {'url-filter': '.*', 'resource-type': ['image']},
    action: {type: 'block'},
  },
];

return (<WebView
  originWhitelist={['*']}
  source={{uri: 'https://google.com'}}
  contentRuleList={CONTENT_BLOCK}
/>);
```