### PR TITLE
feat(Android): Handle RESOURCE_PROTECTED_MEDIA_ID permission

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -161,6 +161,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected RNCWebChromeClient mWebChromeClient = null;
   protected boolean mAllowsFullscreenVideo = false;
+  protected boolean mAllowsProtectedMedia = false;
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
   protected @Nullable String mDownloadingMessage = null;
@@ -670,6 +671,20 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.getSettings().setMinimumFontSize(fontSize);
   }
 
+  @ReactProp(name = "allowsProtectedMedia")
+  public void setAllowsProtectedMedia(WebView view, boolean enabled) {
+    // This variable is used to keep consistency
+    // in case a new WebChromeClient is created
+    // (eg. when mAllowsFullScreenVideo changes)
+    mAllowsProtectedMedia = enabled;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        WebChromeClient client = view.getWebChromeClient();
+        if (client != null && client instanceof RNCWebChromeClient) {
+            ((RNCWebChromeClient) client).setAllowsProtectedMedia(enabled);
+        }
+    }
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
@@ -875,8 +890,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           mReactContext.removeLifecycleEventListener(this);
         }
       };
-
-      webView.setWebChromeClient(mWebChromeClient);
     } else {
       if (mWebChromeClient != null) {
         mWebChromeClient.onHideCustomView();
@@ -888,9 +901,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
         }
       };
-
-      webView.setWebChromeClient(mWebChromeClient);
     }
+    mWebChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
+    webView.setWebChromeClient(mWebChromeClient);
   }
 
   protected static class RNCWebViewClient extends WebViewClient {
@@ -1227,6 +1240,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
 
+    // True if protected media should be allowed, false otherwise
+    protected boolean mAllowsProtectedMedia = false;
+
     public RNCWebChromeClient(ReactContext reactContext, WebView webView) {
       this.mReactContext = reactContext;
       this.mWebView = webView;
@@ -1288,9 +1304,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         } else if (requestedResource.equals(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
           androidPermission = Manifest.permission.CAMERA;
         } else if(requestedResource.equals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
-          androidPermission = PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID;
+          if (mAllowsProtectedMedia) {
+              grantedPermissions.add(requestedResource);
+          }
         }
-        // TODO: RESOURCE_MIDI_SYSEX, RESOURCE_PROTECTED_MEDIA_ID.
+        // TODO: RESOURCE_MIDI_SYSEX.
 
         if (androidPermission != null) {
           if (ContextCompat.checkSelfPermission(mReactContext, androidPermission) == PackageManager.PERMISSION_GRANTED) {
@@ -1479,6 +1497,15 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     public void setProgressChangedFilter(RNCWebView.ProgressChangedFilter filter) {
       progressChangedFilter = filter;
+    }
+
+    /**
+     * Set whether or not protected media should be allowed
+     * /!\ Setting this to false won't revoke permission already granted to the current webpage.
+     * In order to do so, you'd need to reload the page /!\
+     */
+    public void setAllowsProtectedMedia(boolean enabled) {
+        mAllowsProtectedMedia = enabled;
     }
   }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1306,6 +1306,15 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         } else if(requestedResource.equals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
           if (mAllowsProtectedMedia) {
               grantedPermissions.add(requestedResource);
+          } else {
+              /**
+               * Legacy handling (Kept in case it was working under some conditions (given Android version or something))
+               *
+               * Try to ask user to grant permission using Activity.requestPermissions
+               *
+               * Find more details here: https://github.com/react-native-webview/react-native-webview/pull/2732
+               */
+              androidPermission = PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID;
           }
         }
         // TODO: RESOURCE_MIDI_SYSEX.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -89,6 +89,7 @@ This document lays out the current public properties and methods for the React N
 - [`minimumFontSize`](Reference.md#minimumFontSize)
 - [`downloadingMessage`](Reference.md#downloadingMessage)
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
+- [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
 
 ## Methods Index
 
@@ -1591,6 +1592,15 @@ This is the message that is shown in the Toast when the webview is unable to dow
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | string | No       | Android  |
+
+### `allowsProtectedMedia`
+
+Whether or not the Webview can play media protected by DRM. Default is false.
+/!\ Setting this to false won't revoke the permission already granted to the current webpage. In order to do so, you'd have to reload the page as well. /!\
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| boolean | No       | Android  |
 
 ## Methods
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -340,6 +340,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   minimumFontSize?: number;
   downloadingMessage?: string;
   lackPermissionToDownloadMessage?: string;
+  allowsProtectedMedia?: boolean;
 }
 
 export declare type ContentInsetAdjustmentBehavior =
@@ -1119,6 +1120,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   lackPermissionToDownloadMessage?: string;
+
+  /**
+   * Boolean value to control whether webview can play media protected by DRM.
+   * Default is false.
+   * @platform android
+   */
+  allowsProtectedMedia?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
Add a new prop : allowsProtectedMedia to grant `android.webkit.resource.RESOURCE_PROTECTED_MEDIA_ID` permission to webview if set to true.

With the current implementation, Android WebViews can't play any media protected by DRM because the permission is not handled properly.

I propose an implementation where the developer can decide whether or not to allow it using a react prop `allowsProtectedMedia`. The default value is false.
The end user is not warned about this, I leave this responsibility to the developer. I believe this is acceptable as even applications such as Chrome Android do not ask for user permission, they are granted by default.

N.B: I haven't tackled the `RESOURCE_MIDI_SYSEX` permission as I don't have the proper setup to test it.

Also if this approach were to be accepted, should I leave the PR as is, or open a new one off the new arch branch?