### PR TITLE
Fix the "register the module" link in the Custom Android doc

### DIFF
--- a/docs/Custom-Android.md
+++ b/docs/Custom-Android.md
@@ -41,7 +41,7 @@ public class CustomWebViewManager extends RNCWebViewManager {
 }
 ```
 
-You'll need to follow the usual steps to [register the module](native-modules-android.md#register-the-module).
+You'll need to follow the usual steps to [register the module](https://reactnative.dev/docs/native-modules-android#register-the-module-android-specific).
 
 ### Adding New Properties
 

--- a/docs/Custom-Android.portuguese.md
+++ b/docs/Custom-Android.portuguese.md
@@ -41,7 +41,7 @@ public class CustomWebViewManager extends RNCWebViewManager {
 }
 ```
 
-Você precisará seguir as etapas usuais para [registrar o módulo](native-modules-android.md#register-the-module).
+Você precisará seguir as etapas usuais para [registrar o módulo](https://reactnative.dev/docs/native-modules-android#register-the-module-android-specific).
 
 ### Adicionando novas propriedades
 


### PR DESCRIPTION
Fixes #2558