### PR TITLE
Prevent crash from unsupported URI downloads

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -90,6 +90,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -215,7 +216,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         RNCWebViewModule module = getModule(reactContext);
 
-        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+        DownloadManager.Request request;
+        try {
+          request = new DownloadManager.Request(Uri.parse(url));
+        } catch (IllegalArgumentException e) {
+          System.out.println("Unsupported URI, aborting download" + e.toString());
+          e.printStackTrace();
+          return;
+        }
 
         String fileName = URLUtil.guessFileName(url, contentDisposition, mimetype);
         String downloadMessage = "Downloading " + fileName;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -220,8 +220,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         try {
           request = new DownloadManager.Request(Uri.parse(url));
         } catch (IllegalArgumentException e) {
-          System.out.println("Unsupported URI, aborting download" + e.toString());
-          e.printStackTrace();
+          Log.w(TAG, "Unsupported URI, aborting download", e);
           return;
         }
 
@@ -236,8 +235,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           String cookie = CookieManager.getInstance().getCookie(baseUrl);
           request.addRequestHeader("Cookie", cookie);
         } catch (MalformedURLException e) {
-          System.out.println("Error getting cookie for DownloadManager: " + e.toString());
-          e.printStackTrace();
+          Log.w(TAG, "Error getting cookie for DownloadManager", e);
         }
 
         //Finish setting up request
@@ -1000,7 +998,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         if (!topWindowUrl.equalsIgnoreCase(failingUrl)) {
           // If error is not due to top-level navigation, then do not call onReceivedError()
-          Log.w("RNCWebViewManager", "Resource blocked from loading due to SSL error. Blocked URL: "+failingUrl);
+          Log.w(TAG, "Resource blocked from loading due to SSL error. Blocked URL: "+failingUrl);
           return;
         }
 
@@ -1109,10 +1107,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         super.onRenderProcessGone(webView, detail);
 
         if(detail.didCrash()){
-          Log.e("RNCWebViewManager", "The WebView rendering process crashed.");
+          Log.e(TAG, "The WebView rendering process crashed.");
         }
         else{
-          Log.w("RNCWebViewManager", "The WebView rendering process was killed by the system.");
+          Log.w(TAG, "The WebView rendering process was killed by the system.");
         }
 
         // if webView is null, we cannot return any event


### PR DESCRIPTION
As discussed [here](https://github.com/react-native-webview/react-native-webview/pull/2323#issuecomment-1012654602), here's a `try/catch` implementation to mitigate [blob crashes](https://github.com/react-native-webview/react-native-webview/issues/1090), with the block restricted to the call site of the exception. Here's a video of the current behaviour. It **might** make sense to send a toast about the download being unsupported. Please let me know if you feel like that's desirable.

https://user-images.githubusercontent.com/8260207/149483121-5a31a03e-7d00-4b31-a9d2-a01249c5997b.mp4

