### PR TITLE
chore(readme): update Expo in supported platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ _This project is maintained for free by these people using both their free time 
 - [x] Android
 - [x] macOS
 - [x] Windows
-
-_Note: Expo support for React Native WebView started with [Expo SDK v33.0.0](https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c)._
+- [x] Expo (Android, iOS)
 
 ## Getting Started
 


### PR DESCRIPTION
# Why

Current note leads to an old blog post and mention old SDK.

# How

Replace the note with an additional entry to the supported platforms list.