### PR TITLE
Clean up backwards compatibility

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -37,7 +37,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   if (_webView == nil) {
     return nil;
   }
-  
+
   if ([_webView respondsToSelector:@selector(inputAssistantItem)]) {
     UITextInputAssistantItem *inputAssistantItem = [_webView inputAssistantItem];
     inputAssistantItem.leadingBarButtonGroups = @[];
@@ -99,7 +99,7 @@ RCTAutoInsetsProtocol>
 #endif // !TARGET_OS_OSX
   BOOL _savedHideKeyboardAccessoryView;
   BOOL _savedKeyboardDisplayRequiresUserAction;
-  
+
   // Workaround for StatusBar appearance bug for iOS 12
   // https://github.com/react-native-webview/react-native-webview/issues/62
   BOOL _isFullScreenVideoOpen;
@@ -107,7 +107,7 @@ RCTAutoInsetsProtocol>
   UIStatusBarStyle _savedStatusBarStyle;
 #endif // !TARGET_OS_OSX
   BOOL _savedStatusBarHidden;
-  
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
   UIScrollViewContentInsetAdjustmentBehavior _savedContentInsetAdjustmentBehavior;
 #endif
@@ -151,13 +151,13 @@ RCTAutoInsetsProtocol>
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
 #endif
   }
-  
+
 #if !TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter]addObserver:self
                                           selector:@selector(appDidBecomeActive)
                                               name:UIApplicationDidBecomeActiveNotification
                                             object:nil];
-  
+
   [[NSNotificationCenter defaultCenter]addObserver:self
                                           selector:@selector(appWillResignActive)
                                               name:UIApplicationWillResignActiveNotification
@@ -173,19 +173,19 @@ RCTAutoInsetsProtocol>
      addObserver:self
      selector:@selector(keyboardWillShow)
      name:UIKeyboardWillShowNotification object:nil];
-    
+
     // Workaround for StatusBar appearance bug for iOS 12
     // https://github.com/react-native-webview/react-native-webview/issues/62
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(showFullScreenVideoStatusBars)
                                                  name:UIWindowDidBecomeVisibleNotification
                                                object:nil];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(hideFullScreenVideoStatusBars)
                                                  name:UIWindowDidBecomeHiddenNotification
                                                object:nil];
-    
+
   }
 #endif // !TARGET_OS_OSX
   return self;
@@ -211,17 +211,17 @@ RCTAutoInsetsProtocol>
     }
     UIMenuController *menuController = [UIMenuController sharedMenuController];
     NSMutableArray *menuControllerItems = [NSMutableArray arrayWithCapacity:self.menuItems.count];
-    
+
     for(NSDictionary *menuItem in self.menuItems) {
       NSString *menuItemLabel = [RCTConvert NSString:menuItem[@"label"]];
       NSString *menuItemKey = [RCTConvert NSString:menuItem[@"key"]];
       NSString *sel = [NSString stringWithFormat:@"%@%@", CUSTOM_SELECTOR, menuItemKey];
       UIMenuItem *item = [[UIMenuItem alloc] initWithTitle: menuItemLabel
                                                     action: NSSelectorFromString(sel)];
-      
+
       [menuControllerItems addObject: item];
     }
-    
+
     menuController.menuItems = menuControllerItems;
     [menuController setMenuVisible:YES animated:YES];
   }
@@ -295,7 +295,7 @@ RCTAutoInsetsProtocol>
   NSString *sel = NSStringFromSelector(action);
   // Do any of them have our custom keys?
   NSRange match = [sel rangeOfString:CUSTOM_SELECTOR];
-  
+
   if (match.location == 0) {
     return YES;
   }
@@ -353,7 +353,7 @@ RCTAutoInsetsProtocol>
     wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
-  
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
   if (@available(iOS 13.0, *)) {
     WKWebpagePreferences *pagePrefs = [[WKWebpagePreferences alloc]init];
@@ -361,7 +361,7 @@ RCTAutoInsetsProtocol>
     wkWebViewConfig.defaultWebpagePreferences = pagePrefs;
   }
 #endif
-  
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 /* iOS 14 */
   if (@available(iOS 14.0, *)) {
     if ([wkWebViewConfig respondsToSelector:@selector(limitsNavigationsToAppBoundDomains)]) {
@@ -371,16 +371,16 @@ RCTAutoInsetsProtocol>
     }
   }
 #endif
-  
+
   // Shim the HTML5 history API:
   [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
                                                             name:HistoryShimName];
   [self resetupScripts:wkWebViewConfig];
