### PR TITLE
fix(docs): Add information that custom menu items are only available for iOS

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1508,6 +1508,10 @@ Example:
 
 An array of custom menu item objects that will be appended to the UIMenu that appears when selecting text (will appear after 'Copy' and 'Share...').  Used in tandem with `onCustomMenuSelection`
 
+| Type                                                               | Required | Platform |
+| ------------------------------------------------------------------ | -------- | -------- |
+| array of objects: {label: string, key: string}                     | No       | iOS      |
+
 Example:
 
 ```javascript

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1522,6 +1522,10 @@ Example:
 
 Function called when a custom menu item is selected.  It receives a Native event, which includes three custom keys: `label`, `key` and `selectedText`.
 
+| Type                                                               | Required | Platform |
+| ------------------------------------------------------------------ | -------- | -------- |
+| function                                                           | No       | iOS      |
+
 ```javascript
 <WebView 
   menuItems={[{ label: 'Tweet', key: 'tweet' }, { label: 'Save for later', key: 'saveForLater' }]}

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -1502,6 +1502,10 @@ Exemplo:
 
 Uma matriz de objetos de itens de menu personalizados que serão anexados ao UIMenu que aparece ao selecionar o texto (aparecerá após 'Copiar' e 'Compartilhar...'). Usado em conjunto com `onCustomMenuSelection`
 
+| Tipo                                                               | Requerido | Plataforma |
+| ------------------------------------------------------------------ | --------  | --------   |
+| array of objects: {label: string, key: string}                     | Não       | iOS        |
+
 Exemplo:
 
 ```javascript

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -1516,6 +1516,10 @@ Exemplo:
 
 Função chamada quando um item de menu personalizado é selecionado. Ele recebe um evento Nativo, que inclui três chaves personalizadas: `label`, `key` e `selectedText`.
 
+| Tipo                                                               | Requerido | Plataforma |
+| ------------------------------------------------------------------ | --------  | --------   |
+| function                                                           | Não       | iOS        |
+
 ```javascript
 <WebView 
   menuItems={[{ label: 'Tweet', key: 'tweet' }, { label: 'Guardar para depois', key: 'saveForLater' }]}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -732,6 +732,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   /**
    * An array of objects which will be added to the UIMenu controller when selecting text.
    * These will appear after a long press to select text.
+   * @platform ios
    */
   menuItems?: WebViewCustomMenuItems[];
 
@@ -740,6 +741,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * It passes a WebViewEvent with a `nativeEvent`, where custom keys are passed:
    * `customMenuKey`: the string of the menu item
    * `selectedText`: the text selected on the document
+   * @platform ios
    */
   onCustomMenuSelection?: (event: WebViewEvent) => void;
 }


### PR DESCRIPTION
This PR adds two new information tables to the following sections in the Reference.portuguese.md and in the Reference.md:

- menuItems
- onCustomMenuItemSelection

These features are currently only available on iOS which was discussed in some issues and pull requests already:

- #2523 
- #2522 

Currently there is no documentation that says that this feature is only available on iOS. As long there is no feature parity this should be stated in the documentation.