### PR TITLE
Don't crash if trying to download "invalid" URIs on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -311,7 +311,12 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
   public void downloadFile(String downloadingMessage) {
     DownloadManager dm = (DownloadManager) getCurrentActivity().getBaseContext().getSystemService(Context.DOWNLOAD_SERVICE);
 
-    dm.enqueue(this.downloadRequest);
+    try {
+      dm.enqueue(this.downloadRequest);
+    } catch (IllegalArgumentException e) {
+      Log.w("RNCWebViewModule", "Unsupported URI, aborting download", e);
+      return;
+    }
 
     Toast.makeText(getCurrentActivity().getApplicationContext(), downloadingMessage, Toast.LENGTH_LONG).show();
   }


### PR DESCRIPTION
Fixes #2428.

This is based on @karthikiyengar's previous fix in #2328.

If desired, I could also include the tweaks in my [test branch](https://github.com/TheAlmightyBob/react-native-webview/tree/test) for reproing the issue in the example app.... however, since it is an _example_ app and not a _bug regression test_ app, I'm not sure that would be appropriate.