-  
+
   if(@available(macos 10.11, ios 9.0, *)) {
     wkWebViewConfig.allowsAirPlayForMediaPlayback = _allowsAirPlayForMediaPlayback;
   }
-  
+
 #if !TARGET_OS_OSX
   wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;
 #if WEBKIT_IOS_10_APIS_AVAILABLE
@@ -392,11 +392,11 @@ RCTAutoInsetsProtocol>
   wkWebViewConfig.mediaPlaybackRequiresUserAction = _mediaPlaybackRequiresUserAction;
 #endif
 #endif // !TARGET_OS_OSX
-  
+
   if (_applicationNameForUserAgent) {
     wkWebViewConfig.applicationNameForUserAgent = [NSString stringWithFormat:@"%@ %@", wkWebViewConfig.applicationNameForUserAgent, _applicationNameForUserAgent];
   }
-  
+
   return wkWebViewConfig;
 }
 
@@ -409,7 +409,7 @@ RCTAutoInsetsProtocol>
 #else
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
 #endif // !TARGET_OS_OSX
-    
+
     [self setBackgroundColor: _savedBackgroundColor];
 #if !TARGET_OS_OSX
     _webView.scrollView.delegate = self;
@@ -435,7 +435,7 @@ RCTAutoInsetsProtocol>
     _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
-    
+
     _webView.customUserAgent = _userAgent;
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
@@ -443,7 +443,7 @@ RCTAutoInsetsProtocol>
       _webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = _savedAutomaticallyAdjustsScrollIndicatorInsets;
     }
 #endif
-    
+
     [self addSubview:_webView];
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
@@ -454,7 +454,7 @@ RCTAutoInsetsProtocol>
   if (self.menuItems != nil) {
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(startLongPress:)];
     longPress.delegate = self;
-    
+
     longPress.minimumPressDuration = 0.4f;
     longPress.numberOfTouchesRequired = 1;
     longPress.cancelsTouchesInView = YES;
@@ -485,7 +485,7 @@ RCTAutoInsetsProtocol>
       _onContentProcessDidTerminate(event);
     }
   }
-  
+
   [super removeFromSuperview];
 }
 
@@ -496,7 +496,7 @@ RCTAutoInsetsProtocol>
   if (!_autoManageStatusBarEnabled) {
     return;
   }
