### PR TITLE
fix(status-bar): prevent status bar to be hidden, on KeyboardUI event.

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -501,7 +501,8 @@ RCTAutoInsetsProtocol>
   
   _isFullScreenVideoOpen = YES;
   RCTUnsafeExecuteOnMainQueueSync(^{
-    [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
+    [RCTSharedApplication() setStatusBarHidden:NO animated:YES];
+    [RCTSharedApplication() setStatusBarStyle:RCTSharedApplication().statusBarStyle animated:YES];
   });
 #pragma clang diagnostic pop
 }
@@ -515,8 +516,8 @@ RCTAutoInsetsProtocol>
   
   _isFullScreenVideoOpen = NO;
   RCTUnsafeExecuteOnMainQueueSync(^{
-    [RCTSharedApplication() setStatusBarHidden:self->_savedStatusBarHidden animated:YES];
-    [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
+    [RCTSharedApplication() setStatusBarHidden:NO animated:YES];
+    [RCTSharedApplication() setStatusBarStyle:RCTSharedApplication().statusBarStyle animated:YES];
   });
 #pragma clang diagnostic pop
 }


### PR DESCRIPTION
According to the not fixed bug #1190 ,
> FullScreen Observer listening for event that is not limited to just entering Full Screen, also triggered on KeyboardUI windows showing.

Inside our app that is not using FullScreenVideoOpen, our KeyboardUI events are messing up our StatusBar state.

That's why this PR prevents the StatusBar changes.
This PR is well inspired by https://github.com/react-native-webview/react-native-webview/issues/735#issuecomment-581574089 from @[tyleragnew](https://github.com/tyleragnew)

However, the best solution (to me) would be:
- Do not call `showFullScreenVideoStatusBars` and `hideFullScreenVideoStatusBars` during KeyboardUI event.