### PR TITLE
fix(ios): add missing `ignoreSilentHardwareSwitch`

### DIFF
--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -73,6 +73,8 @@ RCT_EXPORT_VIEW_PROPERTY(allowUniversalAccessFromFileURLs, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsInlineMediaPlayback, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsAirPlayForMediaPlayback, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(mediaPlaybackRequiresUserAction, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(ignoreSilentHardwareSwitch, BOOL)
+
 #if WEBKIT_IOS_10_APIS_AVAILABLE
 RCT_EXPORT_VIEW_PROPERTY(dataDetectorTypes, WKDataDetectorTypes)
 #endif


### PR DESCRIPTION
Added missing RCT_EXPORT_VIEW_PROPERTY declaration for `ignoreSilentHardwareSwitch` in `RNCWebViewManager.m`.

`ignoreSilentHardwareSwitch` functionality was not working because of the missing prop declaration in view manager.