### PR TITLE
feat: improve dummy WebView 

### DIFF
--- a/src/WebView.tsx
+++ b/src/WebView.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Text, View } from 'react-native';
 import { IOSWebViewProps, AndroidWebViewProps, WindowsWebViewProps } from './WebViewTypes';
 
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps & WindowsWebViewProps;
 
 // This "dummy" WebView is to render something for unsupported platforms,
-// like for example Expo SDK "web" platform. It matches the previous react-native
-// implementation which is produced by Expo SDK 37.0.0.1 implementation, with
-// similar interface than the native ones have.
+// like for example Expo SDK "web" platform.
 const WebView: React.FunctionComponent<WebViewProps> = () => (
-	<View style={{
-		alignSelf: 'flex-start',
-		borderColor: 'rgb(255, 0, 0)',
-		borderWidth: 1
-	}} />
+	<View style={{ alignSelf: 'flex-start' }}>
+		<Text style={{ color: 'red' }}>
+			React Native WebView do not support this platform.
+		</Text>
+	</View>
 );
 
 export { WebView };

--- a/src/WebView.tsx
+++ b/src/WebView.tsx
@@ -9,7 +9,7 @@ export type WebViewProps = IOSWebViewProps & AndroidWebViewProps & WindowsWebVie
 const WebView: React.FunctionComponent<WebViewProps> = () => (
 	<View style={{ alignSelf: 'flex-start' }}>
 		<Text style={{ color: 'red' }}>
-			React Native WebView do not support this platform.
+			React Native WebView does not support this platform.
 		</Text>
 	</View>
 );


### PR DESCRIPTION
# Why

Currently, the dummy WebView component render as very small red bordered box on unsupported platforms (look at upper left corner of the white render area):
<img  alt="Screenshot 2022-05-29 at 22 28 05" src="https://user-images.githubusercontent.com/719641/170890332-23e72376-82df-4431-8b34-04f8d36289de.png">

# How

I have added a short message to the empty so far View, and altered styling a bit. Border is removed, but the text will be red, so users can more easily spot the problem (if it occurs).

The package name (and capitalization) has been taken from the Readme file.

# Test Plan

Running `yarn lint` do not yield any errors, example app is running as expected.