### PR TITLE
feat: add `getNativeTag` API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['react', 'react-native', 'import', '@typescript-eslint'],
   rules: {
-    'no-underscore-dangle': 'off',
     'no-console': 'off',
     // Lines will be broken before binary operators
     'operator-linebreak': ['error', 'before'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['react', 'react-native', 'import', '@typescript-eslint'],
   rules: {
+    'no-underscore-dangle': 'off',
     'no-console': 'off',
     // Lines will be broken before binary operators
     'operator-linebreak': ['error', 'before'],

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -102,6 +102,7 @@ This document lays out the current public properties and methods for the React N
 - [`clearHistory`](Reference.md#clearHistory)
 - [`requestFocus`](Reference.md#requestFocus)
 - [`postMessage`](Reference.md#postmessagestr)
+- [`getNativeWebView`](Reference.md#getnativewebview)
 
 ---
 
@@ -1673,6 +1674,14 @@ clearHistory();
 ```
 
 Tells this WebView to clear its internal back/forward list. [developer.android.com reference](<https://developer.android.com/reference/android/webkit/WebView.html#clearHistory()>)
+
+### `getNativeWebView()`[⬆](#methods-index)<!-- Link generated with jump2header -->
+
+```javascript
+getNativeWebView();
+```
+
+Returns a ref of the native WebView component.
 
 ## Other Docs
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,11 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
     goForward: () => void;
 
     /**
+     * Get a ref of NativeWebView.
+     */
+    getNativeWebView: () => WebView | null;
+
+    /**
      * Reloads the current page.
      */
     reload: () => void;
@@ -37,7 +42,7 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      */
     requestFocus: () => void;
     
-     /**
+    /**
      * Posts a message to WebView.
      */
     postMessage: (message: string) => void;

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -119,6 +119,8 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
     clearHistory: () => Commands.clearHistory(webViewRef.current),
+    // @ts-ignore
+    getNativeTag: () => webViewRef.current._nativeTag,
   }), [setViewState, webViewRef]);
 
   const directEventCallbacks = useMemo(() => ({

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -119,8 +119,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
     clearHistory: () => Commands.clearHistory(webViewRef.current),
-    // @ts-ignore
-    getNativeTag: () => webViewRef.current._nativeTag,
+    getNativeWebView: () => webViewRef.current,
   }), [setViewState, webViewRef]);
 
   const directEventCallbacks = useMemo(() => ({

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -133,6 +133,8 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
+    // @ts-ignore
+    getNativeTag: () => webViewRef.current._nativeTag,
   }), [setViewState, webViewRef]);
 
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -1,15 +1,15 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
-import {
-  Image,
-  View,
-  NativeModules,
-  ImageSourcePropType,
-} from 'react-native';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { Image, View, NativeModules, ImageSourcePropType } from 'react-native';
 import invariant from 'invariant';
 
 // @ts-expect-error react-native doesn't have this type
 import codegenNativeCommandsUntyped from 'react-native/Libraries/Utilities/codegenNativeCommands';
-import RNCWebView from "./WebViewNativeComponent.ios";
+import RNCWebView from './WebViewNativeComponent.ios';
 import {
   defaultOriginWhitelist,
   defaultRenderError,
@@ -25,11 +25,23 @@ import {
 
 import styles from './WebView.styles';
 
-
-const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
+const codegenNativeCommands = codegenNativeCommandsUntyped as <
+  T extends {},
+  >(options: {
+    supportedCommands: (keyof T)[];
+  }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl'],
+  supportedCommands: [
+    'goBack',
+    'goForward',
+    'reload',
+    'stopLoading',
+    'injectJavaScript',
+    'requestFocus',
+    'postMessage',
+    'loadUrl',
+  ],
 });
 
 const { resolveAssetSource } = Image;
@@ -50,170 +62,202 @@ const RNCWebViewManager = NativeModules.RNCWebViewManager as ViewManager;
 const useWarnIfChanges = <T extends unknown>(value: T, name: string) => {
   const ref = useRef(value);
   if (ref.current !== value) {
-    console.warn(`Changes to property ${name} do nothing after the initial render.`);
+    console.warn(
+      `Changes to property ${name} do nothing after the initial render.`,
+    );
     ref.current = value;
   }
-}
+};
 
-const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
-  javaScriptEnabled = true,
-  cacheEnabled = true,
-  originWhitelist = defaultOriginWhitelist,
-  useSharedProcessPool= true,
-  textInteractionEnabled= true,
-  injectedJavaScript,
-  injectedJavaScriptBeforeContentLoaded,
-  injectedJavaScriptForMainFrameOnly = true,
-  injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true,
-  startInLoadingState,
-  onNavigationStateChange,
-  onLoadStart,
-  onError,
-  onLoad,
-  onLoadEnd,
-  onLoadProgress,
-  onContentProcessDidTerminate: onContentProcessDidTerminateProp,
-  onFileDownload,
-  onHttpError: onHttpErrorProp,
-  onMessage: onMessageProp,
-  renderLoading,
-  renderError,
-  style,
-  containerStyle,
-  source,
-  nativeConfig,
-  allowsInlineMediaPlayback,
-  allowsAirPlayForMediaPlayback,
-  mediaPlaybackRequiresUserAction,
-  dataDetectorTypes,
-  incognito,
-  decelerationRate: decelerationRateProp,
-  onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
-  ...otherProps
-}, ref) => {
-  const webViewRef = useRef<NativeWebViewIOS | null>(null);
-
-  const onShouldStartLoadWithRequestCallback = useCallback((
-    shouldStart: boolean,
-    _url: string,
-    lockIdentifier = 0,
-  ) => {
-    const viewManager
-      = (nativeConfig?.viewManager)
-      || RNCWebViewManager;
-
-    viewManager.startLoadWithResult(!!shouldStart, lockIdentifier);
-  }, [nativeConfig?.viewManager]);
-
-  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onContentProcessDidTerminate } = useWebWiewLogic({
-    onNavigationStateChange,
-    onLoad,
-    onError,
-    onHttpErrorProp,
-    onLoadEnd,
-    onLoadProgress,
-    onLoadStart,
-    onMessageProp,
-    startInLoadingState,
-    originWhitelist,
-    onShouldStartLoadWithRequestProp,
-    onShouldStartLoadWithRequestCallback,
-    onContentProcessDidTerminateProp,
-  });
-
-  useImperativeHandle(ref, () => ({
-    goForward: () => Commands.goForward(webViewRef.current),
-    goBack: () => Commands.goBack(webViewRef.current),
-    reload: () => {
-      setViewState(
-        'LOADING',
-      ); Commands.reload(webViewRef.current)
+const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
+  (
+    {
+      javaScriptEnabled = true,
+      cacheEnabled = true,
+      originWhitelist = defaultOriginWhitelist,
+      useSharedProcessPool = true,
+      textInteractionEnabled = true,
+      injectedJavaScript,
+      injectedJavaScriptBeforeContentLoaded,
+      injectedJavaScriptForMainFrameOnly = true,
+      injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true,
+      startInLoadingState,
+      onNavigationStateChange,
+      onLoadStart,
+      onError,
+      onLoad,
+      onLoadEnd,
+      onLoadProgress,
+      onContentProcessDidTerminate: onContentProcessDidTerminateProp,
+      onFileDownload,
+      onHttpError: onHttpErrorProp,
+      onMessage: onMessageProp,
+      renderLoading,
+      renderError,
+      style,
+      containerStyle,
+      source,
+      nativeConfig,
+      allowsInlineMediaPlayback,
+      allowsAirPlayForMediaPlayback,
+      mediaPlaybackRequiresUserAction,
+      dataDetectorTypes,
+      incognito,
+      decelerationRate: decelerationRateProp,
+      onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
+      ...otherProps
     },
-    stopLoading: () => Commands.stopLoading(webViewRef.current),
-    postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
-    injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
-    requestFocus: () => Commands.requestFocus(webViewRef.current),
-    // @ts-ignore
-    getNativeTag: () => webViewRef.current._nativeTag,
-  }), [setViewState, webViewRef]);
+    ref,
+  ) => {
+    const webViewRef = useRef<NativeWebViewIOS | null>(null);
 
+    const onShouldStartLoadWithRequestCallback = useCallback(
+      (shouldStart: boolean, _url: string, lockIdentifier = 0) => {
+        const viewManager = nativeConfig?.viewManager || RNCWebViewManager;
 
-  useWarnIfChanges(allowsInlineMediaPlayback, 'allowsInlineMediaPlayback');
-  useWarnIfChanges(allowsAirPlayForMediaPlayback, 'allowsAirPlayForMediaPlayback');
-  useWarnIfChanges(incognito, 'incognito');
-  useWarnIfChanges(mediaPlaybackRequiresUserAction, 'mediaPlaybackRequiresUserAction');
-  useWarnIfChanges(dataDetectorTypes, 'dataDetectorTypes');
-
-  let otherView = null;
-  if (viewState === 'LOADING') {
-    otherView = (renderLoading || defaultRenderLoading)();
-  } else if (viewState === 'ERROR') {
-    invariant(lastErrorEvent != null, 'lastErrorEvent expected to be non-null');
-    otherView = (renderError || defaultRenderError)(
-      lastErrorEvent.domain,
-      lastErrorEvent.code,
-      lastErrorEvent.description,
+        viewManager.startLoadWithResult(!!shouldStart, lockIdentifier);
+      },
+      [nativeConfig?.viewManager],
     );
-  } else if (viewState !== 'IDLE') {
-    console.error(`RNCWebView invalid state encountered: ${viewState}`);
-  }
 
-  const webViewStyles = [styles.container, styles.webView, style];
-  const webViewContainerStyle = [styles.container, containerStyle];
+    const {
+      onLoadingStart,
+      onShouldStartLoadWithRequest,
+      onMessage,
+      viewState,
+      setViewState,
+      lastErrorEvent,
+      onHttpError,
+      onLoadingError,
+      onLoadingFinish,
+      onLoadingProgress,
+      onContentProcessDidTerminate,
+    } = useWebWiewLogic({
+      onNavigationStateChange,
+      onLoad,
+      onError,
+      onHttpErrorProp,
+      onLoadEnd,
+      onLoadProgress,
+      onLoadStart,
+      onMessageProp,
+      startInLoadingState,
+      originWhitelist,
+      onShouldStartLoadWithRequestProp,
+      onShouldStartLoadWithRequestCallback,
+      onContentProcessDidTerminateProp,
+    });
 
-  const decelerationRate = processDecelerationRate(decelerationRateProp);
+    useImperativeHandle(
+      ref,
+      () => ({
+        goForward: () => Commands.goForward(webViewRef.current),
+        goBack: () => Commands.goBack(webViewRef.current),
+        reload: () => {
+          setViewState('LOADING');
+          Commands.reload(webViewRef.current);
+        },
+        stopLoading: () => Commands.stopLoading(webViewRef.current),
+        postMessage: (data: string) =>
+          Commands.postMessage(webViewRef.current, data),
+        injectJavaScript: (data: string) =>
+          Commands.injectJavaScript(webViewRef.current, data),
+        requestFocus: () => Commands.requestFocus(webViewRef.current),
+        getNativeWebView: () => webViewRef.current,
+      }),
+      [setViewState, webViewRef],
+    );
 
-  const NativeWebView
-  = (nativeConfig?.component as typeof NativeWebViewIOS | undefined)
-  || RNCWebView;
+    useWarnIfChanges(allowsInlineMediaPlayback, 'allowsInlineMediaPlayback');
+    useWarnIfChanges(
+      allowsAirPlayForMediaPlayback,
+      'allowsAirPlayForMediaPlayback',
+    );
+    useWarnIfChanges(incognito, 'incognito');
+    useWarnIfChanges(
+      mediaPlaybackRequiresUserAction,
+      'mediaPlaybackRequiresUserAction',
+    );
+    useWarnIfChanges(dataDetectorTypes, 'dataDetectorTypes');
 
-  const webView = (
-    <NativeWebView
-      key="webViewKey"
-      {...otherProps}
-      javaScriptEnabled={javaScriptEnabled}
-      cacheEnabled={cacheEnabled}
-      useSharedProcessPool={useSharedProcessPool}
-      textInteractionEnabled={textInteractionEnabled}
-      decelerationRate={decelerationRate}
-      messagingEnabled={typeof onMessage === 'function'}
-      onLoadingError={onLoadingError}
-      onLoadingFinish={onLoadingFinish}
-      onLoadingProgress={onLoadingProgress}
-      onFileDownload={onFileDownload}
-      onLoadingStart={onLoadingStart}
-      onHttpError={onHttpError}
-      onMessage={onMessage}
-      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-      onContentProcessDidTerminate={onContentProcessDidTerminate}
-      injectedJavaScript={injectedJavaScript}
-      injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
-      injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
-      injectedJavaScriptBeforeContentLoadedForMainFrameOnly={injectedJavaScriptBeforeContentLoadedForMainFrameOnly}
-      dataDetectorTypes={dataDetectorTypes}
-      allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
-      allowsInlineMediaPlayback={allowsInlineMediaPlayback}
-      incognito={incognito}
-      mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
-      ref={webViewRef}
-      // TODO: find a better way to type this.
-      source={resolveAssetSource(source as ImageSourcePropType)}
-      style={webViewStyles}
-      {...nativeConfig?.props}
-    />
-  );
+    let otherView = null;
+    if (viewState === 'LOADING') {
+      otherView = (renderLoading || defaultRenderLoading)();
+    } else if (viewState === 'ERROR') {
+      invariant(
+        lastErrorEvent != null,
+        'lastErrorEvent expected to be non-null',
+      );
+      otherView = (renderError || defaultRenderError)(
+        lastErrorEvent.domain,
+        lastErrorEvent.code,
+        lastErrorEvent.description,
+      );
+    } else if (viewState !== 'IDLE') {
+      console.error(`RNCWebView invalid state encountered: ${viewState}`);
+    }
 
-  return (
-    <View style={webViewContainerStyle}>
-      {webView}
-      {otherView}
-    </View>
-  );})
+    const webViewStyles = [styles.container, styles.webView, style];
+    const webViewContainerStyle = [styles.container, containerStyle];
+
+    const decelerationRate = processDecelerationRate(decelerationRateProp);
+
+    const NativeWebView =
+      (nativeConfig?.component as typeof NativeWebViewIOS | undefined) ||
+      RNCWebView;
+
+    const webView = (
+      <NativeWebView
+        key="webViewKey"
+        {...otherProps}
+        javaScriptEnabled={javaScriptEnabled}
+        cacheEnabled={cacheEnabled}
+        useSharedProcessPool={useSharedProcessPool}
+        textInteractionEnabled={textInteractionEnabled}
+        decelerationRate={decelerationRate}
+        messagingEnabled={typeof onMessage === 'function'}
+        onLoadingError={onLoadingError}
+        onLoadingFinish={onLoadingFinish}
+        onLoadingProgress={onLoadingProgress}
+        onFileDownload={onFileDownload}
+        onLoadingStart={onLoadingStart}
+        onHttpError={onHttpError}
+        onMessage={onMessage}
+        onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        onContentProcessDidTerminate={onContentProcessDidTerminate}
+        injectedJavaScript={injectedJavaScript}
+        injectedJavaScriptBeforeContentLoaded={
+          injectedJavaScriptBeforeContentLoaded
+        }
+        injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
+        injectedJavaScriptBeforeContentLoadedForMainFrameOnly={
+          injectedJavaScriptBeforeContentLoadedForMainFrameOnly
+        }
+        dataDetectorTypes={dataDetectorTypes}
+        allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
+        allowsInlineMediaPlayback={allowsInlineMediaPlayback}
+        incognito={incognito}
+        mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
+        ref={webViewRef}
+        // TODO: find a better way to type this.
+        source={resolveAssetSource(source as ImageSourcePropType)}
+        style={webViewStyles}
+        {...nativeConfig?.props}
+      />
+    );
+
+    return (
+      <View style={webViewContainerStyle}>
+        {webView}
+        {otherView}
+      </View>
+    );
+  },
+);
 
 // no native implementation for iOS, depends only on permissions
-const isFileUploadSupported: () => Promise<boolean>
-  = async () => true;
+const isFileUploadSupported: () => Promise<boolean> = async () => true;
 
-const WebView = Object.assign(WebViewComponent, {isFileUploadSupported});
+const WebView = Object.assign(WebViewComponent, { isFileUploadSupported });
 
 export default WebView;

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -1,15 +1,15 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useImperativeHandle,
-  useRef,
-} from 'react';
-import { Image, View, NativeModules, ImageSourcePropType } from 'react-native';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import {
+  Image,
+  View,
+  NativeModules,
+  ImageSourcePropType,
+} from 'react-native';
 import invariant from 'invariant';
 
 // @ts-expect-error react-native doesn't have this type
 import codegenNativeCommandsUntyped from 'react-native/Libraries/Utilities/codegenNativeCommands';
-import RNCWebView from './WebViewNativeComponent.ios';
+import RNCWebView from "./WebViewNativeComponent.ios";
 import {
   defaultOriginWhitelist,
   defaultRenderError,
@@ -25,23 +25,11 @@ import {
 
 import styles from './WebView.styles';
 
-const codegenNativeCommands = codegenNativeCommandsUntyped as <
-  T extends {},
-  >(options: {
-    supportedCommands: (keyof T)[];
-  }) => T;
+
+const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: [
-    'goBack',
-    'goForward',
-    'reload',
-    'stopLoading',
-    'injectJavaScript',
-    'requestFocus',
-    'postMessage',
-    'loadUrl',
-  ],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl'],
 });
 
 const { resolveAssetSource } = Image;
@@ -62,202 +50,169 @@ const RNCWebViewManager = NativeModules.RNCWebViewManager as ViewManager;
 const useWarnIfChanges = <T extends unknown>(value: T, name: string) => {
   const ref = useRef(value);
   if (ref.current !== value) {
-    console.warn(
-      `Changes to property ${name} do nothing after the initial render.`,
-    );
+    console.warn(`Changes to property ${name} do nothing after the initial render.`);
     ref.current = value;
   }
-};
+}
 
-const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
-  (
-    {
-      javaScriptEnabled = true,
-      cacheEnabled = true,
-      originWhitelist = defaultOriginWhitelist,
-      useSharedProcessPool = true,
-      textInteractionEnabled = true,
-      injectedJavaScript,
-      injectedJavaScriptBeforeContentLoaded,
-      injectedJavaScriptForMainFrameOnly = true,
-      injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true,
-      startInLoadingState,
-      onNavigationStateChange,
-      onLoadStart,
-      onError,
-      onLoad,
-      onLoadEnd,
-      onLoadProgress,
-      onContentProcessDidTerminate: onContentProcessDidTerminateProp,
-      onFileDownload,
-      onHttpError: onHttpErrorProp,
-      onMessage: onMessageProp,
-      renderLoading,
-      renderError,
-      style,
-      containerStyle,
-      source,
-      nativeConfig,
-      allowsInlineMediaPlayback,
-      allowsAirPlayForMediaPlayback,
-      mediaPlaybackRequiresUserAction,
-      dataDetectorTypes,
-      incognito,
-      decelerationRate: decelerationRateProp,
-      onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
-      ...otherProps
-    },
-    ref,
+const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
+  javaScriptEnabled = true,
+  cacheEnabled = true,
+  originWhitelist = defaultOriginWhitelist,
+  useSharedProcessPool= true,
+  textInteractionEnabled= true,
+  injectedJavaScript,
+  injectedJavaScriptBeforeContentLoaded,
+  injectedJavaScriptForMainFrameOnly = true,
+  injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true,
+  startInLoadingState,
+  onNavigationStateChange,
+  onLoadStart,
+  onError,
+  onLoad,
+  onLoadEnd,
+  onLoadProgress,
+  onContentProcessDidTerminate: onContentProcessDidTerminateProp,
+  onFileDownload,
+  onHttpError: onHttpErrorProp,
+  onMessage: onMessageProp,
+  renderLoading,
+  renderError,
+  style,
+  containerStyle,
+  source,
+  nativeConfig,
+  allowsInlineMediaPlayback,
+  allowsAirPlayForMediaPlayback,
+  mediaPlaybackRequiresUserAction,
+  dataDetectorTypes,
+  incognito,
+  decelerationRate: decelerationRateProp,
+  onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
+  ...otherProps
+}, ref) => {
+  const webViewRef = useRef<NativeWebViewIOS | null>(null);
+
+  const onShouldStartLoadWithRequestCallback = useCallback((
+    shouldStart: boolean,
+    _url: string,
+    lockIdentifier = 0,
   ) => {
-    const webViewRef = useRef<NativeWebViewIOS | null>(null);
+    const viewManager
+      = (nativeConfig?.viewManager)
+      || RNCWebViewManager;
 
-    const onShouldStartLoadWithRequestCallback = useCallback(
-      (shouldStart: boolean, _url: string, lockIdentifier = 0) => {
-        const viewManager = nativeConfig?.viewManager || RNCWebViewManager;
+    viewManager.startLoadWithResult(!!shouldStart, lockIdentifier);
+  }, [nativeConfig?.viewManager]);
 
-        viewManager.startLoadWithResult(!!shouldStart, lockIdentifier);
-      },
-      [nativeConfig?.viewManager],
+  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onContentProcessDidTerminate } = useWebWiewLogic({
+    onNavigationStateChange,
+    onLoad,
+    onError,
+    onHttpErrorProp,
+    onLoadEnd,
+    onLoadProgress,
+    onLoadStart,
+    onMessageProp,
+    startInLoadingState,
+    originWhitelist,
+    onShouldStartLoadWithRequestProp,
+    onShouldStartLoadWithRequestCallback,
+    onContentProcessDidTerminateProp,
+  });
+
+  useImperativeHandle(ref, () => ({
+    goForward: () => Commands.goForward(webViewRef.current),
+    goBack: () => Commands.goBack(webViewRef.current),
+    reload: () => {
+      setViewState(
+        'LOADING',
+      ); Commands.reload(webViewRef.current)
+    },
+    stopLoading: () => Commands.stopLoading(webViewRef.current),
+    postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
+    injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
+    requestFocus: () => Commands.requestFocus(webViewRef.current),
+    getNativeWebView: () => webViewRef.current,
+  }), [setViewState, webViewRef]);
+
+
+  useWarnIfChanges(allowsInlineMediaPlayback, 'allowsInlineMediaPlayback');
+  useWarnIfChanges(allowsAirPlayForMediaPlayback, 'allowsAirPlayForMediaPlayback');
+  useWarnIfChanges(incognito, 'incognito');
+  useWarnIfChanges(mediaPlaybackRequiresUserAction, 'mediaPlaybackRequiresUserAction');
+  useWarnIfChanges(dataDetectorTypes, 'dataDetectorTypes');
+
+  let otherView = null;
+  if (viewState === 'LOADING') {
+    otherView = (renderLoading || defaultRenderLoading)();
+  } else if (viewState === 'ERROR') {
+    invariant(lastErrorEvent != null, 'lastErrorEvent expected to be non-null');
+    otherView = (renderError || defaultRenderError)(
+      lastErrorEvent.domain,
+      lastErrorEvent.code,
+      lastErrorEvent.description,
     );
+  } else if (viewState !== 'IDLE') {
+    console.error(`RNCWebView invalid state encountered: ${viewState}`);
+  }
 
-    const {
-      onLoadingStart,
-      onShouldStartLoadWithRequest,
-      onMessage,
-      viewState,
-      setViewState,
-      lastErrorEvent,
-      onHttpError,
-      onLoadingError,
-      onLoadingFinish,
-      onLoadingProgress,
-      onContentProcessDidTerminate,
-    } = useWebWiewLogic({
-      onNavigationStateChange,
-      onLoad,
-      onError,
-      onHttpErrorProp,
-      onLoadEnd,
-      onLoadProgress,
-      onLoadStart,
-      onMessageProp,
-      startInLoadingState,
-      originWhitelist,
-      onShouldStartLoadWithRequestProp,
-      onShouldStartLoadWithRequestCallback,
-      onContentProcessDidTerminateProp,
-    });
+  const webViewStyles = [styles.container, styles.webView, style];
+  const webViewContainerStyle = [styles.container, containerStyle];
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        goForward: () => Commands.goForward(webViewRef.current),
-        goBack: () => Commands.goBack(webViewRef.current),
-        reload: () => {
-          setViewState('LOADING');
-          Commands.reload(webViewRef.current);
-        },
-        stopLoading: () => Commands.stopLoading(webViewRef.current),
-        postMessage: (data: string) =>
-          Commands.postMessage(webViewRef.current, data),
-        injectJavaScript: (data: string) =>
-          Commands.injectJavaScript(webViewRef.current, data),
-        requestFocus: () => Commands.requestFocus(webViewRef.current),
-        getNativeWebView: () => webViewRef.current,
-      }),
-      [setViewState, webViewRef],
-    );
+  const decelerationRate = processDecelerationRate(decelerationRateProp);
 
-    useWarnIfChanges(allowsInlineMediaPlayback, 'allowsInlineMediaPlayback');
-    useWarnIfChanges(
-      allowsAirPlayForMediaPlayback,
-      'allowsAirPlayForMediaPlayback',
-    );
-    useWarnIfChanges(incognito, 'incognito');
-    useWarnIfChanges(
-      mediaPlaybackRequiresUserAction,
-      'mediaPlaybackRequiresUserAction',
-    );
-    useWarnIfChanges(dataDetectorTypes, 'dataDetectorTypes');
+  const NativeWebView
+  = (nativeConfig?.component as typeof NativeWebViewIOS | undefined)
+  || RNCWebView;
 
-    let otherView = null;
-    if (viewState === 'LOADING') {
-      otherView = (renderLoading || defaultRenderLoading)();
-    } else if (viewState === 'ERROR') {
-      invariant(
-        lastErrorEvent != null,
-        'lastErrorEvent expected to be non-null',
-      );
-      otherView = (renderError || defaultRenderError)(
-        lastErrorEvent.domain,
-        lastErrorEvent.code,
-        lastErrorEvent.description,
-      );
-    } else if (viewState !== 'IDLE') {
-      console.error(`RNCWebView invalid state encountered: ${viewState}`);
-    }
+  const webView = (
+    <NativeWebView
+      key="webViewKey"
+      {...otherProps}
+      javaScriptEnabled={javaScriptEnabled}
+      cacheEnabled={cacheEnabled}
+      useSharedProcessPool={useSharedProcessPool}
+      textInteractionEnabled={textInteractionEnabled}
+      decelerationRate={decelerationRate}
+      messagingEnabled={typeof onMessage === 'function'}
+      onLoadingError={onLoadingError}
+      onLoadingFinish={onLoadingFinish}
+      onLoadingProgress={onLoadingProgress}
+      onFileDownload={onFileDownload}
+      onLoadingStart={onLoadingStart}
+      onHttpError={onHttpError}
+      onMessage={onMessage}
+      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+      onContentProcessDidTerminate={onContentProcessDidTerminate}
+      injectedJavaScript={injectedJavaScript}
+      injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
+      injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
+      injectedJavaScriptBeforeContentLoadedForMainFrameOnly={injectedJavaScriptBeforeContentLoadedForMainFrameOnly}
+      dataDetectorTypes={dataDetectorTypes}
+      allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
+      allowsInlineMediaPlayback={allowsInlineMediaPlayback}
+      incognito={incognito}
+      mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
+      ref={webViewRef}
+      // TODO: find a better way to type this.
+      source={resolveAssetSource(source as ImageSourcePropType)}
+      style={webViewStyles}
+      {...nativeConfig?.props}
+    />
+  );
 
-    const webViewStyles = [styles.container, styles.webView, style];
-    const webViewContainerStyle = [styles.container, containerStyle];
-
-    const decelerationRate = processDecelerationRate(decelerationRateProp);
-
-    const NativeWebView =
-      (nativeConfig?.component as typeof NativeWebViewIOS | undefined) ||
-      RNCWebView;
-
-    const webView = (
-      <NativeWebView
-        key="webViewKey"
-        {...otherProps}
-        javaScriptEnabled={javaScriptEnabled}
-        cacheEnabled={cacheEnabled}
-        useSharedProcessPool={useSharedProcessPool}
-        textInteractionEnabled={textInteractionEnabled}
-        decelerationRate={decelerationRate}
-        messagingEnabled={typeof onMessage === 'function'}
-        onLoadingError={onLoadingError}
-        onLoadingFinish={onLoadingFinish}
-        onLoadingProgress={onLoadingProgress}
-        onFileDownload={onFileDownload}
-        onLoadingStart={onLoadingStart}
-        onHttpError={onHttpError}
-        onMessage={onMessage}
-        onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-        onContentProcessDidTerminate={onContentProcessDidTerminate}
-        injectedJavaScript={injectedJavaScript}
-        injectedJavaScriptBeforeContentLoaded={
-          injectedJavaScriptBeforeContentLoaded
-        }
-        injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
-        injectedJavaScriptBeforeContentLoadedForMainFrameOnly={
-          injectedJavaScriptBeforeContentLoadedForMainFrameOnly
-        }
-        dataDetectorTypes={dataDetectorTypes}
-        allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
-        allowsInlineMediaPlayback={allowsInlineMediaPlayback}
-        incognito={incognito}
-        mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
-        ref={webViewRef}
-        // TODO: find a better way to type this.
-        source={resolveAssetSource(source as ImageSourcePropType)}
-        style={webViewStyles}
-        {...nativeConfig?.props}
-      />
-    );
-
-    return (
-      <View style={webViewContainerStyle}>
-        {webView}
-        {otherView}
-      </View>
-    );
-  },
-);
+  return (
+    <View style={webViewContainerStyle}>
+      {webView}
+      {otherView}
+    </View>
+  );})
 
 // no native implementation for iOS, depends only on permissions
-const isFileUploadSupported: () => Promise<boolean> = async () => true;
+const isFileUploadSupported: () => Promise<boolean>
+  = async () => true;
 
-const WebView = Object.assign(WebViewComponent, { isFileUploadSupported });
+const WebView = Object.assign(WebViewComponent, {isFileUploadSupported});
 
 export default WebView;

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -113,6 +113,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
+    getNativeWebView: () => webViewRef.current,
   }), [setViewState, webViewRef]);
 
 

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -101,6 +101,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
+    getNativeWebView: () => webViewRef.current,
   }), [setViewState, webViewRef]);
 
   let otherView = null;


### PR DESCRIPTION
to allow communicating directly with webview from the native modules like so:

```objc
RCT_EXPORT_METHOD(runJS:(NSString* __nonnull)js
                  inView:(NSNumber* __nonnull)reactTag
                  withResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
  RCTUnsafeExecuteOnMainQueueSync(^{
    RCTUIManager* uiManager = [self.bridge moduleForClass:[RCTUIManager class]];
    RNCWebView* webView = (RNCWebView*)[uiManager viewForReactTag:reactTag];
    if (webView) {
      [webView injectJavaScript:js];
    }
    resolve(@"OK");
  });
}
```

I understand it's not for normal use cases, but I needed it to improve performance by not passing large data through the JS side like images.

Please refer to the background behind this work here: https://dev.to/craftzdog/how-i-improved-my-react-native-app-50x-faster-5ffi

But it stopped working with the recent webview versions because it no longer exposes the ref of the native component.
