### PR TITLE
fix(android): Prevent libhwui crash when WebView is in ScrollView

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -130,7 +130,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         if (progressChangedFilter.isWaitingForCommandLoadUrl()) {
             return;
         }
-        int reactTag = RNCWebView.getId(webView);
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         WritableMap event = Arguments.createMap();
         event.putDouble("target", reactTag);
         event.putString("title", webView.getTitle());

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -130,15 +130,15 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         if (progressChangedFilter.isWaitingForCommandLoadUrl()) {
             return;
         }
+        int reactTag = RNCWebView.getId(webView);
         WritableMap event = Arguments.createMap();
-        event.putDouble("target", webView.getId());
+        event.putDouble("target", reactTag);
         event.putString("title", webView.getTitle());
         event.putString("url", url);
         event.putBoolean("canGoBack", webView.canGoBack());
         event.putBoolean("canGoForward", webView.canGoForward());
         event.putDouble("progress", (float) newProgress / 100);
 
-        int reactTag = webView.getId();
         UIManagerHelper.getEventDispatcherForReactTag(this.mWebView.getThemedReactContext(), reactTag).dispatchEvent(new TopLoadingProgressEvent(reactTag, event));
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -99,7 +99,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
                 ((RNCWebView) view).dispatchEvent(
                     view,
-                    new TopOpenWindowEvent(view.getId(), event)
+                    new TopOpenWindowEvent(RNCWebViewWrapper.getReactTagFromWebView(view), event)
                 );
 
                 return true;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -1,15 +1,8 @@
 package com.reactnativecommunity.webview;
 
-import androidx.annotation.Nullable;
-
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.graphics.Rect;
-import android.os.Build;
 import android.text.TextUtils;
-import android.util.AttributeSet;
-import android.util.Log;
-
 import android.view.ActionMode;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -21,33 +14,28 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.LifecycleEventListener;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.ContentSizeChangeEvent;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.EventDispatcher;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.scroll.OnScrollDispatchHelper;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.reactnativecommunity.webview.events.TopCustomMenuSelectionEvent;
-import com.reactnativecommunity.webview.events.TopLoadingProgressEvent;
 import com.reactnativecommunity.webview.events.TopMessageEvent;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -194,7 +182,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
                   selectionText = new JSONObject(selectionJson).getString("selection");
                 } catch (JSONException ignored) {}
                 wMap.putString("selectedText", selectionText);
-                dispatchEvent(RNCWebView.this, new TopCustomMenuSelectionEvent(RNCWebView.this.getId(), wMap));
+                dispatchEvent(RNCWebView.this, new TopCustomMenuSelectionEvent(RNCWebViewWrapper.getReactTagFromWebView(RNCWebView.this), wMap));
                 mode.finish();
               }
             }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -407,6 +407,9 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
    * A helper to get react tag id by given WebView
    */
   public static int getId(WebView webView) {
+    if (webView.getParent() == null) {
+      return -1;
+    }
     return ((View) webView.getParent()).getId();
   }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -143,7 +143,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
             dispatchEvent(
                     this,
                     new ContentSizeChangeEvent(
-                            RNCWebView.getId(this),
+                            RNCWebViewWrapper.getReactTagFromWebView(this),
                             w,
                             h
                     )
@@ -326,7 +326,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
                     if (mCatalystInstance != null) {
                         mWebView.sendDirectMessage("onMessage", data);
                     } else {
-                        dispatchEvent(webView, new TopMessageEvent(RNCWebView.getId(webView), data));
+                        dispatchEvent(webView, new TopMessageEvent(RNCWebViewWrapper.getReactTagFromWebView(webView), data));
                     }
                 }
             });
@@ -337,7 +337,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
             if (mCatalystInstance != null) {
                 this.sendDirectMessage("onMessage", eventData);
             } else {
-                dispatchEvent(this, new TopMessageEvent(RNCWebView.getId(this), eventData));
+                dispatchEvent(this, new TopMessageEvent(RNCWebViewWrapper.getReactTagFromWebView(this), eventData));
             }
         }
     }
@@ -365,7 +365,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
         if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
             ScrollEvent event = ScrollEvent.obtain(
-                    RNCWebView.getId(this),
+                    RNCWebViewWrapper.getReactTagFromWebView(this),
                     ScrollEventType.SCROLL,
                     x,
                     y,
@@ -382,7 +382,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
     protected void dispatchEvent(WebView webView, Event event) {
         ThemedReactContext reactContext = getThemedReactContext();
-        int reactTag = RNCWebView.getId(webView);
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag).dispatchEvent(event);
     }
 
@@ -401,16 +401,6 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
   public ThemedReactContext getThemedReactContext() {
     return (ThemedReactContext) this.getContext();
-  }
-
-  /**
-   * A helper to get react tag id by given WebView
-   */
-  public static int getId(WebView webView) {
-    if (webView.getParent() == null) {
-      return -1;
-    }
-    return ((View) webView.getParent()).getId();
   }
 
   protected class RNCWebViewBridge {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -143,7 +143,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
             dispatchEvent(
                     this,
                     new ContentSizeChangeEvent(
-                            this.getId(),
+                            RNCWebView.getId(this),
                             w,
                             h
                     )
@@ -326,7 +326,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
                     if (mCatalystInstance != null) {
                         mWebView.sendDirectMessage("onMessage", data);
                     } else {
-                        dispatchEvent(webView, new TopMessageEvent(webView.getId(), data));
+                        dispatchEvent(webView, new TopMessageEvent(RNCWebView.getId(webView), data));
                     }
                 }
             });
@@ -337,7 +337,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
             if (mCatalystInstance != null) {
                 this.sendDirectMessage("onMessage", eventData);
             } else {
-                dispatchEvent(this, new TopMessageEvent(this.getId(), eventData));
+                dispatchEvent(this, new TopMessageEvent(RNCWebView.getId(this), eventData));
             }
         }
     }
@@ -365,7 +365,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
         if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
             ScrollEvent event = ScrollEvent.obtain(
-                    this.getId(),
+                    RNCWebView.getId(this),
                     ScrollEventType.SCROLL,
                     x,
                     y,
@@ -382,7 +382,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
     protected void dispatchEvent(WebView webView, Event event) {
         ThemedReactContext reactContext = getThemedReactContext();
-        int reactTag = webView.getId();
+        int reactTag = RNCWebView.getId(webView);
         UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag).dispatchEvent(event);
     }
 
@@ -401,6 +401,13 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
   public ThemedReactContext getThemedReactContext() {
     return (ThemedReactContext) this.getContext();
+  }
+
+  /**
+   * A helper to get react tag id by given WebView
+   */
+  public static int getId(WebView webView) {
+    return ((View) webView.getParent()).getId();
   }
 
   protected class RNCWebViewBridge {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -125,7 +125,7 @@ public class RNCWebViewClient extends WebViewClient {
             FLog.w(TAG, "Couldn't use blocking synchronous call for onShouldStartLoadWithRequest due to debugging or missing Catalyst instance, falling back to old event-and-load.");
             progressChangedFilter.setWaitingForCommandLoadUrl(true);
 
-            int reactTag = RNCWebView.getId(view);
+            int reactTag = RNCWebViewWrapper.getReactTagFromWebView(view);
             UIManagerHelper.getEventDispatcherForReactTag((ReactContext) view.getContext(), reactTag).dispatchEvent(new TopShouldStartLoadWithRequestEvent(
                     reactTag,
                     createWebViewEvent(view, url)));
@@ -240,7 +240,7 @@ public class RNCWebViewClient extends WebViewClient {
         eventData.putDouble("code", errorCode);
         eventData.putString("description", description);
 
-        int reactTag = RNCWebView.getId(webView);
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(reactTag, eventData));
     }
 
@@ -257,7 +257,7 @@ public class RNCWebViewClient extends WebViewClient {
             eventData.putInt("statusCode", errorResponse.getStatusCode());
             eventData.putString("description", errorResponse.getReasonPhrase());
 
-            int reactTag = RNCWebView.getId(webView);
+            int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
             UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopHttpErrorEvent(reactTag, eventData));
         }
     }
