### PR TITLE
feat(android): add androidDebuggingEnabled prop

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -684,6 +684,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "androidDebuggingEnabled")
+  public void setAndroidDebuggingEnabled(WebView view, boolean enabled) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      view.setWebContentsDebuggingEnabled(enabled);
+    }
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -68,7 +68,7 @@ Also, if you don't see your device in the Develop menu, and you started Safari b
 
 It's possible to debug WebView contents in the Android emulator or on a device using Chrome DevTools.
 
-1. You will need to make the following change to `MainApplication.java` to enabled web contents debugging:
+1. You will either need to make the following change to `MainApplication.java` to enabled web contents debugging:
 
 ```java
   import android.webkit.WebView;
@@ -80,6 +80,8 @@ It's possible to debug WebView contents in the Android emulator or on a device u
     WebView.setWebContentsDebuggingEnabled(true);
   }
 ```
+
+  Or enable debugging using the `androidDebuggingEnabled` prop.
 
 2. Start app with React Native WebView in Android emulator or Android device
 3. Open `chrome://inspect/#devices` on Chrome (Reference: [Remote debug Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/))

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -90,6 +90,7 @@ This document lays out the current public properties and methods for the React N
 - [`downloadingMessage`](Reference.md#downloadingMessage)
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
+- [`androidDebuggingEnabled`](Reference.md#androidDebuggingEnabled)
 
 ## Methods Index
 
@@ -1603,6 +1604,15 @@ Whether or not the Webview can play media protected by DRM. Default is false.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
+| boolean | No       | Android  |
+
+### `androidDebuggingEnabled`
+
+Boolean value to control whether web contents can be debugged or not (see [`debugging docs`](Debugging.md#android--chrome)).
+Default is false. Supported as of API level 19
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
 | boolean | No       | Android  |
 
 ## Methods

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1127,6 +1127,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   allowsProtectedMedia?: boolean;
+
+  /**
+   * Boolean value to control whether web contents can be debugged or not (see docs/Debugging.md).
+   * Default is false. Supported as of API level 19
+   * @platform android
+   */
+  androidDebuggingEnabled?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -341,6 +341,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   downloadingMessage?: string;
   lackPermissionToDownloadMessage?: string;
   allowsProtectedMedia?: boolean;
+  androidDebuggingEnabled?: boolean;
 }
 
 export declare type ContentInsetAdjustmentBehavior =


### PR DESCRIPTION
Hi!

Proposal PR to add a prop to the `Webview` to allow enabling/disabling Android debugging. Makes it a bit easier instead of having to patch the native code as currently described in the [Debugging](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Debugging.md#android--chrome) docs.

Debugging is already enabled by default in debug builds. This change should allows to have it also in release builds, as well as being able to toggle it on the fly.

Thanks for reviewing!