### PR TITLE
add null check safety for adding mainDocumentURL to event

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1143,9 +1143,13 @@ RCTAutoInsetsProtocol>
   
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+    if (request.mainDocumentURL) {
+      [event addEntriesFromDictionary: @{
+        @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
+      }];
+    }
     [event addEntriesFromDictionary: @{
       @"url": (request.URL).absoluteString,
-      @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)],
       @"isTopFrame": @(isTopFrame)
     }];


### PR DESCRIPTION
There are cases - albeit seldom - where mainDocumentURL in request is nil hence causing a crash when attempting to add it to the event object i.e [event addEntriesFromDictionary]. 
Here is the crash we were encountering: 

```
Fatal Exception: NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]
```

This PR aims to solve the issue.

Related issue: [2442](https://github.com/react-native-webview/react-native-webview/pull/2442)