@@ -287,7 +287,7 @@ public class RNCWebViewClient extends WebViewClient {
 
         WritableMap event = createWebViewEvent(webView, webView.getUrl());
         event.putBoolean("didCrash", detail.didCrash());
-        int reactTag = RNCWebView.getId(webView);
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopRenderProcessGoneEvent(reactTag, event));
 
         // returning false would crash the app.
@@ -295,13 +295,13 @@ public class RNCWebViewClient extends WebViewClient {
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
-        int reactTag = RNCWebView.getId(webView);
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingFinishEvent(reactTag, createWebViewEvent(webView, url)));
     }
 
     protected WritableMap createWebViewEvent(WebView webView, String url) {
         WritableMap event = Arguments.createMap();
-        event.putDouble("target", RNCWebView.getId(webView));
+        event.putDouble("target", RNCWebViewWrapper.getReactTagFromWebView(webView));
         // Don't use webView.getUrl() here, the URL isn't updated to the new value yet in callbacks
         // like onPageFinished
         event.putString("url", url);

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -125,7 +125,7 @@ public class RNCWebViewClient extends WebViewClient {
             FLog.w(TAG, "Couldn't use blocking synchronous call for onShouldStartLoadWithRequest due to debugging or missing Catalyst instance, falling back to old event-and-load.");
             progressChangedFilter.setWaitingForCommandLoadUrl(true);
 
-            int reactTag = view.getId();
+            int reactTag = RNCWebView.getId(view);
             UIManagerHelper.getEventDispatcherForReactTag((ReactContext) view.getContext(), reactTag).dispatchEvent(new TopShouldStartLoadWithRequestEvent(
                     reactTag,
                     createWebViewEvent(view, url)));
@@ -240,8 +240,8 @@ public class RNCWebViewClient extends WebViewClient {
         eventData.putDouble("code", errorCode);
         eventData.putString("description", description);
 
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(webView.getId(), eventData));
+        int reactTag = RNCWebView.getId(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(reactTag, eventData));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
@@ -257,8 +257,8 @@ public class RNCWebViewClient extends WebViewClient {
             eventData.putInt("statusCode", errorResponse.getStatusCode());
             eventData.putString("description", errorResponse.getReasonPhrase());
 
-            int reactTag = webView.getId();
-            UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopHttpErrorEvent(webView.getId(), eventData));
+            int reactTag = RNCWebView.getId(webView);
+            UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopHttpErrorEvent(reactTag, eventData));
         }
     }
 
