### PR TITLE
fix(Android): Don't crash while downloading file with % in filename

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -99,7 +99,7 @@ class RNCWebViewManagerImpl {
                 Log.w(TAG, "Unsupported URI, aborting download", e)
                 return@DownloadListener
             }
-            val fileName = URLUtil.guessFileName(url, contentDisposition, mimetype)
+            var fileName = URLUtil.guessFileName(url, contentDisposition, mimetype)
 
             // Sanitize filename by replacing invalid characters with "_"
             fileName = fileName.replace(invalidCharRegex, "_")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -29,6 +29,8 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
 
+val invalidCharRegex = "[\\\\/%\"]".toRegex()
+
 
 class RNCWebViewManagerImpl {
     companion object {
@@ -98,6 +100,10 @@ class RNCWebViewManagerImpl {
                 return@DownloadListener
             }
             val fileName = URLUtil.guessFileName(url, contentDisposition, mimetype)
+
+            // Sanitize filename by replacing invalid characters with "_"
+            fileName = fileName.replace(invalidCharRegex, "_")
+
             val downloadMessage = "Downloading $fileName"
 
             //Attempt to add cookie, if it exists

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -36,6 +36,7 @@ import com.facebook.react.modules.core.PermissionListener;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.SecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -305,7 +306,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
         try {
             dm.enqueue(mDownloadRequest);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | SecurityException e) {
             Log.w("RNCWebViewModule", "Unsupported URI, aborting download", e);
             return;
         }


### PR DESCRIPTION
We ran into an issue where react-native-webview crashed on Android 13 while downloading a file with the "%" character in its name. It is similar to https://github.com/react-native-webview/react-native-webview/issues/2428, but the fix in v11.22.2 does not prevent the crash because the exception being thrown is different. Here is the stack trace:

`Fatal Exception: java.lang.SecurityException: java.io.IOException: Invalid file path
       at android.os.Parcel.createExceptionOrNull(Parcel.java:3011)
       at android.os.Parcel.createException(Parcel.java:2995)
       at android.os.Parcel.readException(Parcel.java:2978)
       at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
       at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
       at android.content.ContentProviderProxy.insert(ContentProviderNative.java:557)
       at android.content.ContentResolver.insert(ContentResolver.java:2193)
       at android.content.ContentResolver.insert(ContentResolver.java:2155)
       at android.app.DownloadManager.enqueue(DownloadManager.java:1119)
       at com.reactnativecommunity.webview.RNCWebViewModule.downloadFile(RNCWebViewModule.java:313)
       at com.reactnativecommunity.webview.RNCWebViewManager$2.onDownloadStart(RNCWebViewManager.java:252)
       at Ea.handleMessage(chromium-TrichromeWebViewGoogle6432.aab-stable-541411734:522)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7872)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)`

This fix replaces % and a few other invalid characters in the file name with "_". This fixes the issue in our app, resulting in a successful file download.

