### PR TITLE
chore(docs): Add info/warning about injectedJavaScriptBeforeContentLoaded for Android

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -358,7 +358,7 @@ export default class App extends Component {
 This runs the JavaScript in the `runFirst` string before the page is loaded. In this case, the value of `window.isNativeApp` will be set to true before the web code executes.
 
 > **Warning**
-> On Android, this may work, but it is not 100% reliable (see #1609 and #1099).
+> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)).
 
 By setting `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, the JavaScript injection will occur on all frames (not just the top frame) if supported for the given platform. However, although support for `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false` has been implemented for iOS and macOS, [it is not clear](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-600275750) that it is actually possible to inject JS into iframes at this point in the page lifecycle, and so relying on the expected behaviour of this prop when set to `false` is not recommended.
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -357,6 +357,9 @@ export default class App extends Component {
 
 This runs the JavaScript in the `runFirst` string before the page is loaded. In this case, the value of `window.isNativeApp` will be set to true before the web code executes.
 
+> **Warning**
+> On Android, this may work, but it is not 100% reliable (see #1609 and #1099).
+
 By setting `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, the JavaScript injection will occur on all frames (not just the top frame) if supported for the given platform. However, although support for `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false` has been implemented for iOS and macOS, [it is not clear](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-600275750) that it is actually possible to inject JS into iframes at this point in the page lifecycle, and so relying on the expected behaviour of this prop when set to `false` is not recommended.
 
 > On iOS, ~~`injectedJavaScriptBeforeContentLoaded` runs a method on WebView called `evaluateJavaScript:completionHandler:`~~ – this is no longer true as of version `8.2.0`. Instead, we use a `WKUserScript` with injection time `WKUserScriptInjectionTimeAtDocumentStart`. As a consequence, `injectedJavaScriptBeforeContentLoaded` no longer returns an evaluation value nor logs a warning to the console. In the unlikely event that your app depended upon this behaviour, please see migration steps [here](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-574919464) to retain equivalent behaviour.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -198,9 +198,12 @@ Make sure the string evaluates to a valid type (`true` works) and doesn't otherw
 
 On iOS, see [`WKUserScriptInjectionTimeAtDocumentStart`](https://developer.apple.com/documentation/webkit/wkuserscriptinjectiontime/wkuserscriptinjectiontimeatdocumentstart?language=objc)
 
-| Type   | Required | Platform   |
-| ------ | -------- | ---------- |
-| string | No       | iOS, macOS |
+> **Warning**
+> On Android, this may work, but it is not 100% reliable (see #1609 and #1099).
+
+| Type   | Required | Platform                           |
+| ------ | -------- | ---------------------------------- |
+| string | No       | iOS, macOS, Android (experimental) |
 
 To learn more, read the [Communicating between JS and Native](Guide.md#communicating-between-js-and-native) guide.
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -199,7 +199,7 @@ Make sure the string evaluates to a valid type (`true` works) and doesn't otherw
 On iOS, see [`WKUserScriptInjectionTimeAtDocumentStart`](https://developer.apple.com/documentation/webkit/wkuserscriptinjectiontime/wkuserscriptinjectiontimeatdocumentstart?language=objc)
 
 > **Warning**
-> On Android, this may work, but it is not 100% reliable (see #1609 and #1099).
+> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)).
 
 | Type   | Required | Platform                           |
 | ------ | -------- | ---------------------------------- |


### PR DESCRIPTION
Although the Reference doc currently lists this property as iOS/macOS-only, users may find that it has been implemented for Android and appears to work.... only to then be unpleasantly surprised to find that it does not work consistently.

Related to #1609 / #1099

@shirakaba if you're still around 🙂 