### PR TITLE
Adding downloadMessage as a prop

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -159,6 +159,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected boolean mAllowsFullscreenVideo = false;
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
+  protected String mDownloadMessage = "Downloading";
 
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
@@ -248,8 +249,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         module.setDownloadRequest(request);
 
-        if (module.grantFileDownloaderPermissions()) {
-          module.downloadFile();
+        if (module.grantFileDownloaderPermissions(mDownloadMessage)) {
+          module.downloadFile(mDownloadMessage);
         }
       }
     });
@@ -285,6 +286,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "showsVerticalScrollIndicator")
   public void setShowsVerticalScrollIndicator(WebView view, boolean enabled) {
     view.setVerticalScrollBarEnabled(enabled);
+  }
+
+  @ReactProp(name = "downloadMessage")
+  public void setDownloadMessage(WebView view, String message)
+  {
+    mDownloadMessage = message;
   }
 
   @ReactProp(name = "cacheEnabled")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -262,11 +262,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     return webView;
   }
 
-  private String getDownloadingMessage(){
+  private String getDownloadingMessage() {
     return  mDownloadingMessage == null ? DEFAULT_DOWNLOADING_MESSAGE : mDownloadingMessage;
   }
 
-  private String getLackPermissionToDownloadMessage(){
+  private String getLackPermissionToDownloadMessage() {
     return  mDownloadingMessage == null ? DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE : mLackPermissionToDownloadMessage;
   }
 
@@ -301,14 +301,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "downloadingMessage")
-  public void setDownloadingMessage(WebView view, String message)
-  {
+  public void setDownloadingMessage(WebView view, String message) {
     mDownloadingMessage = message;
   }
 
   @ReactProp(name = "lackPermissionToDownloadMessage")
-  public void setLackPermissionToDownlaodMessage(WebView view, String message)
-  {
+  public void setLackPermissionToDownlaodMessage(WebView view, String message) {
     mLackPermissionToDownloadMessage = message;
   }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -153,13 +153,17 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   // state and release page resources (including any running JavaScript).
   protected static final String BLANK_URL = "about:blank";
   protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 250;
+  protected static final String DEFAULT_DOWNLOADING_MESSAGE = "Downloading";
+  protected static final String DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE =
+    "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.";
   protected WebViewConfig mWebViewConfig;
 
   protected RNCWebChromeClient mWebChromeClient = null;
   protected boolean mAllowsFullscreenVideo = false;
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
-  protected String mDownloadMessage = "Downloading";
+  protected @Nullable String mDownloadingMessage = null;
+  protected @Nullable String mLackPermissionToDownloadMessage = null;
 
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
@@ -249,13 +253,21 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         module.setDownloadRequest(request);
 
-        if (module.grantFileDownloaderPermissions(mDownloadMessage)) {
-          module.downloadFile(mDownloadMessage);
+        if (module.grantFileDownloaderPermissions(getDownloadingMessage(), getLackPermissionToDownloadMessage())) {
+          module.downloadFile(getDownloadingMessage());
         }
       }
     });
 
     return webView;
+  }
+
+  private String getDownloadingMessage(){
+    return  mDownloadingMessage == null ? DEFAULT_DOWNLOADING_MESSAGE : mDownloadingMessage;
+  }
+
+  private String getLackPermissionToDownloadMessage(){
+    return  mDownloadingMessage == null ? DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE : mLackPermissionToDownloadMessage;
   }
 
   @ReactProp(name = "javaScriptEnabled")
@@ -288,10 +300,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.setVerticalScrollBarEnabled(enabled);
   }
 
-  @ReactProp(name = "downloadMessage")
-  public void setDownloadMessage(WebView view, String message)
+  @ReactProp(name = "downloadingMessage")
+  public void setDownloadingMessage(WebView view, String message)
   {
-    mDownloadMessage = message;
+    mDownloadingMessage = message;
+  }
+
+  @ReactProp(name = "lackPermissionToDownloadMessage")
+  public void setLackPermissionToDownlaodMessage(WebView view, String message)
+  {
+    mLackPermissionToDownloadMessage = message;
   }
 
   @ReactProp(name = "cacheEnabled")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -95,25 +95,27 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     }
   }
 
