### PR TITLE
fix(android): bump up kotlinVersion to 1.6.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeWebView_kotlinVersion=1.3.50
+ReactNativeWebView_kotlinVersion=1.6.0
 ReactNativeWebView_webkitVersion=1.4.0
 ReactNativeWebView_compileSdkVersion=29
 ReactNativeWebView_buildToolsVersion=29.0.3


### PR DESCRIPTION
Fixes the error "Module was compiled with an incompatible version of Kotlin" #2578
