### PR TITLE
chore: Update node version in CI to 14

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.9.1'
+        node-version: '^14'
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
CI started to fail as some minor version update of a dependency started to require a higher version of node than we were using (12.9.1):

```
yarn install v1.22.17
[1/4] Resolving packages...
[2/4] Fetching packages...
error @jest/create-cache-key-function@27.3.1: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "12.9.1"
error Found incompatible module.
```