-  private PermissionListener webviewFileDownloaderPermissionListener = new PermissionListener() {
-    @Override
-    public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-      switch (requestCode) {
-        case FILE_DOWNLOAD_PERMISSION_REQUEST: {
-          // If request is cancelled, the result arrays are empty.
-          if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            if (downloadRequest != null) {
-              downloadFile();
+  private PermissionListener getWebviewFileDownloaderPermissionListener(String downloadMessage) {
+    return new PermissionListener() {
+      @Override
+      public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        switch (requestCode) {
+          case FILE_DOWNLOAD_PERMISSION_REQUEST: {
+            // If request is cancelled, the result arrays are empty.
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+              if (downloadRequest != null) {
+                downloadFile(downloadMessage);
+              }
+            } else {
+              Toast.makeText(getCurrentActivity().getApplicationContext(), "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.", Toast.LENGTH_LONG).show();
             }
-          } else {
-            Toast.makeText(getCurrentActivity().getApplicationContext(), "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.", Toast.LENGTH_LONG).show();
+            return true;
           }
-          return true;
         }
+        return false;
       }
-      return false;
-    }
-  };
+    };
+  }
 
   public RNCWebViewModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -306,16 +308,15 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     this.downloadRequest = request;
   }
 
-  public void downloadFile() {
+  public void downloadFile(String downloadMessage) {
     DownloadManager dm = (DownloadManager) getCurrentActivity().getBaseContext().getSystemService(Context.DOWNLOAD_SERVICE);
-    String downloadMessage = "Downloading";
 
     dm.enqueue(this.downloadRequest);
 
     Toast.makeText(getCurrentActivity().getApplicationContext(), downloadMessage, Toast.LENGTH_LONG).show();
   }
 
-  public boolean grantFileDownloaderPermissions() {
+  public boolean grantFileDownloaderPermissions(String downloadMessage) {
     // Permission not required for Android Q and above
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
       return true;
@@ -324,7 +325,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     boolean result = ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
     if (!result && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       PermissionAwareActivity activity = getPermissionAwareActivity();
-      activity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, webviewFileDownloaderPermissionListener);
+      activity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, getWebviewFileDownloaderPermissionListener(downloadMessage));
     }
 
     return result;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -95,7 +95,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     }
   }
 
-  private PermissionListener getWebviewFileDownloaderPermissionListener(String downloadMessage) {
+  private PermissionListener getWebviewFileDownloaderPermissionListener(String downloadingMessage, String lackPermissionToDownloadMessage) {
     return new PermissionListener() {
       @Override
       public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
@@ -104,10 +104,10 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
             // If request is cancelled, the result arrays are empty.
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
               if (downloadRequest != null) {
-                downloadFile(downloadMessage);
+                downloadFile(downloadingMessage);
               }
             } else {
-              Toast.makeText(getCurrentActivity().getApplicationContext(), "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.", Toast.LENGTH_LONG).show();
+              Toast.makeText(getCurrentActivity().getApplicationContext(), lackPermissionToDownloadMessage, Toast.LENGTH_LONG).show();
             }
             return true;
           }
@@ -308,15 +308,15 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     this.downloadRequest = request;
   }
 
