### PR TITLE
fix(iOS): setting correct default DecelerationRate for iOS to normal

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -133,6 +133,11 @@ RCTAutoInsetsProtocol>
     _autoManageStatusBarEnabled = YES;
     _contentInset = UIEdgeInsetsZero;
     _savedKeyboardDisplayRequiresUserAction = YES;
+    
+#if !TARGET_OS_OSX
+    _decelerationRate = UIScrollViewDecelerationRateNormal;
+#endif // !TARGET_OS_OSX
+
 #if !TARGET_OS_OSX
     _savedStatusBarStyle = RCTSharedApplication().statusBarStyle;
     _savedStatusBarHidden = RCTSharedApplication().statusBarHidden;

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -811,8 +811,8 @@ Example:
 
 A floating-point number that determines how quickly the scroll view decelerates after the user lifts their finger. You may also use the string shortcuts `"normal"` and `"fast"` which match the underlying iOS settings for `UIScrollViewDecelerationRateNormal` and `UIScrollViewDecelerationRateFast` respectively:
 
-- normal: 0.998
-- fast: 0.99 (the default for iOS web view)
+- normal: 0.998 (the default for iOS web view)
+- fast: 0.99 
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -37,7 +37,7 @@ const processDecelerationRate = (
   decelerationRate: DecelerationRateConstant | number | undefined,
 ) => {
   let newDecelerationRate = decelerationRate;
-  if (newDecelerationRate === 'normal') {
+  if (newDecelerationRate === 'normal' || newDecelerationRate === undefined) {
     newDecelerationRate = 0.998;
   } else if (newDecelerationRate === 'fast') {
     newDecelerationRate = 0.99;

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -37,7 +37,7 @@ const processDecelerationRate = (
   decelerationRate: DecelerationRateConstant | number | undefined,
 ) => {
   let newDecelerationRate = decelerationRate;
-  if (newDecelerationRate === 'normal' || newDecelerationRate === undefined) {
+  if (newDecelerationRate === 'normal') {
     newDecelerationRate = 0.998;
   } else if (newDecelerationRate === 'fast') {
     newDecelerationRate = 0.99;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -438,8 +438,8 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * settings for `UIScrollViewDecelerationRateNormal` and
    * `UIScrollViewDecelerationRateFast` respectively:
    *
-   *   - normal: 0.998
-   *   - fast: 0.99 (the default for iOS web view)
+   *   - normal: 0.998 (the default for iOS web view)
+   *   - fast: 0.99
    * @platform ios
    */
   decelerationRate?: DecelerationRateConstant | number;


### PR DESCRIPTION
- bugfix setting correct default DecelerationRate for iOS to normal rate if undefined. 
- updating wrong docs.

**Source:** developer.apple.com
https://developer.apple.com/documentation/uikit/uiscrollview/decelerationrate