### PR TITLE
fix(windows): Add WinUI Version Opt In Functionality

### DIFF
--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -61,10 +61,8 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   ...otherProps
 }, ref) => {
   const webViewRef = useRef<NativeWebViewWindows | null>(null);
-
-  const RnwVersionSupportsWebView2 = (version.major>1 || version.minor>=68);
   
-  const RCTWebViewString = (RnwVersionSupportsWebView2 && useWebView2) ? 'RCTWebView2' : 'RCTWebView';
+  const RCTWebViewString = useWebView2 ? 'RCTWebView2' : 'RCTWebView';
 
   const onShouldStartLoadWithRequestCallback = useCallback((shouldStart: boolean, url: string, lockIdentifier?: number) => {
     if (lockIdentifier) {
@@ -125,7 +123,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   const webViewContainerStyle = [styles.container, containerStyle];
 
   const NativeWebView
-  = (RnwVersionSupportsWebView2 && useWebView2)? RCTWebView2 : RCTWebView;
+  = useWebView2? RCTWebView2 : RCTWebView;
 
   const webView = <NativeWebView
     key="webViewKey"

--- a/windows/ReactNativeWebView/ReactNativeWebView.vcxproj
+++ b/windows/ReactNativeWebView/ReactNativeWebView.vcxproj
@@ -81,7 +81,9 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" />
     <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <DefineConstants Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(WinUIPackageVersion)','2.8.0-prerelease.210927001'))">WINUI_VERSION_COMPAT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
@@ -112,6 +114,16 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(WinUIPackageVersion)','2.8.0-prerelease.210927001'))">
+    <ClCompile>
+      <PreprocessorDefinitions>WINUI_VERSION_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(WinUIPackageVersion)','2.8.0-prerelease.210927001'))">
+    <Midl>
+      <PreprocessorDefinitions>WINUI_VERSION_COMPAT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </Midl>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ReactWebView.h" />

--- a/windows/ReactNativeWebView/ReactWebView.idl
+++ b/windows/ReactNativeWebView/ReactWebView.idl
@@ -9,7 +9,12 @@ namespace ReactNativeWebView{
 #else
 #define RNW_VERSION_AT_LEAST(x,y,z) false
 #endif
-#if RNW_VERSION_AT_LEAST(0,68,0)
+
+#ifndef WINUI_VERSION_COMPAT
+#define WINUI_VERSION_COMPAT 0
+#endif 
+
+#if RNW_VERSION_AT_LEAST(0,68,0) && WINUI_VERSION_COMPAT
     [default_interface]
     runtimeclass ReactWebView2 : Windows.UI.Xaml.Controls.ContentPresenter{
         ReactWebView2(Microsoft.ReactNative.IReactContext context);

--- a/windows/ReactNativeWebView/pch.h
+++ b/windows/ReactNativeWebView/pch.h
@@ -8,7 +8,11 @@
 #define RNW_VERSION_AT_LEAST(x,y,z) false
 #endif
 
-#if RNW_VERSION_AT_LEAST(0,68,0)
+#ifndef WINUI_VERSION_COMPAT
+#define WINUI_VERSION_COMPAT 0
+#endif 
+
+#if RNW_VERSION_AT_LEAST(0,68,0) && WINUI_VERSION_COMPAT
 #define HAS_WEBVIEW2 1
 #else
 #define HAS_WEBVIEW2 0


### PR DESCRIPTION
Add functionality to opt into WinUI 2.8.0-prerelease for v68+ RNW apps using the Webview module.