### PR TITLE
Fix MacOS CI to XCode 14.0

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.1'
+          xcode-version: '14.0'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Node.js

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.1'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Node.js


### PR DESCRIPTION
The MacOS CI has suddenly started failing with this error:

```
/Users/runner/work/react-native-webview/react-native-webview/node_modules/react-native-macos/React/Views/RCTActivityIndicatorView.m:87:28: error: definition of 'CIFilter' must be imported from module 'CoreImage.CIFilter' before it is required
    CIFilter *colorPoly = [CIFilter filterWithName:@"CIColorPolynomial"];
                           ^
In module 'AppKit' imported from /Users/runner/work/react-native-webview/react-native-webview/example/macos/Pods/Headers/Private/React-Core/React/RCTUIKit.h:126:
In module 'CoreImage' imported from /Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSColor.h:51:
/Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreImage.framework/Headers/CIFilter.h:202:12: note: definition here is not reachable
@interface CIFilter : NSObject <NSSecureCoding, NSCopying>
           ^
```

It seems that what happened is that GitHub Actions started pulling in a newer version of XCode and there was a breaking change... (possibly a newer version of `react-native-macos` would fix this, but starting with the simpler approach as I'm not really familiar w/ `react-native-macos`)