### PR TITLE
fix ex, add js ex, add line, add closing backtick

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1478,6 +1478,7 @@ Example:
 ### `forceDarkOn`
 
 Configuring Dark Theme
+
 *NOTE* : The force dark setting is not persistent. You must call the static method every time your app process is started.
 
 *NOTE* : The change from day<->night mode is a configuration change so by default the activity will be restarted and pickup the new values to apply the theme. Take care when overriding this default behavior to ensure this method is still called when changes are made.
@@ -1538,7 +1539,8 @@ Use WinUI WebView2 control instead of WebView control as the native webview. The
 Example:
 
 ```javascript
-<WebView useWebView2 />
+<WebView useWebView2={true} />
+```
 
 ### `minimumFontSize`
 
@@ -1629,7 +1631,7 @@ Removes the autocomplete popup from the currently focused form field, if present
 (android only)
 
 ```javascript
-
+clearCache(true)
 ```
 
 Clears the resource cache. Note that the cache is per-application, so this will clear the cache for all WebViews used. [developer.android.com reference](<https://developer.android.com/reference/android/webkit/WebView.html#clearCache(boolean)>)


### PR DESCRIPTION
## webview2 example
I have noticed 3 other example used `={true}` syntax. 
1. Other examples used `={true}`, so I believed using this syntax is correct.
2. I also think it is much more beginner friendly.

## Removed JS example for clearCache()
There were no example for clearCache().

## Add line
The *note* section seemed to be seperate from other explanation. 
I added a new line that was joined by other explanations.
It was also a bit hard to read when those two were connected.

## Unclosed backtick
The bactick for an example seemed to be missing. 
A whole section was shown as a code.