### PR TITLE
(Fix Android): Adding cookie header with case insensitive header key to android webview

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -565,6 +565,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
                 view.getSettings().setUserAgentString(headers.getString(key));
               }
             } else {
+              if (key.equalsIgnoreCase("Cookie")) {
+                CookieManager.getInstance().setCookie(url, headers.getString(key));
+              }
+              
               headerMap.put(key, headers.getString(key));
             }
           }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -566,7 +566,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
               }
             } else {
               if (key.equalsIgnoreCase("Cookie")) {
-                CookieManager.getInstance().setCookie(url, headers.getString(key));
+                URI uri = new URI(url);
+                String domain = uri.getHost();
+                CookieManager.getInstance().setCookie(domain, headers.getString(key));
               }
               
               headerMap.put(key, headers.getString(key));


### PR DESCRIPTION
Hello!

According to our tests and to a couple of issues on the issue tracker, passing the header **Cookie** from react-native, did not work on android. We were able to figure out that this is due to a case sensitivity of the header key. By adding this check of the header and adding it to the existing **CookieManager**, cookies passed in as headers started working fine on Android.

Issues found to reference this issue (there might be more): [2172](https://github.com/react-native-webview/react-native-webview/issues/2172), [1352](https://github.com/react-native-webview/react-native-webview/issues/1352)

