### PR TITLE
Fix webkit issue with `bounce={false}` on iOS 16

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -426,8 +426,8 @@ RCTAutoInsetsProtocol>
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     //For UIRefreshControl to work correctly, the bounces should always be true
     _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
-    _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || bounces;
-    _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || bounces;
+    _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || _bounces;
+    _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || _bounces;
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -426,6 +426,8 @@ RCTAutoInsetsProtocol>
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     //For UIRefreshControl to work correctly, the bounces should always be true
     _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
+    _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || bounces;
+    _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || bounces;
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
@@ -1423,6 +1425,8 @@ didFinishNavigation:(WKNavigation *)navigation
   _bounces = bounces;
   //For UIRefreshControl to work correctly, the bounces should always be true
   _webView.scrollView.bounces = _pullToRefreshEnabled || bounces;
+  _webView.scrollView.alwaysBounceHorizontal = _pullToRefreshEnabled || bounces;
+  _webView.scrollView.alwaysBounceVertical = _pullToRefreshEnabled || bounces;
 }
 #endif // !TARGET_OS_OSX
 


### PR DESCRIPTION
Hey hey !

### Issue
- Since iOS 16, there is a bug where using `bounce={false}` that is related to a [webkit bug](https://developer.apple.com/forums/thread/711601)
- It was also reported here #2654

The fix suggested on the apple thread works fine 👌 

### Preview
|Before|After|
|-----|------|
|![Oct-01-2022 00-25-46](https://user-images.githubusercontent.com/17592779/193364635-269969ec-27fa-4273-aa3c-82b7229cc50a.gif)|![Oct-01-2022 00-24-54](https://user-images.githubusercontent.com/17592779/193364624-58cd6e99-e94a-45de-a077-8b5c8fded17e.gif)|