-  public void downloadFile(String downloadMessage) {
+  public void downloadFile(String downloadingMessage) {
     DownloadManager dm = (DownloadManager) getCurrentActivity().getBaseContext().getSystemService(Context.DOWNLOAD_SERVICE);
 
     dm.enqueue(this.downloadRequest);
 
-    Toast.makeText(getCurrentActivity().getApplicationContext(), downloadMessage, Toast.LENGTH_LONG).show();
+    Toast.makeText(getCurrentActivity().getApplicationContext(), downloadingMessage, Toast.LENGTH_LONG).show();
   }
 
-  public boolean grantFileDownloaderPermissions(String downloadMessage) {
+  public boolean grantFileDownloaderPermissions(String downloadingMessage, String lackPermissionToDownloadMessage) {
     // Permission not required for Android Q and above
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
       return true;
@@ -325,7 +325,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     boolean result = ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
     if (!result && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       PermissionAwareActivity activity = getPermissionAwareActivity();
-      activity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, getWebviewFileDownloaderPermissionListener(downloadMessage));
+      activity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, getWebviewFileDownloaderPermissionListener(downloadingMessage, lackPermissionToDownloadMessage));
     }
 
     return result;

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -86,6 +86,7 @@ This document lays out the current public properties and methods for the React N
 - [`forceDarkOn`](Reference.md#forceDarkOn)
 - [`useWebView2`](Reference.md#useWebView2)
 - [`minimumFontSize`](Reference.md#minimumFontSize)
+- [`downloadMessage`](Reference.md#downloadMessage)
 
 ## Methods Index
 
@@ -1555,6 +1556,14 @@ Example:
 ```javascript
 <WebView minimumFontSize={1} />
 ```
+
+### `downloadMessage`
+
+This is the message that is shown in the Toast when downloading a file via WebView. Default message is "Downloading".
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
 
 ## Methods
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -86,7 +86,8 @@ This document lays out the current public properties and methods for the React N
 - [`forceDarkOn`](Reference.md#forceDarkOn)
 - [`useWebView2`](Reference.md#useWebView2)
 - [`minimumFontSize`](Reference.md#minimumFontSize)
-- [`downloadMessage`](Reference.md#downloadMessage)
+- [`downloadingMessage`](Reference.md#downloadingMessage)
+- [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 
 ## Methods Index
 
@@ -1557,9 +1558,17 @@ Example:
 <WebView minimumFontSize={1} />
 ```
 
-### `downloadMessage`
+### `downloadingMessage`
 
 This is the message that is shown in the Toast when downloading a file via WebView. Default message is "Downloading".
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
+
+### `lackPermissionToDownloadMessage`
+
+This is the message that is shown in the Toast when the webview is unable to download a file. Default message is "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.".
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -332,6 +332,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   readonly urlPrefixesForDefaultIntent?: string[];
   forceDarkOn?: boolean;
   minimumFontSize?: number;
+  downloadMessage?: string;
 }
 
 export declare type ContentInsetAdjustmentBehavior = 'automatic' | 'scrollableAxes' | 'never' | 'always';
@@ -1078,6 +1079,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   minimumFontSize?: number;
+
+  /**
+   * Sets the message to be shown in the toast when downloading via the webview.
+   * Default is 'Downloading'.
+   * @platform android
+   */
+  downloadMessage?: string;
 }
 
 export interface WebViewSharedProps extends ViewProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -332,7 +332,8 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   readonly urlPrefixesForDefaultIntent?: string[];
   forceDarkOn?: boolean;
   minimumFontSize?: number;
-  downloadMessage?: string;
+  downloadingMessage?: string;
+  lackPermissionToDownloadMessage?: string;
 }
 
 export declare type ContentInsetAdjustmentBehavior = 'automatic' | 'scrollableAxes' | 'never' | 'always';
@@ -1085,7 +1086,14 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Default is 'Downloading'.
    * @platform android
    */
-  downloadMessage?: string;
+  downloadingMessage?: string;
+
+  /**
+   * Sets the message to be shown in the toast when webview is unable to download due to permissions issue.
+   * Default is 'Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.'.
+   * @platform android
+   */
+  lackPermissionToDownloadMessage?: string;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
Adding downloadMessage as a prop to react native web view so that the library consumer can specify the message shown in when downloading content.

Meant to address this issue: https://github.com/react-native-webview/react-native-webview/issues/2436

For our app, this allows the message to be localized (see the toast near the bottom):
<img src="https://user-images.githubusercontent.com/26827220/169111389-a9e3681d-78c2-4cfe-902f-859a76f28828.png" align="left" width="200" >




