### PR TITLE
fix: cannot find `react-native-test-app` when Metro starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react": "17.0.2",
     "react-native": "^0.66.0-0",
     "react-native-macos": "^0.66.0-0",
-    "react-native-test-app": "^1.1.2",
+    "react-native-test-app": "^1.3.2",
     "react-native-windows": "^0.66.0-0",
     "selenium-appium": "1.0.2",
     "selenium-webdriver": "4.0.0-alpha.7",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,13 +1,32 @@
-const fs = require('fs');
-const path = require('path');
-
-const windowsProjectFile = path.join(
-  'node_modules',
-  '.generated',
-  'windows',
-  'ReactTestApp',
-  'ReactTestApp.vcxproj',
-);
+const project = (() => {
+  const fs = require('fs');
+  const path = require('path');
+  try {
+    const {
+      androidManifestPath,
+      iosProjectPath,
+      windowsProjectPath,
+    } = require('react-native-test-app');
+    return {
+      android: {
+        sourceDir: path.join('example', 'android'),
+        manifestPath: androidManifestPath(
+          path.join(__dirname, 'example', 'android'),
+        ),
+      },
+      ios: {
+        project: iosProjectPath('example/ios'),
+      },
+      windows: fs.existsSync('example/windows/WebviewExample.sln') && {
+        sourceDir: path.join('example', 'windows'),
+        solutionFile: 'WebviewExample.sln',
+        project: windowsProjectPath(path.join(__dirname, 'example', 'windows')),
+      },
+    };
+  } catch (_) {
+    return undefined;
+  }
+})();
 
 module.exports = {
   dependencies: {
@@ -30,51 +49,5 @@ module.exports = {
       },
     },
   },
-  project: {
-    android: {
-      sourceDir: path.join('example', 'android'),
-      manifestPath: path.relative(
-        path.join(__dirname, 'example', 'android'),
-        path.join(
-          path.dirname(require.resolve('react-native-test-app/package.json')),
-          'android',
-          'app',
-          'src',
-          'main',
-          'AndroidManifest.xml',
-        ),
-      ),
-    },
-    ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require('react-native-test-app/scripts/configure');
-        if (
-          packageSatisfiesVersionRange(
-            '@react-native-community/cli-platform-ios',
-            '<5.0.2',
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // `project` was only used to infer `sourceDir` and `podfile`.
-          return 'example/ios/ReactTestApp-Dummy.xcodeproj';
-        }
-        // `sourceDir` and `podfile` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return 'node_modules/.generated/ios/ReactTestApp.xcodeproj';
-      })(),
-    },
-    windows: fs.existsSync(windowsProjectFile) && {
-      sourceDir: path.join('example', 'windows'),
-      solutionFile: 'WebviewExample.sln',
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, 'example', 'windows'),
-          windowsProjectFile,
-        ),
-      },
-    },
-  },
+  ...(project ? { project } : undefined),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10680,10 +10680,10 @@ react-native-macos@^0.66.0-0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.1.2.tgz#e0a102b7cce05bc79c11d85b72f8222d7ee3a5e8"
-  integrity sha512-yLh6YZTQlMncuwN+C4i0TCNc/KR+t0/fwI9Roivy2/efmTDJW6moEKA0r/UgLvNQ+R3eXy9c5Utc2EdgyTXtMw==
+react-native-test-app@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.2.tgz#9b01389712aff0b0568a0cae6beaeb5323052351"
+  integrity sha512-bRfe3vzH2LilfPgpDC1BZy6GRUWHfJOjRlDYu/B3J1acUCjxxnBle8f/anrNbu4TRL2au7/5zqIkUWXTjqTuYA==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
Resolves #2430