### PR TITLE
Bump Node to Restore Pipeline

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.9.1'
+        node-version: '12.13.0'
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
**_What_**
Current Node version is not compatible with @jest/create-cache-key-function. Bumping to restore pipeline.