### PR TITLE
refactor: Remove WEBKIT_IOS_10_APIS_AVAILABLE check

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -385,14 +385,10 @@ RCTAutoInsetsProtocol>
   
 #if !TARGET_OS_OSX
   wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;
-#if WEBKIT_IOS_10_APIS_AVAILABLE
   wkWebViewConfig.mediaTypesRequiringUserActionForPlayback = _mediaPlaybackRequiresUserAction
   ? WKAudiovisualMediaTypeAll
   : WKAudiovisualMediaTypeNone;
   wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
-#else
-  wkWebViewConfig.mediaPlaybackRequiresUserAction = _mediaPlaybackRequiresUserAction;
-#endif
 #endif // !TARGET_OS_OSX
   
   if (_applicationNameForUserAgent) {


### PR DESCRIPTION
WEBKIT_IOS_10_APIS_AVAILABLE was deleted since RN 0.64.0 (https://github.com/facebook/react-native/commit/a422592c95398f8c2ef04ecaf082463f5a7a843c) 

From the previous link: 
> Delete WEBKIT_IOS_10_APIS_AVAILABLE because React Native doesn't support iOS 9 and WEBKIT_IOS_10_APIS_AVAILABLE would always be true.

So it's safe to remove it here too.