### PR TITLE
(iOS & Android) Custom Menu Items - Android implementation & removes default menu in iOS 

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1676,14 +1676,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-          return true;
-        }
-
-        @Override
-        public void onGetContentRect (ActionMode mode, 
-                View view, 
-                Rect outRect){
-
           String js = "(function(){ const wr = " + RNCWebView.this.getWidth() + "/window.innerWidth; const hr = " + RNCWebView.this.getHeight() +"/window.innerHeight; const rect = window.getSelection()?.getRangeAt(0)?.getBoundingClientRect(); return JSON.stringify({x: (rect?.x * wr), y: (rect?.y * hr), width: (rect?.width * wr), height: (rect?.height * hr), selectionText: encodeURIComponent(window.getSelection().toString())})})()";
           RNCWebView.this.evaluateJavascript(js, new ValueCallback<String>() {
             @Override
@@ -1708,6 +1700,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
               }
             }
           });
+          return true;
+        }
+
+        @Override
+        public void onGetContentRect (ActionMode mode, 
+                View view, 
+                Rect outRect){
           outRect.set(
             (int)RNCWebView.this.selectionX,
             (int)RNCWebView.this.selectionY,

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -627,7 +627,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "menuItems")
   public void setMenuItems(WebView view, @Nullable ReadableArray menuItems) {
-    ((RNCWebView) view).setMenuItems(menuItems.toArrayList());
+    if (menuItems == null) {
+       ((RNCWebView) view).setMenuItems(null);
+    } else {
+      ((RNCWebView) view).setMenuItems(menuItems.toArrayList());
+    }
   }
 
   @ReactProp(name = "allowsFullscreenVideo")
@@ -1642,9 +1646,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public ActionMode startActionMode(ActionMode.Callback callback, int type) {
-      if(menuItems == null || menuItems.size() == 0){
+      if(menuItems == null ){
         return super.startActionMode(callback, type);
       }
+
       return super.startActionMode(new ActionMode.Callback2() {
         @Override
         public boolean onCreateActionMode(ActionMode mode, Menu menu) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1689,22 +1689,22 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
             @Override
             public void onReceiveValue(String value) {
               try{
-                JSONObject json = new JSONObject(value.substring(1, value.length() - 1).replaceAll("\\\\",""));
-                double x = json.getDouble("x"); 
-                double y = json.getDouble("y"); 
-                double width = json.getDouble("width"); 
-                double height = json.getDouble("height"); 
-                String selectionText = URLDecoder.decode(json.getString("selectionText"));
-                if(x != RNCWebView.this.selectionX || y != RNCWebView.this.selectionY || width != RNCWebView.this.selectionWidth  || height != RNCWebView.this.selectionHeight || selectionText != RNCWebView.this.selectionText){
-                  RNCWebView.this.selectionX = x;
-                  RNCWebView.this.selectionY = y;
-                  RNCWebView.this.selectionWidth = width;
-                  RNCWebView.this.selectionHeight = height;
-                  RNCWebView.this.selectionText = selectionText;
-                  mode.invalidateContentRect();
-                }
+                  JSONObject json = new JSONObject(value.substring(1, value.length() - 1).replaceAll("\\\\",""));
+                  double x = json.getDouble("x"); 
+                  double y = json.getDouble("y"); 
+                  double width = json.getDouble("width"); 
+                  double height = json.getDouble("height"); 
+                  String selectionText = URLDecoder.decode(json.getString("selectionText"));
+                  if(x != RNCWebView.this.selectionX || y != RNCWebView.this.selectionY || width != RNCWebView.this.selectionWidth  || height != RNCWebView.this.selectionHeight || selectionText != RNCWebView.this.selectionText){
+                    RNCWebView.this.selectionX = x;
+                    RNCWebView.this.selectionY = y;
+                    RNCWebView.this.selectionWidth = width;
+                    RNCWebView.this.selectionHeight = height;
+                    RNCWebView.this.selectionText = selectionText;
+                    mode.invalidateContentRect();
+                  }
               }catch(JSONException e){
-                throw new RuntimeException(e);
+                Log.w(TAG, "Selection info not valid JSON", e);
               }
             }
           });

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -58,7 +58,6 @@ import androidx.webkit.WebViewFeature;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
-//import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.facebook.react.views.scroll.OnScrollDispatchHelper;
@@ -101,6 +100,7 @@ import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import	java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1684,7 +1684,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
                 View view, 
                 Rect outRect){
 
-          String js = "(function(){ let wr = " + RNCWebView.this.getWidth() + "/window.innerWidth; let hr = " + RNCWebView.this.getHeight() +"/window.innerHeight; let rect = window.getSelection()?.getRangeAt(0)?.getBoundingClientRect(); return JSON.stringify({x: (rect?.x * wr), y: (rect?.y * hr), width: (rect?.width * wr), height: (rect?.height * hr), selectionText: window.getSelection().toString()?.replace(/\"/g, '%%22')?.replace(/\\\\/g, '%%5C')})})()";
+          String js = "(function(){ const wr = " + RNCWebView.this.getWidth() + "/window.innerWidth; const hr = " + RNCWebView.this.getHeight() +"/window.innerHeight; const rect = window.getSelection()?.getRangeAt(0)?.getBoundingClientRect(); return JSON.stringify({x: (rect?.x * wr), y: (rect?.y * hr), width: (rect?.width * wr), height: (rect?.height * hr), selectionText: encodeURIComponent(window.getSelection().toString())})})()";
           RNCWebView.this.evaluateJavascript(js, new ValueCallback<String>() {
             @Override
             public void onReceiveValue(String value) {
@@ -1699,7 +1699,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
                   RNCWebView.this.selectionY = y;
                   RNCWebView.this.selectionWidth = width;
                   RNCWebView.this.selectionHeight = height;
-                  RNCWebView.this.selectionText = json.getString("selectionText").replaceAll("%%22", "\"").replaceAll("%%5C", "\\\\");
+                  RNCWebView.this.selectionText = URLDecoder.decode(json.getString("selectionText"));
                   mode.invalidateContentRect();
                 }
               }catch(JSONException e){

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -100,7 +100,7 @@ import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import	java.net.URLDecoder;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1694,12 +1694,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
                 double y = json.getDouble("y"); 
                 double width = json.getDouble("width"); 
                 double height = json.getDouble("height"); 
-                if(x != RNCWebView.this.selectionX || y != RNCWebView.this.selectionY || width !=RNCWebView.this.selectionWidth  || height != RNCWebView.this.selectionHeight){
+                String selectionText = URLDecoder.decode(json.getString("selectionText"));
+                if(x != RNCWebView.this.selectionX || y != RNCWebView.this.selectionY || width != RNCWebView.this.selectionWidth  || height != RNCWebView.this.selectionHeight || selectionText != RNCWebView.this.selectionText){
                   RNCWebView.this.selectionX = x;
                   RNCWebView.this.selectionY = y;
                   RNCWebView.this.selectionWidth = width;
                   RNCWebView.this.selectionHeight = height;
-                  RNCWebView.this.selectionText = URLDecoder.decode(json.getString("selectionText"));
+                  RNCWebView.this.selectionText = selectionText;
                   mode.invalidateContentRect();
                 }
               }catch(JSONException e){

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -515,11 +515,6 @@ RCTAutoInsetsProtocol>
     longPress.numberOfTouchesRequired = 1;
     longPress.cancelsTouchesInView = YES;
     [self addGestureRecognizer:longPress];
-
-  //#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 /* __IPHONE_16_0 */
-  //  UIEditMenuInteraction *editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate: self];
-  //  [self addInteraction:editMenuInteraction];
-  //#endif
   }
 #endif // !TARGET_OS_OSX
 }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -56,9 +56,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   if (!self.menuItems || self.menuItems.count == 0) {              
     return YES;
   }
-  else{
-    return NO;
-  }
+  return NO;
 }
 @end
 #endif // !TARGET_OS_OSX

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -50,12 +50,21 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
 @end
 @implementation RNCWKWebView_
+
 - (BOOL)canPerformAction:(SEL)action 
               withSender:(id)sender{
+  
   if (!self.menuItems) {              
     return YES;
   }
   return NO;
+}
+
+- (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder API_AVAILABLE(ios(13.0))  {
+    if (@available(iOS 16.0, *)) {
+        [builder removeMenuForIdentifier:UIMenuLookup];
+    }
+    [super buildMenuWithBuilder:builder];
 }
 @end
 #endif // !TARGET_OS_OSX
@@ -504,6 +513,11 @@ RCTAutoInsetsProtocol>
     longPress.numberOfTouchesRequired = 1;
     longPress.cancelsTouchesInView = YES;
     [self addGestureRecognizer:longPress];
+
+  //#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 /* __IPHONE_16_0 */
+  //  UIEditMenuInteraction *editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate: self];
+  //  [self addInteraction:editMenuInteraction];
+  //#endif
   }
 #endif // !TARGET_OS_OSX
 }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -46,6 +46,21 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   return nil;
 }
 @end
+@interface RNCWKWebView_ : WKWebView
+@property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
+@end
+@implementation RNCWKWebView_
+- (BOOL)canPerformAction:(SEL)action 
+              withSender:(id)sender{
+  
+  if (!self.menuItems || self.menuItems.count == 0) {              
+    return YES;
+  }
+  else{
+    return NO;
+  }
+}
+@end
 #endif // !TARGET_OS_OSX
 
 #if TARGET_OS_OSX
@@ -81,7 +96,7 @@ RCTAutoInsetsProtocol>
 @property (nonatomic, copy) RCTDirectEventBlock onScroll;
 @property (nonatomic, copy) RCTDirectEventBlock onContentProcessDidTerminate;
 #if !TARGET_OS_OSX
-@property (nonatomic, copy) WKWebView *webView;
+@property (nonatomic, copy) RNCWKWebView_ *webView;
 #else
 @property (nonatomic, copy) RNCWKWebView *webView;
 #endif // !TARGET_OS_OSX
@@ -427,7 +442,7 @@ RCTAutoInsetsProtocol>
   if (self.window != nil && _webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
 #if !TARGET_OS_OSX
-    _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
+    _webView = [[RNCWKWebView_ alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
 #else
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
 #endif // !TARGET_OS_OSX
@@ -435,6 +450,7 @@ RCTAutoInsetsProtocol>
     [self setBackgroundColor: _savedBackgroundColor];
 #if !TARGET_OS_OSX
     _webView.scrollView.delegate = self;
+    _webView.menuItems = self.menuItems;
 #endif // !TARGET_OS_OSX
     _webView.UIDelegate = self;
     _webView.navigationDelegate = self;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -62,7 +62,9 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 
 - (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder API_AVAILABLE(ios(13.0))  {
     if (@available(iOS 16.0, *)) {
+      if(self.menuItems){
         [builder removeMenuForIdentifier:UIMenuLookup];
+      }
     }
     [super buildMenuWithBuilder:builder];
 }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -52,8 +52,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 @implementation RNCWKWebView_
 - (BOOL)canPerformAction:(SEL)action 
               withSender:(id)sender{
-  
-  if (!self.menuItems || self.menuItems.count == 0) {              
+  if (!self.menuItems) {              
     return YES;
   }
   return NO;
@@ -221,24 +220,34 @@ RCTAutoInsetsProtocol>
 {
   // When a long press ends, bring up our custom UIMenu
   if(pressSender.state == UIGestureRecognizerStateEnded) {
-    if (!self.menuItems || self.menuItems.count == 0) {
+
+    _webView.menuItems = self.menuItems;
+    
+    if (!self.menuItems) {
       return;
     }
-    UIMenuController *menuController = [UIMenuController sharedMenuController];
-    NSMutableArray *menuControllerItems = [NSMutableArray arrayWithCapacity:self.menuItems.count];
-    
-    for(NSDictionary *menuItem in self.menuItems) {
-      NSString *menuItemLabel = [RCTConvert NSString:menuItem[@"label"]];
-      NSString *menuItemKey = [RCTConvert NSString:menuItem[@"key"]];
-      NSString *sel = [NSString stringWithFormat:@"%@%@", CUSTOM_SELECTOR, menuItemKey];
-      UIMenuItem *item = [[UIMenuItem alloc] initWithTitle: menuItemLabel
-                                                    action: NSSelectorFromString(sel)];
-      
-      [menuControllerItems addObject: item];
+    else if (self.menuItems.count == 0) {
+      UIMenuController *menuController = [UIMenuController sharedMenuController];
+      menuController.menuItems = nil;
+      [menuController setMenuVisible:NO animated:YES];
     }
-    
-    menuController.menuItems = menuControllerItems;
-    [menuController setMenuVisible:YES animated:YES];
+    else { 
+      UIMenuController *menuController = [UIMenuController sharedMenuController];
+      NSMutableArray *menuControllerItems = [NSMutableArray arrayWithCapacity:self.menuItems.count];
+      
+      for(NSDictionary *menuItem in self.menuItems) {
+        NSString *menuItemLabel = [RCTConvert NSString:menuItem[@"label"]];
+        NSString *menuItemKey = [RCTConvert NSString:menuItem[@"key"]];
+        NSString *sel = [NSString stringWithFormat:@"%@%@", CUSTOM_SELECTOR, menuItemKey];
+        UIMenuItem *item = [[UIMenuItem alloc] initWithTitle: menuItemLabel
+                                                      action: NSSelectorFromString(sel)];
+        
+        [menuControllerItems addObject: item];
+      }
+      
+      menuController.menuItems = menuControllerItems;
+      [menuController setMenuVisible:YES animated:YES];
+    }
   }
 }
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1510,7 +1510,7 @@ Example:
 ```
 ### `menuItems`
 
-An array of custom menu item objects that will be appended to the UIMenu that appears when selecting text (will appear after 'Copy' and 'Share...').  Used in tandem with `onCustomMenuSelection`
+An array of custom menu item objects that will be shown as the context menu when text on the webpage is selected.   Used in tandem with `onCustomMenuSelection`.
 
 | Type                                                               | Required | Platform |
 | ------------------------------------------------------------------ | -------- | -------- |

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -1500,7 +1500,7 @@ Exemplo:
 ```
 ### `menuItems`
 
-Uma matriz de objetos de itens de menu personalizados que serão anexados ao UIMenu que aparece ao selecionar o texto (aparecerá após 'Copiar' e 'Compartilhar...'). Usado em conjunto com `onCustomMenuSelection`
+Uma matriz de objetos de itens de menu personalizados que serão mostrados como o menu de contexto quando o texto na página da Web for selecionado. Usado em conjunto com `onCustomMenuSelection`
 
 | Tipo                                                               | Requerido | Plataforma |
 | ------------------------------------------------------------------ | --------  | --------   |

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -20,6 +20,7 @@ import LocalPageLoad from './examples/LocalPageLoad';
 import Messaging from './examples/Messaging';
 import NativeWebpage from './examples/NativeWebpage';
 import ApplePay from './examples/ApplePay';
+import CustomMenu from './examples/CustomMenu';
 
 const TESTS = {
   Messaging: {
@@ -101,6 +102,14 @@ const TESTS = {
     render() {
       return <ApplePay />;
     },
+  },
+  CustomMenu: {
+    title: 'Custom Menu',
+    testId: 'CustomMenu',
+    description: 'Test to custom context menu shown on highlighting text',
+    render() {
+      return <CustomMenu />;
+    },
   }
 };
 
@@ -164,6 +173,11 @@ export default class App extends Component<Props, State> {
             testID="testType_pageLoad"
             title="LocalPageLoad"
             onPress={() => this._changeTest('PageLoad')}
+          />
+          <Button
+            testID="testType_customMenu"
+            title="CustomMenu"
+            onPress={() => this._changeTest('CustomMenu')}
           />
           <Button
             testID="testType_downloads"

--- a/example/examples/CustomMenu.tsx
+++ b/example/examples/CustomMenu.tsx
@@ -1,0 +1,68 @@
+import React, {Component} from 'react';
+import {Button, Linking, Text, View} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `
+<!DOCTYPE html>\n
+<html>
+  <head>
+    <title>Context Menu</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=320, user-scalable=no">
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 0;
+        font: 62.5% arial, sans-serif;
+        background: #ccc;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Select the text to see the custom context menu.
+    </p>
+    <p>
+      The custom context menu will show the custom menu's defined in the menuItems prop and call the onCustomMenuSelection
+      on clicking on the menu Item.
+    </p>
+    <p>
+      Third Para
+    </p>
+  </body>
+</html>
+`;
+
+type Props = {};
+type State = {};
+
+//export default class CustomMenu extends Component<Props, State> {
+export default CustomMenu = () => {
+  const [selectionInfo, setSelectionInfo] = React.useState(null)
+
+    return (
+      <View>
+        <View style={{ height: 120 }}>
+          <WebView
+            source={{html: HTML}}
+            automaticallyAdjustContentInsets={false}
+            menuItems={[{ label: 'Highlight', key: 'highlight' }, { label: 'Strikethrough', key: 'strikethrough' }]}
+            onCustomMenuSelection={(webViewEvent) => {
+            const { label, key, selectedText } = webViewEvent.nativeEvent;
+            console.log('Custom Menu Tapped: ', label, ' :: ', key, ' :: ', selectedText)
+            setSelectionInfo(webViewEvent.nativeEvent)
+          }}
+          />
+        </View>
+        {selectionInfo && 
+          <Text> 
+              onCustomMenuSelection called: {"\n"}
+              - label: {selectionInfo?.label}{"\n"}
+              - key: {selectionInfo?.key}{"\n"}
+              - selectedText: {selectionInfo?.selectedText}
+          </Text>
+        }
+      </View>
+    );
+}

--- a/example/examples/CustomMenu.tsx
+++ b/example/examples/CustomMenu.tsx
@@ -24,11 +24,11 @@ const HTML = `
       Select the text to see the custom context menu.
     </p>
     <p>
-      The custom context menu will show the custom menu's defined in the menuItems prop and call the onCustomMenuSelection
-      on clicking on the menu Item.
+      The custom context menu will show the custom menus defined in the menuItems prop and call the onCustomMenuSelection
+      on clicking on the menu Item. Testing symbols ' " < & > + - = ^ % $ # @ ! ~ ; :  ? 
     </p>
     <p>
-      Third Para
+      "Third Para with quotes"
     </p>
   </body>
 </html>
@@ -49,10 +49,10 @@ export default CustomMenu = () => {
             automaticallyAdjustContentInsets={false}
             menuItems={[{ label: 'Highlight', key: 'highlight' }, { label: 'Strikethrough', key: 'strikethrough' }]}
             onCustomMenuSelection={(webViewEvent) => {
-            const { label, key, selectedText } = webViewEvent.nativeEvent;
-            console.log('Custom Menu Tapped: ', label, ' :: ', key, ' :: ', selectedText)
-            setSelectionInfo(webViewEvent.nativeEvent)
-          }}
+              const { label, key, selectedText } = webViewEvent.nativeEvent;
+              console.log('Custom Menu Tapped: ', label, ' :: ', key, ' :: ', selectedText)
+              setSelectionInfo(webViewEvent.nativeEvent)
+            }}
           />
         </View>
         {selectionInfo && 

--- a/example/examples/CustomMenu.tsx
+++ b/example/examples/CustomMenu.tsx
@@ -18,6 +18,23 @@ const HTML = `
         background: #ccc;
       }
     </style>
+    <script>
+      //script to clear selection/highlight
+      const messageEventListenerFn = (e) =>{
+        try{  
+          if(e.origin === '' && typeof window.ReactNativeWebView === 'object'){
+            const parsedData = JSON.parse(e.data)  
+            if(parsedData?.what === 'clearSelection'){
+              window.getSelection()?.removeAllRanges()
+            }
+          }
+        }catch(e){
+          console.log('External: ', 'exception in eventListener: ', e.message)
+        } 
+      }
+      window.addEventListener('message', (e) => messageEventListenerFn(e))
+      document.addEventListener('message', (e) => messageEventListenerFn(e))
+    </script>
   </head>
   <body>
     <p>
@@ -40,18 +57,21 @@ type State = {};
 //export default class CustomMenu extends Component<Props, State> {
 export default CustomMenu = () => {
   const [selectionInfo, setSelectionInfo] = React.useState(null)
+  const webviewRef = React.useRef()
 
     return (
       <View>
         <View style={{ height: 120 }}>
           <WebView
+            ref={webviewRef}
             source={{html: HTML}}
             automaticallyAdjustContentInsets={false}
             menuItems={[{ label: 'Highlight', key: 'highlight' }, { label: 'Strikethrough', key: 'strikethrough' }]}
             onCustomMenuSelection={(webViewEvent) => {
               const { label, key, selectedText } = webViewEvent.nativeEvent;
-              console.log('Custom Menu Tapped: ', label, ' :: ', key, ' :: ', selectedText)
               setSelectionInfo(webViewEvent.nativeEvent)
+              //clearing the selection by sending a message. This would need a script on the source page to listen to the message.
+              webviewRef.current?.postMessage(JSON.stringify({what: 'clearSelection'}))
             }}
           />
         </View>


### PR DESCRIPTION
### What's in this PR
---
- Implements Custom Context Menu in Android
- Removes the default menu items, showing only the custom menu items in both iOS and Android
- Added a CustomMenu example 

This adds to the work done in #2101 in iOS, and resolves issues #2244, #2522 for Android.

| iOS  | Android |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/20735539/180301261-f35d4ac3-8fdd-4e52-9684-c2930754fb86.png" width="250"/> | <img src="https://user-images.githubusercontent.com/20735539/180301340-65476b1d-03a9-4b1f-b8f0-21f6e5ec7652.png" width="250"/> |


### How to test
---

Add WebView as shown below:
```
<WebView
  source={{html: HTML}}
  menuItems={[{ label: 'Highlight', key: 'highlight' }, { label: 'Strikethrough', key: 'strikethrough' }]}
  onCustomMenuSelection={(webViewEvent) => {
    const { label, key, selectedText } = webViewEvent.nativeEvent;
    console.log('Custom Menu Item Clicked: ', label, ' :: ', key, ' :: ', selectedText)
  }}
/>
```

A demo has also been added to examples. Custom Menus as set in the WebView prop `menuItems` will be shown on highlighting text. And then on tapping a menu item, `onCustomMenuSelection` will be called. 

If no `menuItems` prop, then the default menu is shown.


