### PR TITLE
chore(windows): fix noisy warning

### DIFF
--- a/windows/ReactNativeWebView/ReactWebViewManager.cpp
+++ b/windows/ReactNativeWebView/ReactWebViewManager.cpp
@@ -96,7 +96,7 @@ namespace winrt::ReactNativeWebView::implementation {
                           if (isUrlEncodedForm)
                           {
                             auto formContent = winrt::single_threaded_observable_map<winrt::hstring, winrt::hstring>();
-                            auto counter = 0u;
+                            size_t counter = 0u;
                             auto current = formBody.find_first_of("&");
                             while (counter <= formBody.find_last_of("&"))
                             {


### PR DESCRIPTION
fixes a type width warning when adding a size_t to an unsigned int