### PR TITLE
Support File Input On Macos

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -315,6 +315,23 @@ RCTAutoInsetsProtocol>
   return nil;
 }
 
+/**
+ * Enables file input on macos, see https://developer.apple.com/documentation/webkit/wkuidelegate/1641952-webview
+ */
+#if TARGET_OS_OSX
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> *URLs))completionHandler
+{
+  NSOpenPanel *openPanel = [NSOpenPanel openPanel];
+  openPanel.allowsMultipleSelection = parameters.allowsMultipleSelection;
+  [openPanel beginSheetModalForWindow:webView.window completionHandler:^(NSInteger result) {
+    if (result == NSModalResponseOK)
+      completionHandler(openPanel.URLs);
+    else
+      completionHandler(nil);
+  }];
+}
+#endif //Target_OS_OSX
+
 - (WKWebViewConfiguration *)setUpWkWebViewConfig
 {
   WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -217,6 +217,14 @@ WebView.isFileUploadSupported().then(res => {
 
 ```
 
+##### MacOS
+
+Add read access for `User Selected File` in `Signing & Capabilities` tab under `App Sandbox`:
+
+<img width="856" alt="settings screenshot" src="https://user-images.githubusercontent.com/36531255/200541359-dde130d0-169e-4b58-8b2f-205442d76fdd.png">
+
+Note: Attempting to open a file input without this permission will crash the webview.
+
 ### Multiple Files Upload
 
 You can control **single** or **multiple** file selection by specifing the [`multiple`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple) attribute on your `input` element:

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -172,7 +172,7 @@ export default class App extends Component<Props, State> {
               onPress={() => this._changeTest('Downloads')}
             />
           )}
-          {Platform.OS === 'android' && (
+          {(Platform.OS === 'android' || Platform.OS === 'macos') && (
             <Button
               testID="testType_uploads"
               title="Uploads"


### PR DESCRIPTION
Support File Input On MacOS #2633, by implementing https://developer.apple.com/documentation/webkit/wkopenpanelparameters?language=objc

This requires `User Selected File` read permission otherwise will crash when attempting to open file input

<img width="856" alt="Screen Shot 2022-11-08 at 12 28 32" src="https://user-images.githubusercontent.com/36531255/200541359-dde130d0-169e-4b58-8b2f-205442d76fdd.png">


