### PR TITLE
fix(android): cacheEnabled - make compatible with android sdk-33

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -316,13 +316,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     if (enabled) {
       Context ctx = view.getContext();
       if (ctx != null) {
-        view.getSettings().setAppCachePath(ctx.getCacheDir().getAbsolutePath());
         view.getSettings().setCacheMode(WebSettings.LOAD_DEFAULT);
-        view.getSettings().setAppCacheEnabled(true);
       }
     } else {
       view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-      view.getSettings().setAppCacheEnabled(false);
     }
   }
 


### PR DESCRIPTION
[Android 13 hits Platform Stability](https://android-developers.googleblog.com/2022/06/android-13-beta-3-platform-stability.html) and as such apps might be interesting in updating. Updating the `compileSdkVersion` to 33 results in build errors. It looks like both `setAppCachePath` and `setAppCacheEnabled` got deprecated.