### PR TITLE
fix(iOS): Adding the contentProcessDidTerminate property into useWebViewLogic hook arguments (fixes #2559)

### DIFF
--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -72,6 +72,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   onLoad,
   onLoadEnd,
   onLoadProgress,
+  onContentProcessDidTerminate: onContentProcessDidTerminateProp,
   onFileDownload,
   onHttpError: onHttpErrorProp,
   onMessage: onMessageProp,
@@ -117,6 +118,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     originWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
+    onContentProcessDidTerminateProp,
   });
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Fixes #2559 as suggested by the comments there.

Successfully tested on ipad 6th gen, iOS 15.5 following procedure in issue.