### PR TITLE
Prevent crash when trying to download blob urls

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -215,7 +215,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         RNCWebViewModule module = getModule(reactContext);
 
-        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url.replaceFirst("^blob:", "")));;
 
         String fileName = URLUtil.guessFileName(url, contentDisposition, mimetype);
         String downloadMessage = "Downloading " + fileName;


### PR DESCRIPTION
This PR is a simple fix that addresses crashes on Android when trying to Download blobs. I've tested this with the example app, here's a video of the user experience:

https://user-images.githubusercontent.com/8260207/149129687-842c8751-2499-4fae-8006-c56b519cdad2.mp4

I have also tested downloading regular, non-blob files and it works fine. 

It would be great to get this merged, given that it's a simple (hopefully non-controversial) fix for a severe problem that affects a lot of users 🙏 

Prior art: 
https://github.com/react-native-webview/react-native-webview/pull/1216
https://github.com/react-native-webview/react-native-webview/pull/1546
https://github.com/react-native-webview/react-native-webview/pull/2091

Prior issues:  
https://github.com/react-native-webview/react-native-webview/issues/1090
https://github.com/react-native-webview/react-native-webview/issues/295
https://github.com/react-native-webview/react-native-webview/pull/1760
https://github.com/react-native-webview/react-native-webview/issues/1945
https://github.com/react-native-webview/react-native-webview/issues/2073