@@ -287,21 +287,21 @@ public class RNCWebViewClient extends WebViewClient {
 
         WritableMap event = createWebViewEvent(webView, webView.getUrl());
         event.putBoolean("didCrash", detail.didCrash());
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopRenderProcessGoneEvent(webView.getId(), event));
+        int reactTag = RNCWebView.getId(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopRenderProcessGoneEvent(reactTag, event));
 
         // returning false would crash the app.
         return true;
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingFinishEvent(webView.getId(), createWebViewEvent(webView, url)));
+        int reactTag = RNCWebView.getId(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingFinishEvent(reactTag, createWebViewEvent(webView, url)));
     }
 
     protected WritableMap createWebViewEvent(WebView webView, String url) {
         WritableMap event = Arguments.createMap();
-        event.putDouble("target", webView.getId());
+        event.putDouble("target", RNCWebView.getId(webView));
         // Don't use webView.getUrl() here, the URL isn't updated to the new value yet in callbacks
         // like onPageFinished
         event.putString("url", url);

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -71,7 +71,7 @@ public class RNCWebViewClient extends WebViewClient {
       ((RNCWebView) webView).dispatchEvent(
         webView,
         new TopLoadingStartEvent(
-          webView.getId(),
+          RNCWebViewWrapper.getReactTagFromWebView(webView),
           createWebViewEvent(webView, url)));
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -1,7 +1,6 @@
 package com.reactnativecommunity.webview
 
 import android.app.DownloadManager
-import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -16,7 +15,6 @@ import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.WebSettings
 import android.webkit.WebView
-import android.widget.FrameLayout
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import com.facebook.react.bridge.ReadableArray
@@ -29,7 +27,7 @@ import org.json.JSONObject
 import java.io.UnsupportedEncodingException
 import java.net.MalformedURLException
 import java.net.URL
-import java.util.*
+import java.util.Locale
 
 val invalidCharRegex = "[\\\\/%\"]".toRegex()
 
@@ -500,12 +498,12 @@ class RNCWebViewManagerImpl {
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
-    fun setInjectedJavaScriptObject(view: RNCWebView, value: String?) {
+    fun setInjectedJavaScriptObject(viewWrapper: RNCWebViewWrapper, value: String?) {
         val view = viewWrapper.webView
         view.setInjectedJavaScriptObject(value)
     }
 
-    fun setJavaScriptCanOpenWindowsAutomatically(view: RNCWebView, value: Boolean) {
+    fun setJavaScriptCanOpenWindowsAutomatically(viewWrapper: RNCWebViewWrapper, value: Boolean) {
         val view = viewWrapper.webView
         view.settings.javaScriptCanOpenWindowsAutomatically = value
     }
@@ -619,13 +617,13 @@ class RNCWebViewManagerImpl {
         mLackPermissionToDownloadMessage = value
     }
 
-    fun setHasOnOpenWindowEvent(view: RNCWebView, value: Boolean) {
+    fun setHasOnOpenWindowEvent(viewWrapper: RNCWebViewWrapper, value: Boolean) {
         val view = viewWrapper.webView
         mHasOnOpenWindowEvent = value
         setupWebChromeClient(view)
     }
 
-    fun setMinimumFontSize(view: RNCWebView, value: Int) {
+    fun setMinimumFontSize(viewWrapper: RNCWebViewWrapper, value: Int) {
         val view = viewWrapper.webView
         view.settings.minimumFontSize = value
     }
@@ -644,12 +642,12 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMenuCustomItems(view: RNCWebView, value: ReadableArray) {
+    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray) {
         val view = viewWrapper.webView
         view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
     }
 
-    fun setNestedScrollEnabled(view: RNCWebView, value: Boolean) {
+    fun setNestedScrollEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
         val view = viewWrapper.webView
         view.nestedScrollEnabled = value
     }
@@ -701,7 +699,7 @@ class RNCWebViewManagerImpl {
         CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled)
     }
 
-    fun setWebviewDebuggingEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setWebviewDebuggingEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
         RNCWebView.setWebContentsDebuggingEnabled(enabled)
     }
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -705,20 +705,3 @@ class RNCWebViewManagerImpl {
         RNCWebView.setWebContentsDebuggingEnabled(enabled)
     }
 }
-
-/**
- * A [FrameLayout] container to hold the [RNCWebView].
- * We need this to prevent WebView crash when the WebView is out of viewport and
- * [com.facebook.react.views.view.ReactViewGroup] clips the canvas.
- * The WebView will then create an empty offscreen surface and NPE.
- */
-class RNCWebViewWrapper(context: Context, webView: RNCWebView) : FrameLayout(context) {
-  init {
-    // We make the WebView as transparent on top of the container,
-    // and let React Native sets background color for the container.
-    webView.setBackgroundColor(Color.TRANSPARENT)
-    addView(webView)
-  }
-
-  val webView: RNCWebView = getChildAt(0) as RNCWebView
-}

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -714,6 +714,9 @@ class RNCWebViewManagerImpl {
  */
 class RNCWebViewWrapper(context: Context, webView: RNCWebView) : FrameLayout(context) {
   init {
+    // We make the WebView as transparent on top of the container,
+    // and let React Native sets background color for the container.
+    webView.setBackgroundColor(Color.TRANSPARENT)
     addView(webView)
   }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.reactnativecommunity.webview
 
 import android.app.DownloadManager
+import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -15,6 +16,7 @@ import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.WebSettings
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import com.facebook.react.bridge.ReadableArray
@@ -62,12 +64,12 @@ class RNCWebViewManagerImpl {
         return RNCWebView(context)
     }
 
-    fun createViewInstance(context: ThemedReactContext): RNCWebView {
+    fun createViewInstance(context: ThemedReactContext): RNCWebViewWrapper {
       val webView = createRNCWebViewInstance(context)
       return createViewInstance(context, webView);
     }
 
-    fun createViewInstance(context: ThemedReactContext, webView: RNCWebView): RNCWebView {
+    fun createViewInstance(context: ThemedReactContext, webView: RNCWebView): RNCWebViewWrapper {
         setupWebChromeClient(webView)
         context.addLifecycleEventListener(webView)
         mWebViewConfig.configWebView(webView)
@@ -79,8 +81,8 @@ class RNCWebViewManagerImpl {
         settings.allowFileAccess = false
         settings.allowContentAccess = false
         settings.allowFileAccessFromFileURLs = false
-        setAllowUniversalAccessFromFileURLs(webView, false)
-        setMixedContentMode(webView, "never")
+        settings.allowUniversalAccessFromFileURLs = false
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
 
         // Fixes broken full-screen modals/galleries due to body height being 0.
         webView.layoutParams = ViewGroup.LayoutParams(
@@ -135,7 +137,7 @@ class RNCWebViewManagerImpl {
                 )
             }
         })
-        return webView
+        return RNCWebViewWrapper(context, webView)
     }
 
     private fun setupWebChromeClient(
@@ -223,25 +225,26 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setUserAgent(view: WebView, userAgent: String?) {
+    fun setUserAgent(viewWrapper: RNCWebViewWrapper, userAgent: String?) {
         mUserAgent = userAgent
-        setUserAgentString(view)
+        setUserAgentString(viewWrapper)
     }
 
-    fun setApplicationNameForUserAgent(view: WebView, applicationName: String?) {
+    fun setApplicationNameForUserAgent(viewWrapper: RNCWebViewWrapper, applicationName: String?) {
         when {
             applicationName != null -> {
-                val defaultUserAgent = WebSettings.getDefaultUserAgent(view.context)
+                val defaultUserAgent = WebSettings.getDefaultUserAgent(viewWrapper.webView.context)
                 mUserAgentWithApplicationName = "$defaultUserAgent $applicationName"
             }
             else -> {
                 mUserAgentWithApplicationName = null
             }
         }
-        setUserAgentString(view)
+        setUserAgentString(viewWrapper)
     }
 
-    private fun setUserAgentString(view: WebView) {
+    private fun setUserAgentString(viewWrapper: RNCWebViewWrapper) {
+        val view = viewWrapper.webView
         when {
             mUserAgent != null -> {
                 view.settings.userAgentString = mUserAgent
@@ -255,7 +258,7 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setBasicAuthCredential(view: WebView, credential: ReadableMap?) {
+    fun setBasicAuthCredential(viewWrapper: RNCWebViewWrapper, credential: ReadableMap?) {
         var basicAuthCredential: RNCBasicAuthCredential? = null
         if (credential != null) {
             if (credential.hasKey("username") && credential.hasKey("password")) {
@@ -264,10 +267,11 @@ class RNCWebViewManagerImpl {
                 basicAuthCredential = RNCBasicAuthCredential(username, password)
             }
         }
-        (view as RNCWebView).setBasicAuthCredential(basicAuthCredential)
+        viewWrapper.webView.setBasicAuthCredential(basicAuthCredential)
     }
 
-    fun onDropViewInstance(webView: RNCWebView) {
+    fun onDropViewInstance(viewWrapper: RNCWebViewWrapper) {
+        val webView = viewWrapper.webView
         webView.themedReactContext.removeLifecycleEventListener(webView)
         webView.cleanupCallbacksAndDestroy()
         webView.mWebChromeClient = null
@@ -303,7 +307,8 @@ class RNCWebViewManagerImpl {
         .build()
     }
 
-    fun receiveCommand(webView: RNCWebView, commandId: String, args: ReadableArray) {
+    fun receiveCommand(viewWrapper: RNCWebViewWrapper, commandId: String, args: ReadableArray) {
+      val webView = viewWrapper.webView
       when (commandId) {
         "goBack" -> webView.goBack()
         "goForward" -> webView.goForward()
@@ -346,7 +351,8 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMixedContentMode(view: WebView, mixedContentMode: String?) {
+    fun setMixedContentMode(viewWrapper: RNCWebViewWrapper, mixedContentMode: String?) {
+        val view = viewWrapper.webView
         if (mixedContentMode == null || "never" == mixedContentMode) {
             view.settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
         } else if ("always" == mixedContentMode) {
@@ -356,8 +362,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setAllowUniversalAccessFromFileURLs(view: WebView, allow: Boolean) {
-        view.settings.allowUniversalAccessFromFileURLs = allow
+    fun setAllowUniversalAccessFromFileURLs(viewWrapper: RNCWebViewWrapper, allow: Boolean) {
+        viewWrapper.webView.settings.allowUniversalAccessFromFileURLs = allow
     }
 
     private fun getDownloadingMessageOrDefault(): String? {
@@ -369,7 +375,8 @@ class RNCWebViewManagerImpl {
             ?: DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE
     }
 
-    fun setSource(view: RNCWebView, source: ReadableMap?, newArch: Boolean = true) {
+    fun setSource(viewWrapper: RNCWebViewWrapper, source: ReadableMap?, newArch: Boolean = true) {
+        val view = viewWrapper.webView
         if (source != null) {
             if (source.hasKey("html")) {
                 val html = source.getString("html")
@@ -442,15 +449,18 @@ class RNCWebViewManagerImpl {
         view.loadUrl(BLANK_URL)
     }
 
-    fun setMessagingModuleName(view: RNCWebView, value: String?) {
+    fun setMessagingModuleName(viewWrapper: RNCWebViewWrapper, value: String?) {
+        val view = viewWrapper.webView
         view.messagingModuleName = value
     }
 
-    fun setCacheEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setCacheEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+      val view = viewWrapper.webView
       view.settings.cacheMode = if (enabled) WebSettings.LOAD_DEFAULT else WebSettings.LOAD_NO_CACHE
     }
 
-    fun setIncognito(view: RNCWebView, enabled: Boolean) {
+    fun setIncognito(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         // Don't do anything when incognito is disabled
         if (!enabled) {
             return;
@@ -470,68 +480,84 @@ class RNCWebViewManagerImpl {
         view.settings.saveFormData = false;
     }
 
-    fun setInjectedJavaScript(view: RNCWebView, injectedJavaScript: String?) {
+    fun setInjectedJavaScript(viewWrapper: RNCWebViewWrapper, injectedJavaScript: String?) {
+        val view = viewWrapper.webView
         view.injectedJS = injectedJavaScript
     }
 
-    fun setInjectedJavaScriptBeforeContentLoaded(view: RNCWebView, value: String?) {
+    fun setInjectedJavaScriptBeforeContentLoaded(viewWrapper: RNCWebViewWrapper, value: String?) {
+        val view = viewWrapper.webView
         view.injectedJSBeforeContentLoaded = value
     }
 
-    fun setInjectedJavaScriptForMainFrameOnly(view: RNCWebView, value: Boolean) {
+    fun setInjectedJavaScriptForMainFrameOnly(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.injectedJavaScriptForMainFrameOnly = value
     }
 
-    fun setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(view: RNCWebView, value: Boolean) {
+    fun setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
     fun setInjectedJavaScriptObject(view: RNCWebView, value: String?) {
+        val view = viewWrapper.webView
         view.setInjectedJavaScriptObject(value)
     }
 
     fun setJavaScriptCanOpenWindowsAutomatically(view: RNCWebView, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.javaScriptCanOpenWindowsAutomatically = value
     }
 
-    fun setShowsVerticalScrollIndicator(view: RNCWebView, value: Boolean) {
+    fun setShowsVerticalScrollIndicator(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.isVerticalScrollBarEnabled = value
     }
 
-    fun setShowsHorizontalScrollIndicator(view: RNCWebView, value: Boolean) {
+    fun setShowsHorizontalScrollIndicator(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.isHorizontalScrollBarEnabled = value
     }
 
-    fun setMessagingEnabled(view: RNCWebView, value: Boolean) {
+    fun setMessagingEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.setMessagingEnabled(value)
     }
 
-    fun setMediaPlaybackRequiresUserAction(view: RNCWebView, value: Boolean) {
+    fun setMediaPlaybackRequiresUserAction(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.mediaPlaybackRequiresUserGesture = value
     }
 
-    fun setHasOnScroll(view: RNCWebView, value: Boolean) {
+    fun setHasOnScroll(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.setHasScrollEvent(value)
     }
 
-    fun setJavaScriptEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setJavaScriptEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         view.settings.javaScriptEnabled = enabled
     }
 
-    fun setAllowFileAccess(view: RNCWebView, allowFileAccess: Boolean) {
+    fun setAllowFileAccess(viewWrapper: RNCWebViewWrapper, allowFileAccess: Boolean) {
+        val view = viewWrapper.webView
         view.settings.allowFileAccess = allowFileAccess;
     }
 
-    fun setAllowFileAccessFromFileURLs(view: RNCWebView, value: Boolean) {
+    fun setAllowFileAccessFromFileURLs(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.allowFileAccessFromFileURLs = value;
     }
 
-    fun setAllowsFullscreenVideo(view: RNCWebView, value: Boolean) {
+    fun setAllowsFullscreenVideo(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         mAllowsFullscreenVideo = value
         setupWebChromeClient(view)
     }
 
-    fun setAndroidLayerType(view: RNCWebView, layerTypeString: String?) {
+    fun setAndroidLayerType(viewWrapper: RNCWebViewWrapper, layerTypeString: String?) {
+        val view = viewWrapper.webView
         val layerType = when (layerTypeString) {
             "hardware" -> View.LAYER_TYPE_HARDWARE
             "software" -> View.LAYER_TYPE_SOFTWARE
@@ -540,7 +566,8 @@ class RNCWebViewManagerImpl {
         view.setLayerType(layerType, null)
     }
 
-    fun setCacheMode(view: RNCWebView, cacheModeString: String?) {
+    fun setCacheMode(viewWrapper: RNCWebViewWrapper, cacheModeString: String?) {
+        val view = viewWrapper.webView
         view.settings.cacheMode = when (cacheModeString) {
             "LOAD_CACHE_ONLY" -> WebSettings.LOAD_CACHE_ONLY
             "LOAD_CACHE_ELSE_NETWORK" -> WebSettings.LOAD_CACHE_ELSE_NETWORK
@@ -550,7 +577,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setDomStorageEnabled(view: RNCWebView, value: Boolean) {
+    fun setDomStorageEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.domStorageEnabled = value
     }
 
@@ -558,7 +586,8 @@ class RNCWebViewManagerImpl {
         mDownloadingMessage = value
     }
 
-    fun setForceDarkOn(view: RNCWebView, enabled: Boolean) {
+    fun setForceDarkOn(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         // Only Android 10+ support dark mode
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
@@ -581,7 +610,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setGeolocationEnabled(view: RNCWebView, value: Boolean) {
+    fun setGeolocationEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.setGeolocationEnabled(value)
     }
 
@@ -590,15 +620,18 @@ class RNCWebViewManagerImpl {
     }
 
     fun setHasOnOpenWindowEvent(view: RNCWebView, value: Boolean) {
+        val view = viewWrapper.webView
         mHasOnOpenWindowEvent = value
         setupWebChromeClient(view)
     }
 
     fun setMinimumFontSize(view: RNCWebView, value: Int) {
+        val view = viewWrapper.webView
         view.settings.minimumFontSize = value
     }
 
-    fun setAllowsProtectedMedia(view: RNCWebView, enabled: Boolean) {
+    fun setAllowsProtectedMedia(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+      val view = viewWrapper.webView
       // This variable is used to keep consistency
       // in case a new WebChromeClient is created
       // (eg. when mAllowsFullScreenVideo changes)
@@ -612,14 +645,17 @@ class RNCWebViewManagerImpl {
     }
 
     fun setMenuCustomItems(view: RNCWebView, value: ReadableArray) {
+        val view = viewWrapper.webView
         view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
     }
 
     fun setNestedScrollEnabled(view: RNCWebView, value: Boolean) {
+        val view = viewWrapper.webView
         view.nestedScrollEnabled = value
     }
 
-    fun setOverScrollMode(view: RNCWebView, overScrollModeString: String?) {
+    fun setOverScrollMode(viewWrapper: RNCWebViewWrapper, overScrollModeString: String?) {
+        val view = viewWrapper.webView
         view.overScrollMode = when (overScrollModeString) {
             "never" -> View.OVER_SCROLL_NEVER
             "content" -> View.OVER_SCROLL_IF_CONTENT_SCROLLS
@@ -628,37 +664,58 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setSaveFormDataDisabled(view: RNCWebView, disabled: Boolean) {
+    fun setSaveFormDataDisabled(viewWrapper: RNCWebViewWrapper, disabled: Boolean) {
+        val view = viewWrapper.webView
         view.settings.saveFormData = !disabled
     }
 
-    fun setScalesPageToFit(view: RNCWebView, value: Boolean) {
+    fun setScalesPageToFit(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.loadWithOverviewMode = value
         view.settings.useWideViewPort = value
     }
 
-    fun setSetBuiltInZoomControls(view: RNCWebView, value: Boolean) {
+    fun setSetBuiltInZoomControls(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.builtInZoomControls = value
     }
 
-    fun setSetDisplayZoomControls(view: RNCWebView, value: Boolean) {
+    fun setSetDisplayZoomControls(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.displayZoomControls = value
 
     }
 
-    fun setSetSupportMultipleWindows(view: RNCWebView, value: Boolean) {
+    fun setSetSupportMultipleWindows(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.setSupportMultipleWindows(value)
     }
 
-    fun setTextZoom(view: RNCWebView, value: Int) {
+    fun setTextZoom(viewWrapper: RNCWebViewWrapper, value: Int) {
+        val view = viewWrapper.webView
         view.settings.textZoom = value
     }
 
-    fun setThirdPartyCookiesEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setThirdPartyCookiesEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled)
     }
 
     fun setWebviewDebuggingEnabled(view: RNCWebView, enabled: Boolean) {
         RNCWebView.setWebContentsDebuggingEnabled(enabled)
     }
+}
+
+/**
+ * A [FrameLayout] container to hold the [RNCWebView].
+ * We need this to prevent WebView crash when the WebView is out of viewport and
+ * [com.facebook.react.views.view.ReactViewGroup] clips the canvas.
+ * The WebView will then create an empty offscreen surface and NPE.
+ */
+class RNCWebViewWrapper(context: Context, webView: RNCWebView) : FrameLayout(context) {
+  init {
+    addView(webView)
+  }
+
+  val webView: RNCWebView = getChildAt(0) as RNCWebView
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewWrapper.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewWrapper.kt
@@ -1,0 +1,39 @@
+package com.reactnativecommunity.webview
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import android.webkit.WebView
+import android.widget.FrameLayout
+
+/**
+ * A [FrameLayout] container to hold the [RNCWebView].
+ * We need this to prevent WebView crash when the WebView is out of viewport and
+ * [com.facebook.react.views.view.ReactViewGroup] clips the canvas.
+ * The WebView will then create an empty offscreen surface and NPE.
+ */
+class RNCWebViewWrapper(context: Context, webView: RNCWebView) : FrameLayout(context) {
+  init {
+    // We make the WebView as transparent on top of the container,
+    // and let React Native sets background color for the container.
+    webView.setBackgroundColor(Color.TRANSPARENT)
+    addView(webView)
+  }
+
+  val webView: RNCWebView = getChildAt(0) as RNCWebView
+
+  companion object {
+    /**
+     * A helper to get react tag id by given WebView
+     */
+    @JvmStatic
+    fun getReactTagFromWebView(webView: WebView): Int {
+      // It is expected that the webView is enclosed by [RNCWebViewWrapper] as the first child.
+      // Therefore, it must have a parent, and the parent ID is the reactTag.
+      // In exceptional cases, such as receiving WebView messaging after the view has been unmounted,
+      // the WebView will not have a parent.
+      // In this case, we simply return -1 to indicate that it was not found.
+      return (webView.parent as? View)?.id ?: -1
+    }
+  }
+}

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -7,8 +7,8 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.RNCWebViewManagerDelegate;
@@ -33,10 +33,10 @@ import org.json.JSONObject;
 import java.util.Map;
 
 @ReactModule(name = RNCWebViewManagerImpl.NAME)
-public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
-        implements RNCWebViewManagerInterface<RNCWebView> {
+public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
+        implements RNCWebViewManagerInterface<RNCWebViewWrapper> {
 
-    private final ViewManagerDelegate<RNCWebView> mDelegate;
+    private final ViewManagerDelegate<RNCWebViewWrapper> mDelegate;
     private final RNCWebViewManagerImpl mRNCWebViewManagerImpl;
 
     public RNCWebViewManager() {
@@ -46,7 +46,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<RNCWebView> getDelegate() {
+    protected ViewManagerDelegate<RNCWebViewWrapper> getDelegate() {
         return mDelegate;
     }
 
@@ -58,129 +58,129 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @NonNull
     @Override
-    protected RNCWebView createViewInstance(@NonNull ThemedReactContext context) {
+    protected RNCWebViewWrapper createViewInstance(@NonNull ThemedReactContext context) {
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
     @Override
     @ReactProp(name = "allowFileAccess")
-    public void setAllowFileAccess(RNCWebView view, boolean value) {
+    public void setAllowFileAccess(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccess(view, value);
     }
 
     @Override
     @ReactProp(name = "allowFileAccessFromFileURLs")
-    public void setAllowFileAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowFileAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccessFromFileURLs(view, value);
 
     }
 
     @Override
     @ReactProp(name = "allowUniversalAccessFromFileURLs")
-    public void setAllowUniversalAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowUniversalAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowUniversalAccessFromFileURLs(view, value);
     }
 
     @Override
     @ReactProp(name = "allowsFullscreenVideo")
-    public void setAllowsFullscreenVideo(RNCWebView view, boolean value) {
+    public void setAllowsFullscreenVideo(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsFullscreenVideo(view, value);
     }
 
     @Override
     @ReactProp(name = "allowsProtectedMedia")
-    public void setAllowsProtectedMedia(RNCWebView view, boolean value) {
+    public void setAllowsProtectedMedia(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsProtectedMedia(view, value);
     }
 
     @Override
     @ReactProp(name = "androidLayerType")
-    public void setAndroidLayerType(RNCWebView view, @Nullable String value) {
+    public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);
     }
 
     @Override
     @ReactProp(name = "applicationNameForUserAgent")
-    public void setApplicationNameForUserAgent(RNCWebView view, @Nullable String value) {
+    public void setApplicationNameForUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setApplicationNameForUserAgent(view, value);
     }
 
     @Override
     @ReactProp(name = "basicAuthCredential")
-    public void setBasicAuthCredential(RNCWebView view, @Nullable ReadableMap value) {
+    public void setBasicAuthCredential(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setBasicAuthCredential(view, value);
     }
 
     @Override
     @ReactProp(name = "cacheEnabled")
-    public void setCacheEnabled(RNCWebView view, boolean value) {
+    public void setCacheEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setCacheEnabled(view, value);
     }
 
     @Override
     @ReactProp(name = "cacheMode")
-    public void setCacheMode(RNCWebView view, @Nullable String value) {
+    public void setCacheMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setCacheMode(view, value);
     }
 
     @Override
     @ReactProp(name = "domStorageEnabled")
-    public void setDomStorageEnabled(RNCWebView view, boolean value) {
+    public void setDomStorageEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setDomStorageEnabled(view, value);
     }
 
     @Override
     @ReactProp(name = "downloadingMessage")
-    public void setDownloadingMessage(RNCWebView view, @Nullable String value) {
+    public void setDownloadingMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setDownloadingMessage(value);
     }
 
     @Override
     @ReactProp(name = "forceDarkOn")
-    public void setForceDarkOn(RNCWebView view, boolean value) {
+    public void setForceDarkOn(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setForceDarkOn(view, value);
     }
 
     @Override
     @ReactProp(name = "geolocationEnabled")
-    public void setGeolocationEnabled(RNCWebView view, boolean value) {
+    public void setGeolocationEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setGeolocationEnabled(view, value);
     }
 
     @Override
     @ReactProp(name = "hasOnScroll")
-    public void setHasOnScroll(RNCWebView view, boolean hasScrollEvent) {
+    public void setHasOnScroll(RNCWebViewWrapper view, boolean hasScrollEvent) {
         mRNCWebViewManagerImpl.setHasOnScroll(view, hasScrollEvent);
     }
 
     @Override
     @ReactProp(name = "incognito")
-    public void setIncognito(RNCWebView view, boolean value) {
+    public void setIncognito(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setIncognito(view, value);
     }
 
     @Override
     @ReactProp(name = "injectedJavaScript")
-    public void setInjectedJavaScript(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScript(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScript(view, value);
     }
 
     @Override
     @ReactProp(name = "injectedJavaScriptBeforeContentLoaded")
-    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, value);
     }
 
     @Override
     @ReactProp(name = "injectedJavaScriptForMainFrameOnly")
-    public void setInjectedJavaScriptForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptForMainFrameOnly(view, value);
 
     }
 
     @Override
     @ReactProp(name = "injectedJavaScriptBeforeContentLoadedForMainFrameOnly")
-    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(view, value);
 
     }
@@ -192,18 +192,18 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Override
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
-    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean value) {
+    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setJavaScriptCanOpenWindowsAutomatically(view, value);
     }
 
     @ReactProp(name = "javaScriptEnabled")
-    public void setJavaScriptEnabled(RNCWebView view, boolean enabled) {
+    public void setJavaScriptEnabled(RNCWebViewWrapper view, boolean enabled) {
         mRNCWebViewManagerImpl.setJavaScriptEnabled(view, enabled);
     }
 
     @Override
     @ReactProp(name = "lackPermissionToDownloadMessage")
-    public void setLackPermissionToDownloadMessage(RNCWebView view, @Nullable String value) {
+    public void setLackPermissionToDownloadMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setLackPermissionToDownloadMessage(value);
     }
 
@@ -215,7 +215,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Override
     @ReactProp(name = "mediaPlaybackRequiresUserAction")
-    public void setMediaPlaybackRequiresUserAction(RNCWebView view, boolean value) {
+    public void setMediaPlaybackRequiresUserAction(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMediaPlaybackRequiresUserAction(view, value);
     }
 
@@ -231,97 +231,97 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Override
     @ReactProp(name = "messagingEnabled")
-    public void setMessagingEnabled(RNCWebView view, boolean value) {
+    public void setMessagingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMessagingEnabled(view, value);
     }
 
     @Override
     @ReactProp(name = "messagingModuleName")
-    public void setMessagingModuleName(RNCWebView view, @Nullable String value) {
+    public void setMessagingModuleName(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMessagingModuleName(view, value);
     }
 
     @Override
     @ReactProp(name = "minimumFontSize")
-    public void setMinimumFontSize(RNCWebView view, int value) {
+    public void setMinimumFontSize(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setMinimumFontSize(view, value);
     }
 
     @Override
     @ReactProp(name = "mixedContentMode")
-    public void setMixedContentMode(RNCWebView view, @Nullable String value) {
+    public void setMixedContentMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMixedContentMode(view, value);
     }
 
     @Override
     @ReactProp(name = "nestedScrollEnabled")
-    public void setNestedScrollEnabled(RNCWebView view, boolean value) {
+    public void setNestedScrollEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setNestedScrollEnabled(view, value);
     }
 
     @Override
     @ReactProp(name = "overScrollMode")
-    public void setOverScrollMode(RNCWebView view, @Nullable String value) {
+    public void setOverScrollMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setOverScrollMode(view, value);
     }
 
     @Override
     @ReactProp(name = "saveFormDataDisabled")
-    public void setSaveFormDataDisabled(RNCWebView view, boolean value) {
+    public void setSaveFormDataDisabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSaveFormDataDisabled(view, value);
     }
 
     @Override
     @ReactProp(name = "scalesPageToFit")
-    public void setScalesPageToFit(RNCWebView view, boolean value) {
+    public void setScalesPageToFit(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setScalesPageToFit(view, value);
     }
 
     @Override
     @ReactProp(name = "setBuiltInZoomControls")
-    public void setSetBuiltInZoomControls(RNCWebView view, boolean value) {
+    public void setSetBuiltInZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetBuiltInZoomControls(view, value);
     }
 
     @Override
     @ReactProp(name = "setDisplayZoomControls")
-    public void setSetDisplayZoomControls(RNCWebView view, boolean value) {
+    public void setSetDisplayZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetDisplayZoomControls(view, value);
     }
 
     @Override
     @ReactProp(name = "setSupportMultipleWindows")
-    public void setSetSupportMultipleWindows(RNCWebView view, boolean value) {
+    public void setSetSupportMultipleWindows(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetSupportMultipleWindows(view, value);
     }
 
     @Override
     @ReactProp(name = "showsHorizontalScrollIndicator")
-    public void setShowsHorizontalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsHorizontalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsHorizontalScrollIndicator(view, value);
     }
 
     @Override
     @ReactProp(name = "showsVerticalScrollIndicator")
-    public void setShowsVerticalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsVerticalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsVerticalScrollIndicator(view, value);
     }
 
     @Override
     @ReactProp(name = "newSource")
-    public void setNewSource(RNCWebView view, @Nullable ReadableMap value) {
+    public void setNewSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setSource(view, value, true);
     }
 
     @Override
     @ReactProp(name = "textZoom")
-    public void setTextZoom(RNCWebView view, int value) {
+    public void setTextZoom(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setTextZoom(view, value);
     }
 
     @Override
     @ReactProp(name = "thirdPartyCookiesEnabled")
-    public void setThirdPartyCookiesEnabled(RNCWebView view, boolean value) {
+    public void setThirdPartyCookiesEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setThirdPartyCookiesEnabled(view, value);
     }
 
@@ -333,130 +333,130 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     /* iOS PROPS - no implemented here */
     @Override
-    public void setAllowingReadAccessToURL(RNCWebView view, @Nullable String value) {}
+    public void setAllowingReadAccessToURL(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
-    public void setAllowsBackForwardNavigationGestures(RNCWebView view, boolean value) {}
+    public void setAllowsBackForwardNavigationGestures(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setAllowsInlineMediaPlayback(RNCWebView view, boolean value) {}
+    public void setAllowsInlineMediaPlayback(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setAllowsAirPlayForMediaPlayback(RNCWebView view, boolean value) {}
+    public void setAllowsAirPlayForMediaPlayback(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setAllowsLinkPreview(RNCWebView view, boolean value) {}
+    public void setAllowsLinkPreview(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setAutomaticallyAdjustContentInsets(RNCWebView view, boolean value) {}
+    public void setAutomaticallyAdjustContentInsets(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setAutoManageStatusBarEnabled(RNCWebView view, boolean value) {}
+    public void setAutoManageStatusBarEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setBounces(RNCWebView view, boolean value) {}
+    public void setBounces(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setContentInset(RNCWebView view, @Nullable ReadableMap value) {}
+    public void setContentInset(RNCWebViewWrapper view, @Nullable ReadableMap value) {}
 
     @Override
-    public void setContentInsetAdjustmentBehavior(RNCWebView view, @Nullable String value) {}
+    public void setContentInsetAdjustmentBehavior(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
-    public void setContentMode(RNCWebView view, @Nullable String value) {}
+    public void setContentMode(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
-    public void setDataDetectorTypes(RNCWebView view, @Nullable ReadableArray value) {}
+    public void setDataDetectorTypes(RNCWebViewWrapper view, @Nullable ReadableArray value) {}
 
     @Override
-    public void setDecelerationRate(RNCWebView view, double value) {}
+    public void setDecelerationRate(RNCWebViewWrapper view, double value) {}
 
     @Override
-    public void setDirectionalLockEnabled(RNCWebView view, boolean value) {}
+    public void setDirectionalLockEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setEnableApplePay(RNCWebView view, boolean value) {}
+    public void setEnableApplePay(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setHideKeyboardAccessoryView(RNCWebView view, boolean value) {}
+    public void setHideKeyboardAccessoryView(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setKeyboardDisplayRequiresUserAction(RNCWebView view, boolean value) {}
+    public void setKeyboardDisplayRequiresUserAction(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setPagingEnabled(RNCWebView view, boolean value) {}
+    public void setPagingEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setPullToRefreshEnabled(RNCWebView view, boolean value) {}
+    public void setPullToRefreshEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setScrollEnabled(RNCWebView view, boolean value) {}
+    public void setScrollEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setSharedCookiesEnabled(RNCWebView view, boolean value) {}
+    public void setSharedCookiesEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setUseSharedProcessPool(RNCWebView view, boolean value) {}
+    public void setUseSharedProcessPool(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setLimitsNavigationsToAppBoundDomains(RNCWebView view, boolean value) {}
+    public void setLimitsNavigationsToAppBoundDomains(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setTextInteractionEnabled(RNCWebView view, boolean value) {}
+    public void setTextInteractionEnabled(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setHasOnFileDownload(RNCWebView view, boolean value) {}
+    public void setHasOnFileDownload(RNCWebViewWrapper view, boolean value) {}
 
     @Override
-    public void setMediaCapturePermissionGrantType(RNCWebView view, @Nullable String value) {}
+    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
-    public void setFraudulentWebsiteWarningEnabled(RNCWebView view, boolean value) {}
+    public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}
     /* !iOS PROPS - no implemented here */
 
     @Override
     @ReactProp(name = "userAgent")
-    public void setUserAgent(RNCWebView view, @Nullable String value) {
+    public void setUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setUserAgent(view, value);
     }
 
     // These will never be called because we use the shared impl for now
   @Override
-  public void goBack(RNCWebView view) {
-    view.goBack();
+  public void goBack(RNCWebViewWrapper view) {
+    view.getWebView().goBack();
   }
 
   @Override
-  public void goForward(RNCWebView view) {
-    view.goForward();
+  public void goForward(RNCWebViewWrapper view) {
+    view.getWebView().goForward();
   }
 
   @Override
-  public void reload(RNCWebView view) {
-    view.reload();
+  public void reload(RNCWebViewWrapper view) {
+    view.getWebView().reload();
   }
 
   @Override
-  public void stopLoading(RNCWebView view) {
-    view.stopLoading();
+  public void stopLoading(RNCWebViewWrapper view) {
+    view.getWebView().stopLoading();
   }
 
   @Override
-  public void injectJavaScript(RNCWebView view, String javascript) {
-      view.evaluateJavascriptWithFallback(javascript);
+  public void injectJavaScript(RNCWebViewWrapper view, String javascript) {
+      view.getWebView().evaluateJavascriptWithFallback(javascript);
   }
 
   @Override
-  public void requestFocus(RNCWebView view) {
+  public void requestFocus(RNCWebViewWrapper view) {
       view.requestFocus();
   }
 
   @Override
-  public void postMessage(RNCWebView view, String data) {
+  public void postMessage(RNCWebViewWrapper view, String data) {
       try {
         JSONObject eventInitDict = new JSONObject();
         eventInitDict.put("data", data);
-        view.evaluateJavascriptWithFallback(
+        view.getWebView().evaluateJavascriptWithFallback(
           "(function () {" +
             "var event;" +
             "var data = " + eventInitDict.toString() + ";" +
@@ -475,30 +475,30 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
   }
 
   @Override
-  public void loadUrl(RNCWebView view, String url) {
-      view.loadUrl(url);
+  public void loadUrl(RNCWebViewWrapper view, String url) {
+      view.getWebView().loadUrl(url);
   }
 
   @Override
-  public void clearFormData(RNCWebView view) {
-      view.clearFormData();
+  public void clearFormData(RNCWebViewWrapper view) {
+      view.getWebView().clearFormData();
   }
 
   @Override
-  public void clearCache(RNCWebView view, boolean includeDiskFiles) {
-      view.clearCache(includeDiskFiles);
+  public void clearCache(RNCWebViewWrapper view, boolean includeDiskFiles) {
+      view.getWebView().clearCache(includeDiskFiles);
   }
 
   @Override
-  public void clearHistory(RNCWebView view) {
-      view.clearHistory();
+  public void clearHistory(RNCWebViewWrapper view) {
+      view.getWebView().clearHistory();
   }
   // !These will never be called
 
   @Override
-    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebView view) {
+    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper view) {
         // Do not register default touch emitter and let WebView implementation handle touches
-        view.setWebViewClient(new RNCWebViewClient());
+        view.getWebView().setWebViewClient(new RNCWebViewClient());
     }
 
     @Override
@@ -531,13 +531,13 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
     }
 
     @Override
-    public void receiveCommand(@NonNull RNCWebView reactWebView, String commandId, @Nullable ReadableArray args) {
+    public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
     }
 
     @Override
-    public void onDropViewInstance(@NonNull RNCWebView view) {
+    public void onDropViewInstance(@NonNull RNCWebViewWrapper view) {
         mRNCWebViewManagerImpl.onDropViewInstance(view);
         super.onDropViewInstance(view);
     }

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -186,7 +186,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @ReactProp(name = "injectedJavaScriptObject")
-    public void setInjectedJavaScriptObject(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScriptObject(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptObject(view, value);
     }
 
@@ -209,7 +209,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     @ReactProp(name = "hasOnOpenWindowEvent")
-    public void setHasOnOpenWindowEvent(RNCWebView view, boolean hasEvent) {
+    public void setHasOnOpenWindowEvent(RNCWebViewWrapper view, boolean hasEvent) {
         mRNCWebViewManagerImpl.setHasOnOpenWindowEvent(view, hasEvent);
     }
 
@@ -221,13 +221,13 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     @ReactProp(name = "menuItems")
-    public void setMenuItems(RNCWebView view, @Nullable ReadableArray items) {
+    public void setMenuItems(RNCWebViewWrapper view, @Nullable ReadableArray items) {
         mRNCWebViewManagerImpl.setMenuCustomItems(view, items);
     }
 
     @Override
     @ReactProp(name = "suppressMenuItems ")
-    public void setSuppressMenuItems(RNCWebView view, @Nullable ReadableArray items) {}
+    public void setSuppressMenuItems(RNCWebViewWrapper view, @Nullable ReadableArray items) {}
 
     @Override
     @ReactProp(name = "messagingEnabled")
@@ -327,7 +327,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     @ReactProp(name = "webviewDebuggingEnabled")
-    public void setWebviewDebuggingEnabled(RNCWebView view, boolean value) {
+    public void setWebviewDebuggingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setWebviewDebuggingEnabled(view, value);
     }
 

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -6,11 +6,9 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.reactnativecommunity.webview.events.TopCustomMenuSelectionEvent;
 import com.reactnativecommunity.webview.events.TopHttpErrorEvent;
@@ -23,16 +21,9 @@ import com.reactnativecommunity.webview.events.TopOpenWindowEvent;
 import com.reactnativecommunity.webview.events.TopRenderProcessGoneEvent;
 import com.reactnativecommunity.webview.events.TopShouldStartLoadWithRequestEvent;
 
-import android.graphics.Color;
-import android.webkit.WebChromeClient;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.Map;
-import java.util.HashMap;
 
-public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
+public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
 
     private final RNCWebViewManagerImpl mRNCWebViewManagerImpl;
 
@@ -46,113 +37,113 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @Override
-    public RNCWebView createViewInstance(ThemedReactContext context) {
+    public RNCWebViewWrapper createViewInstance(ThemedReactContext context) {
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
-    public RNCWebView createViewInstance(ThemedReactContext context, RNCWebView webView) {
+    public RNCWebViewWrapper createViewInstance(ThemedReactContext context, RNCWebView webView) {
       return mRNCWebViewManagerImpl.createViewInstance(context, webView);
     }
 
     @ReactProp(name = "allowFileAccess")
-    public void setAllowFileAccess(RNCWebView view, boolean value) {
+    public void setAllowFileAccess(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccess(view, value);
     }
 
     @ReactProp(name = "allowFileAccessFromFileURLs")
-    public void setAllowFileAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowFileAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccessFromFileURLs(view, value);
 
     }
 
     @ReactProp(name = "allowUniversalAccessFromFileURLs")
-    public void setAllowUniversalAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowUniversalAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowUniversalAccessFromFileURLs(view, value);
     }
 
     @ReactProp(name = "allowsFullscreenVideo")
-    public void setAllowsFullscreenVideo(RNCWebView view, boolean value) {
+    public void setAllowsFullscreenVideo(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsFullscreenVideo(view, value);
     }
 
     @ReactProp(name = "allowsProtectedMedia")
-    public void setAllowsProtectedMedia(RNCWebView view, boolean value) {
+    public void setAllowsProtectedMedia(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsProtectedMedia(view, value);
     }
 
     @ReactProp(name = "androidLayerType")
-    public void setAndroidLayerType(RNCWebView view, @Nullable String value) {
+    public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);
     }
 
     @ReactProp(name = "applicationNameForUserAgent")
-    public void setApplicationNameForUserAgent(RNCWebView view, @Nullable String value) {
+    public void setApplicationNameForUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setApplicationNameForUserAgent(view, value);
     }
 
     @ReactProp(name = "basicAuthCredential")
-    public void setBasicAuthCredential(RNCWebView view, @Nullable ReadableMap value) {
+    public void setBasicAuthCredential(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setBasicAuthCredential(view, value);
     }
 
     @ReactProp(name = "cacheEnabled")
-    public void setCacheEnabled(RNCWebView view, boolean value) {
+    public void setCacheEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setCacheEnabled(view, value);
     }
 
     @ReactProp(name = "cacheMode")
-    public void setCacheMode(RNCWebView view, @Nullable String value) {
+    public void setCacheMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setCacheMode(view, value);
     }
 
     @ReactProp(name = "domStorageEnabled")
-    public void setDomStorageEnabled(RNCWebView view, boolean value) {
+    public void setDomStorageEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setDomStorageEnabled(view, value);
     }
 
     @ReactProp(name = "downloadingMessage")
-    public void setDownloadingMessage(RNCWebView view, @Nullable String value) {
+    public void setDownloadingMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setDownloadingMessage(value);
     }
 
     @ReactProp(name = "forceDarkOn")
-    public void setForceDarkOn(RNCWebView view, boolean value) {
+    public void setForceDarkOn(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setForceDarkOn(view, value);
     }
 
     @ReactProp(name = "geolocationEnabled")
-    public void setGeolocationEnabled(RNCWebView view, boolean value) {
+    public void setGeolocationEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setGeolocationEnabled(view, value);
     }
 
     @ReactProp(name = "hasOnScroll")
-    public void setHasOnScroll(RNCWebView view, boolean hasScrollEvent) {
+    public void setHasOnScroll(RNCWebViewWrapper view, boolean hasScrollEvent) {
         mRNCWebViewManagerImpl.setHasOnScroll(view, hasScrollEvent);
     }
 
     @ReactProp(name = "incognito")
-    public void setIncognito(RNCWebView view, boolean value) {
+    public void setIncognito(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setIncognito(view, value);
     }
 
     @ReactProp(name = "injectedJavaScript")
-    public void setInjectedJavaScript(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScript(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScript(view, value);
     }
 
     @ReactProp(name = "injectedJavaScriptBeforeContentLoaded")
-    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, value);
     }
 
     @ReactProp(name = "injectedJavaScriptForMainFrameOnly")
-    public void setInjectedJavaScriptForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptForMainFrameOnly(view, value);
 
     }
 
     @ReactProp(name = "injectedJavaScriptBeforeContentLoadedForMainFrameOnly")
-    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(view, value);
 
     }
@@ -163,17 +154,17 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
-    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean value) {
+    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setJavaScriptCanOpenWindowsAutomatically(view, value);
     }
 
     @ReactProp(name = "javaScriptEnabled")
-    public void setJavaScriptEnabled(RNCWebView view, boolean enabled) {
+    public void setJavaScriptEnabled(RNCWebViewWrapper view, boolean enabled) {
         mRNCWebViewManagerImpl.setJavaScriptEnabled(view, enabled);
     }
 
     @ReactProp(name = "lackPermissionToDownloadMessage")
-    public void setLackPermissionToDownloadMessage(RNCWebView view, @Nullable String value) {
+    public void setLackPermissionToDownloadMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setLackPermissionToDownloadMessage(value);
     }
 
@@ -183,12 +174,12 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @ReactProp(name = "mediaPlaybackRequiresUserAction")
-    public void setMediaPlaybackRequiresUserAction(RNCWebView view, boolean value) {
+    public void setMediaPlaybackRequiresUserAction(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMediaPlaybackRequiresUserAction(view, value);
     }
 
     @ReactProp(name = "messagingEnabled")
-    public void setMessagingEnabled(RNCWebView view, boolean value) {
+    public void setMessagingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMessagingEnabled(view, value);
     }
 
@@ -198,77 +189,77 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @ReactProp(name = "messagingModuleName")
-    public void setMessagingModuleName(RNCWebView view, @Nullable String value) {
+    public void setMessagingModuleName(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMessagingModuleName(view, value);
     }
 
     @ReactProp(name = "minimumFontSize")
-    public void setMinimumFontSize(RNCWebView view, int value) {
+    public void setMinimumFontSize(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setMinimumFontSize(view, value);
     }
 
     @ReactProp(name = "mixedContentMode")
-    public void setMixedContentMode(RNCWebView view, @Nullable String value) {
+    public void setMixedContentMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMixedContentMode(view, value);
     }
 
     @ReactProp(name = "nestedScrollEnabled")
-    public void setNestedScrollEnabled(RNCWebView view, boolean value) {
+    public void setNestedScrollEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setNestedScrollEnabled(view, value);
     }
 
     @ReactProp(name = "overScrollMode")
-    public void setOverScrollMode(RNCWebView view, @Nullable String value) {
+    public void setOverScrollMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setOverScrollMode(view, value);
     }
 
     @ReactProp(name = "saveFormDataDisabled")
-    public void setSaveFormDataDisabled(RNCWebView view, boolean value) {
+    public void setSaveFormDataDisabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSaveFormDataDisabled(view, value);
     }
 
     @ReactProp(name = "scalesPageToFit")
-    public void setScalesPageToFit(RNCWebView view, boolean value) {
+    public void setScalesPageToFit(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setScalesPageToFit(view, value);
     }
 
     @ReactProp(name = "setBuiltInZoomControls")
-    public void setSetBuiltInZoomControls(RNCWebView view, boolean value) {
+    public void setSetBuiltInZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetBuiltInZoomControls(view, value);
     }
 
     @ReactProp(name = "setDisplayZoomControls")
-    public void setSetDisplayZoomControls(RNCWebView view, boolean value) {
+    public void setSetDisplayZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetDisplayZoomControls(view, value);
     }
 
     @ReactProp(name = "setSupportMultipleWindows")
-    public void setSetSupportMultipleWindows(RNCWebView view, boolean value) {
+    public void setSetSupportMultipleWindows(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetSupportMultipleWindows(view, value);
     }
 
     @ReactProp(name = "showsHorizontalScrollIndicator")
-    public void setShowsHorizontalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsHorizontalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsHorizontalScrollIndicator(view, value);
     }
 
     @ReactProp(name = "showsVerticalScrollIndicator")
-    public void setShowsVerticalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsVerticalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsVerticalScrollIndicator(view, value);
     }
 
     @ReactProp(name = "source")
-    public void setSource(RNCWebView view, @Nullable ReadableMap value) {
+    public void setSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setSource(view, value, false);
     }
 
     @ReactProp(name = "textZoom")
-    public void setTextZoom(RNCWebView view, int value) {
+    public void setTextZoom(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setTextZoom(view, value);
     }
 
     @ReactProp(name = "thirdPartyCookiesEnabled")
-    public void setThirdPartyCookiesEnabled(RNCWebView view, boolean value) {
+    public void setThirdPartyCookiesEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setThirdPartyCookiesEnabled(view, value);
     }
 
@@ -278,14 +269,14 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @ReactProp(name = "userAgent")
-    public void setUserAgent(RNCWebView view, @Nullable String value) {
+    public void setUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setUserAgent(view, value);
     }
 
     @Override
-    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebView view) {
+    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
         // Do not register default touch emitter and let WebView implementation handle touches
-        view.setWebViewClient(new RNCWebViewClient());
+        viewWrapper.getWebView().setWebViewClient(new RNCWebViewClient());
     }
 
     @Override
@@ -318,13 +309,13 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @Override
-    public void receiveCommand(@NonNull RNCWebView reactWebView, String commandId, @Nullable ReadableArray args) {
+    public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
     }
 
     @Override
-    public void onDropViewInstance(@NonNull RNCWebView view) {
+    public void onDropViewInstance(@NonNull RNCWebViewWrapper view) {
         mRNCWebViewManagerImpl.onDropViewInstance(view);
         super.onDropViewInstance(view);
     }

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -41,8 +41,8 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
-    public RNCWebViewWrapper createViewInstance(ThemedReactContext context, RNCWebView webView) {
-      return mRNCWebViewManagerImpl.createViewInstance(context, webView);
+    public RNCWebViewWrapper createViewInstance(ThemedReactContext context, RNCWebViewWrapper view) {
+      return mRNCWebViewManagerImpl.createViewInstance(context, view.getWebView());
     }
 
     @ReactProp(name = "allowFileAccess")
@@ -149,7 +149,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     }
 
     @ReactProp(name = "injectedJavaScriptObject")
-    public void setInjectedJavaScriptObject(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScriptObject(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptObject(view, value);
     }
 
@@ -169,7 +169,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     }
 
     @ReactProp(name = "hasOnOpenWindowEvent")
-    public void setHasOnOpenWindowEvent(RNCWebView view, boolean hasEvent) {
+    public void setHasOnOpenWindowEvent(RNCWebViewWrapper view, boolean hasEvent) {
         mRNCWebViewManagerImpl.setHasOnOpenWindowEvent(view, hasEvent);
     }
 
@@ -184,7 +184,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     }
 
     @ReactProp(name = "menuItems")
-    public void setMenuCustomItems(RNCWebView view, @Nullable ReadableArray items) {
+    public void setMenuCustomItems(RNCWebViewWrapper view, @Nullable ReadableArray items) {
         mRNCWebViewManagerImpl.setMenuCustomItems(view, items);
     }
 
@@ -264,7 +264,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     }
 
     @ReactProp(name = "webviewDebuggingEnabled")
-    public void setWebviewDebuggingEnabled(RNCWebView view, boolean value) {
+    public void setWebviewDebuggingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setWebviewDebuggingEnabled(view, value);
     }
 


### PR DESCRIPTION
# Why

possible solution for #2771

# How

observations:

- the crash is from https://android.googlesource.com/platform/frameworks/base/+/f05f9b960832b6272b6740721c0a4bbd1ce632c1/libs/hwui/pipeline/skia/GLFunctorDrawable.cpp#95 which looks like for WebView to draw something on offscreen buffer because it hits the view boundary.

- the `MakeRenderTarget()` returns null because ~SK_SUPPORT_GPU is undefined in skia build.~ the offscreen surface size is 0, i.e. `!imageInfo.width() || !imageInfo.height()`  I could confirm it returns null by attaching debugger. https://android.googlesource.com/platform/external/skia/+/be52e9ba4d0a3c1e27c2ac215ddb14ab2b72274b/include/core/SkSurface.h#337

- modern devices should use skia vulkan (skiavk) renderer for hwui. supposedly it will not crash.  i.e. `adb shell getprop ro.hwui.use_vulkan` returns true and `adb shell getprop debug.hwui.renderer` returns nothing.

- the call path happens only on hwui skiagl render type. it is the default setting for emulator on my mac m1. `adb shell getprop debug.hwui.renderer` returns skiagl for me.

- i could also reproduce the crash on devices by forcing hwui skiagl mode: `adb shell setprop debug.hwui.renderer skiagl`.

- from the crash stacktrace, i could see `android::uirenderer::skiapipeline::RenderNodeDrawable::forceDraw()`. it might also be a root cause where android should not call forceDraw at this point.

- since it's offscreen only, i could also reproduce the crash from a single webview example.
```jsx
<ScrollView>
  <View style={{ height: 5000, flexDirection: 'column' }}>
    <View style={{ height: 2000, backgrounColor: 'green' }} collapsible={false} />
    <WebView style={{ height: 1000 }}  source={{ html: HTML }} />
    <View style={{ height: 2000, backgrounColor: 'green' }} collapsible={false} />
  </View>
</ScrollView>
```

- tried to rewrite the above example in android native code without react-native. it works fine without crashes for me. my hypothesis is that the reason to trigger forceDraw should be somewhere in react-native. finally get the code in [ReactViewGroup](https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java#L987) which clip the canvas and it may come with side effects for webview compositing.

- then the question is "how could we create a dedicated android canvas for webview?" the answer in this pr is to wrap a webview inside a FrameLayout.

this pr basically updates the view hierachy to have

```xml
<FrameLayout>
  <WebView />
</FrameLayout>

<FrameLayout>
  <WebView />
</FrameLayout>
```

# Test Plan

- test #2771 example.
- check if there's any regression from example test cases.