### PR TITLE
iOS: Fix webview not loading in background tab

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -402,9 +402,9 @@ RCTAutoInsetsProtocol>
   return wkWebViewConfig;
 }
 
-- (void)didMoveToWindow
+- (void)didMoveToSuperview
 {
-  if (self.window != nil && _webView == nil) {
+  if (_webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
 #if !TARGET_OS_OSX
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];


### PR DESCRIPTION
Initial issue here: https://github.com/react-native-webview/react-native-webview/issues/2431#issuecomment-1203646983
Fix reference from: https://github.com/react-native-webview/react-native-webview/pull/1852#issuecomment-1120470181

This fixes the issue where the web view is not loaded during initial app render when it is on a separate tab.

Testing using:
`"react-native": "0.68.2"`
`"react-native-webview": "11.21.1"`

Thanks to @gbhrdt and @goleary