### PR TITLE
[Android] Respect "filename*" parameter in the field Content-Disposition when detecting filenames for downloading.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -33,7 +33,6 @@ import android.webkit.JavascriptInterface;
 import android.webkit.RenderProcessGoneDetail;
 import android.webkit.SslErrorHandler;
 import android.webkit.PermissionRequest;
-import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;

--- a/android/src/main/java/com/reactnativecommunity/webview/URLUtil.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/URLUtil.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactnativecommunity.webview;
+
+import android.net.Uri;
+import android.webkit.MimeTypeMap;
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class URLUtil {
+    /**
+     * Guesses canonical filename that a download would have, using
+     * the URL and contentDisposition. File extension, if not defined,
+     * is added based on the mimetype
+     * @param url Url to the content
+     * @param contentDisposition Content-Disposition HTTP header or {@code null}
+     * @param mimeType Mime-type of the content or {@code null}
+     *
+     * @return suggested filename
+     */
+    public static final String guessFileName(
+            String url,
+            @Nullable String contentDisposition,
+            @Nullable String mimeType) {
+        String filename = null;
+        String extension = null;
+
+        // If we couldn't do anything with the hint, move toward the content disposition
+        if (filename == null && contentDisposition != null) {
+            filename = parseContentDisposition(contentDisposition);
+            if (filename != null) {
+                int index = filename.lastIndexOf('/') + 1;
+                if (index > 0) {
+                    filename = filename.substring(index);
+                }
+            }
+        }
+
+        // If all the other http-related approaches failed, use the plain uri
+        if (filename == null) {
+            String decodedUrl = Uri.decode(url);
+            if (decodedUrl != null) {
+                int queryIndex = decodedUrl.indexOf('?');
+                // If there is a query string strip it, same as desktop browsers
+                if (queryIndex > 0) {
+                    decodedUrl = decodedUrl.substring(0, queryIndex);
+                }
+                if (!decodedUrl.endsWith("/")) {
+                    int index = decodedUrl.lastIndexOf('/') + 1;
+                    if (index > 0) {
+                        filename = decodedUrl.substring(index);
+                    }
+                }
+            }
+        }
+
+        // Finally, if couldn't get filename from URI, get a generic filename
+        if (filename == null) {
+            filename = "downloadfile";
+        }
+
+        // Split filename between base and extension
+        // Add an extension if filename does not have one
+        int dotIndex = filename.indexOf('.');
+        if (dotIndex < 0) {
+            if (mimeType != null) {
+                extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                if (extension != null) {
+                    extension = "." + extension;
+                }
+            }
+            if (extension == null) {
+                if (mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/")) {
+                    if (mimeType.equalsIgnoreCase("text/html")) {
+                        extension = ".html";
+                    } else {
+                        extension = ".txt";
+                    }
+                } else {
+                    extension = ".bin";
+                }
+            }
+        } else {
+            if (mimeType != null) {
+                // Compare the last segment of the extension against the mime type.
+                // If there's a mismatch, discard the entire extension.
+                int lastDotIndex = filename.lastIndexOf('.');
+                String typeFromExt = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                        filename.substring(lastDotIndex + 1));
+                if (typeFromExt != null && !typeFromExt.equalsIgnoreCase(mimeType)) {
+                    extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                    if (extension != null) {
+                        extension = "." + extension;
+                    }
+                }
+            }
+            if (extension == null) {
+                extension = filename.substring(dotIndex);
+            }
+            filename = filename.substring(0, dotIndex);
+        }
+
+        return filename + extension;
+    }
+
+    /** Regex used to parse content-disposition headers */
+    private static final Pattern CONTENT_DISPOSITION_PATTERN =
+            Pattern.compile("attachment;\\s*filename\\s*=\\s*(\"?)([^\"]*)\\1\\s*$",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Parse the Content-Disposition HTTP Header. The format of the header
+     * is defined here: http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html
+     * This header provides a filename for content that is going to be
+     * downloaded to the file system. We only support the attachment type.
+     * Note that RFC 2616 specifies the filename value must be double-quoted.
+     * Unfortunately some servers do not quote the value so to maintain
+     * consistent behaviour with other browsers, we allow unquoted values too.
+     */
+    static String parseContentDisposition(String contentDisposition) {
+        try {
+            Matcher m = CONTENT_DISPOSITION_PATTERN.matcher(contentDisposition);
+            if (m.find()) {
+                return m.group(2);
+            }
+        } catch (IllegalStateException ex) {
+             // This function is defined as returning null when it can't parse the header
+        }
+        return null;
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/URLUtil.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/URLUtil.java
@@ -20,6 +20,8 @@ import android.net.Uri;
 import android.webkit.MimeTypeMap;
 import androidx.annotation.Nullable;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -122,7 +124,7 @@ public final class URLUtil {
 
     /** Regex used to parse content-disposition headers */
     private static final Pattern CONTENT_DISPOSITION_PATTERN =
-            Pattern.compile("attachment;\\s*filename\\s*=\\s*(\"?)([^\"]*)\\1\\s*$",
+            Pattern.compile("attachment(?:;\\s*filename\\s*=\\s*(\"?)([^\"]*)\\1)?(?:;\\s*filename\\s*\\*\\s*=\\s*([^']+)'[^']*'([^']*))?\\s*$",
             Pattern.CASE_INSENSITIVE);
 
     /**
@@ -138,6 +140,13 @@ public final class URLUtil {
         try {
             Matcher m = CONTENT_DISPOSITION_PATTERN.matcher(contentDisposition);
             if (m.find()) {
+                if (m.group(3) != null && m.group(4) != null) {
+                    try {
+                        return URLDecoder.decode(m.group(4), m.group(3));
+                    } catch (UnsupportedEncodingException e) {
+                        // Skip the ext-parameter as the encoding is unsupported
+                    }
+                }
                 return m.group(2);
             }
         } catch (IllegalStateException ex) {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -165,13 +165,11 @@ export default class App extends Component<Props, State> {
             title="LocalPageLoad"
             onPress={() => this._changeTest('PageLoad')}
           />
-          {Platform.OS == 'ios' && (
-            <Button
-              testID="testType_downloads"
-              title="Downloads"
-              onPress={() => this._changeTest('Downloads')}
-            />
-          )}
+          <Button
+            testID="testType_downloads"
+            title="Downloads"
+            onPress={() => this._changeTest('Downloads')}
+          />
           {Platform.OS === 'android' && (
             <Button
               testID="testType_uploads"

--- a/example/examples/Downloads.tsx
+++ b/example/examples/Downloads.tsx
@@ -21,6 +21,8 @@ const HTML = `
   </head>
   <body>
     <a href="https://www.7-zip.org/a/7za920.zip">Example zip file download</a>
+    <br>
+    <a href="http://test.greenbytes.de/tech/tc2231/attwithisofn2231iso.asis">Download file with non-ascii filename</a>
   </body>
 </html>
 `;


### PR DESCRIPTION
According to [Section 4.3 of RFC6266](https://www.rfc-editor.org/rfc/rfc6266#section-4.3), filenames with non-ASCII characters may be specified with a `"filename*"` parameter.

This library uses `android.webkit.URLUtil.guessFileName` to detect filenames. However, the API is a simplistic implementation of the RFC, and thus cannot understand the `"filename*"` parameter, which leads to issue #2353.

I modified the implementation of `android.webkit.URLUtil` and added a naive support for the `"filename*"` parameter. Besides, I added a test case in `example/examples/Downloads.tsx` to cover this case.

NOTE that my modified implementation is still too simple, and may fail to cover [every corner case](http://test.greenbytes.de/tech/tc2231/) of the RFC. Nevertheless, since filename detection is not the focus of this library, the modification shall be valuable as long as it understands the `"filename*"` parameter in most cases.

Looking forward to your revision.