### PR TITLE
Mark android-only methods as possibly undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,19 +46,19 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      * (Android only)
      * Removes the autocomplete popup from the currently focused form field, if present.
      */
-    clearFormData: () => void;
+    clearFormData?: () => void;
 
      /**
      * (Android only)
      * Clears the resource cache. Note that the cache is per-application, so this will clear the cache for all WebViews used.
      */
-    clearCache: (clear: boolean) => void;
+    clearCache?: (clear: boolean) => void;
 
      /**
      * (Android only)
      * Tells this WebView to clear its internal back/forward list.
      */
-    clearHistory: () => void;
+    clearHistory?: () => void;
 }
 
 export {WebView};


### PR DESCRIPTION
Closes #2361. Makes android-only methods possibly undefined properties on `WebView`.