### PR TITLE
Update Kotlin version for compatibility with RN 69/ Expo 46

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeWebView_kotlinVersion=1.3.50
+ReactNativeWebView_kotlinVersion=1.6.0
 ReactNativeWebView_webkitVersion=1.4.0
 ReactNativeWebView_compileSdkVersion=29
 ReactNativeWebView_buildToolsVersion=29.0.3


### PR DESCRIPTION
Hi! It sounds like you already have this covered, so feel free to close; just wanted to let you know that I tested this change against a new project using [Expo 46-beta6](https://blog.expo.dev/expo-sdk-46-beta-is-now-available-9dfee4040aa7), and it fixes the compilation issue we experienced when installing this package (identical to: https://github.com/react-native-webview/react-native-webview/issues/2578).

Thank you!