-  
+
   _isFullScreenVideoOpen = YES;
   RCTUnsafeExecuteOnMainQueueSync(^{
     [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
@@ -510,7 +510,7 @@ RCTAutoInsetsProtocol>
   if (!_autoManageStatusBarEnabled) {
     return;
   }
-  
+
   _isFullScreenVideoOpen = NO;
   RCTUnsafeExecuteOnMainQueueSync(^{
     [RCTSharedApplication() setStatusBarHidden:self->_savedStatusBarHidden animated:YES];
@@ -569,7 +569,7 @@ RCTAutoInsetsProtocol>
   if (_webView == nil) {
     return;
   }
-  
+
   CGFloat alpha = CGColorGetAlpha(backgroundColor.CGColor);
   BOOL opaque = (alpha == 1.0);
 #if !TARGET_OS_OSX
@@ -593,7 +593,7 @@ RCTAutoInsetsProtocol>
   if (_webView == nil) {
     return;
   }
-  
+
   if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
     CGPoint contentOffset = _webView.scrollView.contentOffset;
     _webView.scrollView.contentInsetAdjustmentBehavior = behavior;
@@ -639,7 +639,7 @@ RCTAutoInsetsProtocol>
 {
   if (![_source isEqualToDictionary:source]) {
     _source = [source copy];
-    
+
     if (_webView != nil) {
       [self visitSource];
     }
@@ -650,7 +650,7 @@ RCTAutoInsetsProtocol>
 {
   if (![_allowingReadAccessToURL isEqualToString:allowingReadAccessToURL]) {
     _allowingReadAccessToURL = [allowingReadAccessToURL copy];
-    
+
     if (_webView != nil) {
       [self visitSource];
     }
@@ -694,9 +694,9 @@ RCTAutoInsetsProtocol>
     NSArray *httpCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headers forURL:urlString];
     [self writeCookiesToWebView:httpCookies completion:nil];
   }
-  
+
   NSURLRequest *request = [self requestForSource:_source];
-  
+
   [self syncCookiesToWebView:^{
     // Because of the way React works, as pages redirect, we actually end up
     // passing the redirect urls back here, so we ignore them if trying to load
@@ -727,20 +727,20 @@ RCTAutoInsetsProtocol>
     _savedKeyboardDisplayRequiresUserAction = keyboardDisplayRequiresUserAction;
     return;
   }
-  
+
   if (_savedKeyboardDisplayRequiresUserAction == true) {
     return;
   }
-  
+
   UIView* subview;
-  
+
   for (UIView* view in _webView.scrollView.subviews) {
     if([[view.class description] hasPrefix:@"WK"])
       subview = view;
   }
-  
+
   if(subview == nil) return;
-  
+
   Class class = subview.class;
 
   Method method;
@@ -781,7 +781,7 @@ RCTAutoInsetsProtocol>
       ((void (*)(id, SEL, void*, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3);
     });
   }
-  
+
   method_setImplementation(method, override);
 }
 
@@ -791,34 +791,34 @@ RCTAutoInsetsProtocol>
     _savedHideKeyboardAccessoryView = hideKeyboardAccessoryView;
     return;
   }
-  
+
   if (_savedHideKeyboardAccessoryView == false) {
     return;
   }
-  
+
   UIView* subview;
-  
+
   for (UIView* view in _webView.scrollView.subviews) {
     if([[view.class description] hasPrefix:@"WK"])
       subview = view;
   }
-  
+
   if(subview == nil) return;
-  
+
   NSString* name = [NSString stringWithFormat:@"%@_SwizzleHelperWK", subview.class.superclass];
   Class newClass = NSClassFromString(name);
-  
+
   if(newClass == nil)
   {
     newClass = objc_allocateClassPair(subview.class, [name cStringUsingEncoding:NSASCIIStringEncoding], 0);
     if(!newClass) return;
-    
+
     Method method = class_getInstanceMethod([_SwizzleHelperWK class], @selector(inputAccessoryView));
     class_addMethod(newClass, @selector(inputAccessoryView), method_getImplementation(method), method_getTypeEncoding(method));
-    
+
     objc_registerClassPair(newClass);
   }
-  
+
   object_setClass(subview, newClass);
 }
 
@@ -909,7 +909,7 @@ RCTAutoInsetsProtocol>
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  
+
   // Ensure webview takes the position and dimensions of RNCWebView
   _webView.frame = self.bounds;
 #if !TARGET_OS_OSX
@@ -1051,7 +1051,7 @@ RCTAutoInsetsProtocol>
 #else
   NSAlert *alert = [[NSAlert alloc] init];
   [alert setMessageText:prompt];
-  
+
   const NSRect RCTSingleTextFieldFrame = NSMakeRect(0.0, 0.0, 275.0, 22.0);
   NSTextField *textField = [[NSTextField alloc] initWithFrame:RCTSingleTextFieldFrame];
   textField.cell.scrollable = YES;
@@ -1060,7 +1060,7 @@ RCTAutoInsetsProtocol>
   }
   textField.stringValue = defaultText;
   [alert setAccessoryView:textField];
-  
+
   [alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK button")];
   [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")];
   [alert beginSheetModalForWindow:[NSApp keyWindow] completionHandler:^(NSModalResponse response) {
@@ -1119,7 +1119,7 @@ RCTAutoInsetsProtocol>
 {
   static NSDictionary<NSNumber *, NSString *> *navigationTypes;
   static dispatch_once_t onceToken;
-  
+
   dispatch_once(&onceToken, ^{
     navigationTypes = @{
       @(WKNavigationTypeLinkActivated): @"click",
@@ -1130,11 +1130,11 @@ RCTAutoInsetsProtocol>
       @(WKNavigationTypeOther): @"other",
     };
   });
-  
+
   WKNavigationType navigationType = navigationAction.navigationType;
   NSURLRequest *request = navigationAction.request;
   BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
-  
+
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     [event addEntriesFromDictionary: @{
@@ -1150,7 +1150,7 @@ RCTAutoInsetsProtocol>
       return;
     }
   }
-  
+
   if (_onLoadingStart) {
     // We have this check to filter out iframe requests and whatnot
     if (isTopFrame) {
@@ -1162,7 +1162,7 @@ RCTAutoInsetsProtocol>
       _onLoadingStart(event);
     }
   }
-  
+
   // Allow all navigation by default
   decisionHandler(WKNavigationActionPolicyAllow);
 }
@@ -1242,7 +1242,7 @@ RCTAutoInsetsProtocol>
       // http://stackoverflow.com/questions/1024748/how-do-i-fix-nsurlerrordomain-error-999-in-iphone-3-0-os
       return;
     }
-    
+
     if ([error.domain isEqualToString:@"WebKitErrorDomain"] &&
         (error.code == 102 || error.code == 101)) {
       // Error code 102 "Frame load interrupted" is raised by the WKWebView
@@ -1250,7 +1250,7 @@ RCTAutoInsetsProtocol>
       // implementing OAuth with a WebView.
       return;
     }
-    
+
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     [event addEntriesFromDictionary:@{
       @"didFailProvisionalNavigation": @YES,
@@ -1325,11 +1325,11 @@ didFinishNavigation:(WKNavigation *)navigation
       }
     }];
   }
-  
+
   if (_ignoreSilentHardwareSwitch) {
     [self forceIgnoreSilentHardwareSwitch:true];
   }
-  
+
   if (_onLoadingFinish) {
     _onLoadingFinish([self baseEvent]);
   }
@@ -1358,7 +1358,7 @@ didFinishNavigation:(WKNavigation *)navigation
    * manually call [_webView loadRequest:request].
    */
   NSURLRequest *request = [self requestForSource:self.source];
-  
+
   if (request.URL && !_webView.URL.absoluteString.length) {
     [_webView loadRequest:request];
   } else {
@@ -1384,13 +1384,13 @@ didFinishNavigation:(WKNavigation *)navigation
 - (void)setPullToRefreshEnabled:(BOOL)pullToRefreshEnabled
 {
   _pullToRefreshEnabled = pullToRefreshEnabled;
-  
+
   if (pullToRefreshEnabled) {
     [self addPullToRefreshControl];
   } else {
     [_refreshControl removeFromSuperview];
   }
-  
+
   [self setBounces:_bounces];
 }
 #endif // !TARGET_OS_OSX
@@ -1418,11 +1418,11 @@ didFinishNavigation:(WKNavigation *)navigation
 
 - (void)setInjectedJavaScript:(NSString *)source {
   _injectedJavaScript = source;
-  
+
   self.atEndScript = source == nil ? nil : [[WKUserScript alloc] initWithSource:source
                                                                   injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
                                                                forMainFrameOnly:_injectedJavaScriptForMainFrameOnly];
-  
+
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1430,11 +1430,11 @@ didFinishNavigation:(WKNavigation *)navigation
 
 - (void)setInjectedJavaScriptBeforeContentLoaded:(NSString *)source {
   _injectedJavaScriptBeforeContentLoaded = source;
-  
+
   self.atStartScript = source == nil ? nil : [[WKUserScript alloc] initWithSource:source
                                                                     injectionTime:WKUserScriptInjectionTimeAtDocumentStart
                                                                  forMainFrameOnly:_injectedJavaScriptBeforeContentLoadedForMainFrameOnly];
-  
+
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1452,7 +1452,7 @@ didFinishNavigation:(WKNavigation *)navigation
 
 - (void)setMessagingEnabled:(BOOL)messagingEnabled {
   _messagingEnabled = messagingEnabled;
-  
+
   self.postMessageScript = _messagingEnabled ?
   [
     [WKUserScript alloc]
@@ -1472,7 +1472,7 @@ didFinishNavigation:(WKNavigation *)navigation
     forMainFrameOnly:YES
   ] :
   nil;
-  
+
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1514,7 +1514,7 @@ didFinishNavigation:(WKNavigation *)navigation
     }
     return;
   }
-  
+
   NSString *html5HistoryAPIShimSource = [NSString stringWithFormat:
                                            @"(function(history) {\n"
                                          "  function notify(type) {\n"
@@ -1537,7 +1537,7 @@ didFinishNavigation:(WKNavigation *)navigation
   ];
   WKUserScript *script = [[WKUserScript alloc] initWithSource:html5HistoryAPIShimSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
   [wkWebViewConfig.userContentController addUserScript:script];
-  
+
   if(_sharedCookiesEnabled) {
     // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
     // See also https://forums.developer.apple.com/thread/97194
@@ -1547,7 +1547,7 @@ didFinishNavigation:(WKNavigation *)navigation
     }
     [self syncCookiesToWebView:nil];
   }
-  
+
   if(_messagingEnabled){
     if (self.postMessageScript){
       [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -262,7 +262,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
   _shouldStartLoad = YES;
   request[@"lockIdentifier"] = @(_shouldStartLoadLock.condition);
   callback(request);
-  
+
   // Block the main thread for a maximum of 250ms until the JS thread returns
   if ([_shouldStartLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:.25]]) {
     BOOL returnValue = _shouldStartLoad;


### PR DESCRIPTION
Removes the backwards compatibility with iOS versions prior to 11.0. This cleans up the native code quite a lot and also matches the versions supported by [React Native itself](https://github.com/facebook/react-native#-requirements).

⚠️ Builds on top of #2490, so that should be merged first…