### PR TITLE
feat(ios): Added allowTextStyleOptions

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -81,6 +81,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
 @property (nonatomic, assign) BOOL enableApplePay;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
+@property (nonatomic, assign) BOOL allowTextStyleOptions;
 #if !TARGET_OS_OSX
 @property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
 #endif

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -119,6 +119,7 @@ RCT_EXPORT_VIEW_PROPERTY(messagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(enableApplePay, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(allowTextStyleOptions, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(menuItems, NSArray);
 RCT_EXPORT_VIEW_PROPERTY(onCustomMenuSelection, RCTDirectEventBlock)
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -90,6 +90,7 @@ This document lays out the current public properties and methods for the React N
 - [`downloadingMessage`](Reference.md#downloadingMessage)
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
+- [`allowTextStyleOptions`](Reference.md#allowTextStyleOptions)
 
 ## Methods Index
 
@@ -1604,6 +1605,14 @@ Whether or not the Webview can play media protected by DRM. Default is false.
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | boolean | No       | Android  |
+
+### `allowTextStyleOptions`
+
+When this is set to false, the menu items for selected text do not include the text style options (Bold, Italic, Underline). Default is true.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| boolean | No       | iOS  |
 
 ## Methods
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -59,8 +59,9 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   javaScriptEnabled = true,
   cacheEnabled = true,
   originWhitelist = defaultOriginWhitelist,
-  useSharedProcessPool= true,
-  textInteractionEnabled= true,
+  useSharedProcessPool = true,
+  textInteractionEnabled = true,
+  allowTextStyleOptions = true,
   injectedJavaScript,
   injectedJavaScriptBeforeContentLoaded,
   injectedJavaScriptForMainFrameOnly = true,
@@ -191,8 +192,10 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       dataDetectorTypes={dataDetectorTypes}
       allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
       allowsInlineMediaPlayback={allowsInlineMediaPlayback}
+      allowTextStyleOptions={allowTextStyleOptions}
       incognito={incognito}
       mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
+      
       ref={webViewRef}
       // TODO: find a better way to type this.
       source={resolveAssetSource(source as ImageSourcePropType)}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -387,6 +387,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   limitsNavigationsToAppBoundDomains?: boolean;
   textInteractionEnabled?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
+  allowTextStyleOptions?: boolean;
 }
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -408,6 +409,7 @@ export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
   scrollEnabled?: boolean;
   useSharedProcessPool?: boolean;
   onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
+  allowTextStyleOptions?: boolean;
 }
 
 export interface WindowsNativeWebViewProps extends CommonNativeWebViewProps {
@@ -745,6 +747,15 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   onCustomMenuSelection?: (event: WebViewEvent) => void;
+
+  /**
+   * When this is set to false, the menu items for selected text do not include the
+   * text style options (Bold, Italic, Underline).
+   * 
+   * Default is true.
+   * @platform ios
+   */
+  allowTextStyleOptions?: boolean;
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
This option makes it possible to enabled/disable the text style options on selected text.
This is useful when working with rich text editor (like Lexical) to disable certain styling using the native menu. We are currently using a `patch-package` in our app with this feature.