### PR TITLE
docs: prop also available for Android

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -198,9 +198,9 @@ Make sure the string evaluates to a valid type (`true` works) and doesn't otherw
 
 On iOS, see [`WKUserScriptInjectionTimeAtDocumentStart`](https://developer.apple.com/documentation/webkit/wkuserscriptinjectiontime/wkuserscriptinjectiontimeatdocumentstart?language=objc)
 
-| Type   | Required | Platform   |
-| ------ | -------- | ---------- |
-| string | No       | iOS, macOS |
+| Type   | Required | Platform            |
+| ------ | -------- | ------------------- |
+| string | No       | iOS, Android, macOS |
 
 To learn more, read the [Communicating between JS and Native](Guide.md#communicating-between-js-and-native) guide.
 


### PR DESCRIPTION
It was stated that the prop `injectedJavaScriptBeforeContentLoaded` was only available for iOS and macOS. 
But I found that it is also implemented for Android. I have updated the documentation accordingly.

**References can be found here**

[/src/WebViewTypes.ts#L287](https://github.com/react-native-webview/react-native-webview/blob/53ff8fb86691e6d143f67e3351e722e7f87f2e65/src/WebViewTypes.ts#L287)

[/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L483 ](https://github.com/react-native-webview/react-native-webview/blob/53ff8fb86691e6d143f67e3351e722e7f87f2e65/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L483)

[/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L943](https://github.com/react-native-webview/react-native-webview/blob/53ff8fb86691e6d143f67e3351e722e7f87f2e65/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L943)