### PR TITLE
[NewArchBranch] Allow passing a custom RNCWebView subclass to RNCWebViewManager's createViewInstance (old architecture only)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -61,7 +61,11 @@ class RNCWebViewManagerImpl {
     }
 
     fun createViewInstance(context: ThemedReactContext): RNCWebView {
-        val webView = createRNCWebViewInstance(context)
+      val webView = createRNCWebViewInstance(context)
+      return createViewInstance(context, webView);
+    }
+
+    fun createViewInstance(context: ThemedReactContext, webView: RNCWebView): RNCWebView {
         setupWebChromeClient(webView)
         context.addLifecycleEventListener(webView)
         mWebViewConfig.configWebView(webView)

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -47,6 +47,10 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
+    public RNCWebView createViewInstance(ThemedReactContext context, RNCWebView webView) {
+      return mRNCWebViewManagerImpl.createViewInstance(context, webView);
+    }
+
     @ReactProp(name = "allowFileAccess")
     public void setAllowFileAccess(RNCWebView view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccess(view, value);

--- a/docs/Custom-Android.md
+++ b/docs/Custom-Android.md
@@ -25,8 +25,8 @@ public class CustomWebViewManager extends RNCWebViewManager {
   }
 
   @Override
-  protected RNCWebView createRNCWebViewInstance(ThemedReactContext reactContext) {
-    return new CustomWebView(reactContext);
+  protected RNCWebView createViewInstance(ThemedReactContext reactContext) {
+    return super.createViewInstance(reactContext, new CustomWebView(reactContext));
   }
 
   @Override
@@ -35,7 +35,7 @@ public class CustomWebViewManager extends RNCWebViewManager {
   }
 
   @Override
-  protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
+  protected void addEventEmitters(ThemedReactContext reactContext, RNCWebView view) {
     view.setWebViewClient(new CustomWebViewClient());
   }
 }


### PR DESCRIPTION
@Titozzz 

(as I said on Slack, I'm open to better ideas, but this seemed like the simplest way to get things working again)