### PR TITLE
fix(js): messagingEnabled prop

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -164,7 +164,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   const webView = <NativeWebView
     key="webViewKey"
     {...otherProps}
-    messagingEnabled={typeof onMessage === 'function'}
+    messagingEnabled={typeof onMessageProp === 'function'}
     messagingModuleName={messagingModuleName}
 
     onLoadingError={onLoadingError}

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -174,7 +174,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       useSharedProcessPool={useSharedProcessPool}
       textInteractionEnabled={textInteractionEnabled}
       decelerationRate={decelerationRate}
-      messagingEnabled={typeof onMessage === 'function'}
+      messagingEnabled={typeof onMessageProp === 'function'}
       onLoadingError={onLoadingError}
       onLoadingFinish={onLoadingFinish}
       onLoadingProgress={onLoadingProgress}

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -149,7 +149,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
       javaScriptEnabled={javaScriptEnabled}
       cacheEnabled={cacheEnabled}
       useSharedProcessPool={useSharedProcessPool}
-      messagingEnabled={typeof onMessage === 'function'}
+      messagingEnabled={typeof onMessageProp === 'function'}
       onLoadingError={onLoadingError}
       onLoadingFinish={onLoadingFinish}
       onLoadingProgress={onLoadingProgress}

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -126,7 +126,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   const webView = <NativeWebView
     key="webViewKey"
     {...otherProps}
-    messagingEnabled={typeof onMessage === 'function'}
+    messagingEnabled={typeof onMessageProp === 'function'}
     onLoadingError={onLoadingError}
     onLoadingFinish={onLoadingFinish}
     onLoadingProgress={onLoadingProgress}


### PR DESCRIPTION
This was always being set to `true`, even if no `onMessage` handler was provided. At the point that `messagingEnabled` is set, `onMessage` actually refers to a wrapper callback from `WebViewShared`, which is always defined, not the actual `onMessage` handler that was provided (or not) by the application.

This regressed in version 11.22.0

Thanks to @Ldoppea for indirectly bringing this to my attention. 😁 