### PR TITLE
docs: add more details on onContentProcessDidTerminate

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -573,11 +573,14 @@ url
 
 ### `onContentProcessDidTerminate`[⬆](#props-index)<!-- Link generated with jump2header -->
 
-Function that is invoked when the `WebView` content process is terminated.
+Function that is invoked when the `WebView` content process is terminated. 
 
 | Type     | Required | Platform                |
 | -------- | -------- | ----------------------- |
 | function | No       | iOS and macOS WKWebView |
+
+iOS Web views use a separate process to render and manage web content. WebKit calls this method when the process for the specified web view terminates for any reason. 
+The reason is not necessarily a crash. For instance, since iOS WebViews are not included in the total RAM of the app, they can be terminated independently of the app to liberate memory for new apps the user is opening. It's not unexpected to have WebViews get terminated after a while in the background.
 
 Example:
 


### PR DESCRIPTION
We were logging every call to `onContentProcessDidTerminate` as an unexpected error on our app. 

Turns out it was completely expected to happen at some point. 
I added more details from [the Apple docs](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455639-webviewwebcontentprocessdidtermi) to make users aware that WKWebView live in completely different processes than the app. As such they are not included in the total RAM of the app, and can be terminated independently of the app to liberate some new apps.