### PR TITLE
fix(ios): support requestFocus

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -109,6 +109,7 @@ typedef enum RNCWebViewPermissionGrantType : NSUInteger {
 - (void)goBack;
 - (void)reload;
 - (void)stopLoading;
+- (void)requestFocus;
 #if !TARGET_OS_OSX
 - (void)addPullToRefreshControl;
 - (void)pullToRefresh:(UIRefreshControl *_Nonnull)refreshControl;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -213,17 +213,17 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
       }
         UIMenuController *menuController = [UIMenuController sharedMenuController];
         NSMutableArray *menuControllerItems = [NSMutableArray arrayWithCapacity:self.menuItems.count];
-        
+
         for(NSDictionary *menuItem in self.menuItems) {
             NSString *menuItemLabel = [RCTConvert NSString:menuItem[@"label"]];
             NSString *menuItemKey = [RCTConvert NSString:menuItem[@"key"]];
             NSString *sel = [NSString stringWithFormat:@"%@%@", CUSTOM_SELECTOR, menuItemKey];
             UIMenuItem *item = [[UIMenuItem alloc] initWithTitle: menuItemLabel
                                                           action: NSSelectorFromString(sel)];
-            
+
             [menuControllerItems addObject: item];
         }
-  
+
         menuController.menuItems = menuControllerItems;
         [menuController setMenuVisible:YES animated:YES];
     }
@@ -382,7 +382,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   if(@available(macos 10.11, ios 9.0, *)) {
     wkWebViewConfig.allowsAirPlayForMediaPlayback = _allowsAirPlayForMediaPlayback;
   }
-    
+
 #if !TARGET_OS_OSX
   wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;
 #if WEBKIT_IOS_10_APIS_AVAILABLE
@@ -1404,6 +1404,13 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 - (void)stopLoading
 {
   [_webView stopLoading];
+}
+
+- (void)requestFocus
+{
+  #if !TARGET_OS_OSX
+    [_webView becomeFirstResponder];
+  #endif // !TARGET_OS_OSX
 }
 
 #if !TARGET_OS_OSX

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -240,6 +240,18 @@ RCT_EXPORT_METHOD(stopLoading:(nonnull NSNumber *)reactTag)
   }];
 }
 
+RCT_EXPORT_METHOD(requestFocus:(nonnull NSNumber *)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {
+    RNCWebView *view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RNCWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RNCWebView, got: %@", view);
+    } else {
+      [view requestFocus];
+    }
+  }];
+}
+
 #pragma mark - Exported synchronous methods
 
 - (BOOL)          webView:(RNCWebView *)webView


### PR DESCRIPTION
Previously, calling `.requestFocus()` would result in: 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/170175677-63823fe4-802e-4cfd-92f9-ba8435b1b292.png">

This also allows consumers to mark the webview as the first responder, so that keyboard shortcuts, for example, can work right away as soon as the webview is loaded.