### PR TITLE
fix(macos): mediaCapturePermissionGrantType is iOS only

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -149,7 +149,9 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     _savedAutomaticallyAdjustsScrollIndicatorInsets = NO;
 #endif
     _enableApplePay = NO;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
+#endif
   }
 
 #if !TARGET_OS_OSX


### PR DESCRIPTION
macOS fails to build because `_mediaCapturePermissionGrantType` is defined only for iOS:
https://github.com/react-native-webview/react-native-webview/blob/55b8a7702c82cc7b1713474daf6edf117f934d83/apple/RNCWebView.h#L95-L97