### PR TITLE
Make WKWebView inspectable on platforms with inspectable flag

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -440,6 +440,13 @@ RCTAutoInsetsProtocol>
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 
+#ifdef DEBUG
+    // https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/
+    if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+      webView.inspectable = YES;
+    }
+#endif
+
     _webView.customUserAgent = _userAgent;
 
 #if !TARGET_OS_OSX

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -441,10 +441,17 @@ RCTAutoInsetsProtocol>
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 
 #ifdef DEBUG
+// We have to do both the #if check and the @available check. The first gates compilation when compiling on older
+// versions of Xcode (14.2 and lower, to be specific). The @available() checks ensure we're _running_ on a supported
+// OS.
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300 || \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400 || \
+    __TV_OS_VERSION_MAX_ALLOWED >= 160400
     // https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/
-    if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
-      webView.inspectable = YES;
+    if (@available(macos 13.3, ios 16.4, tvOS 16.4, *)) {
+        _webView.inspectable = YES;
     }
+#endif
 #endif
 
     _webView.customUserAgent = _userAgent;

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -31,7 +31,7 @@ The Android example app will built, the Metro Bundler will launch, and the examp
 #### For iOS:
 
 ```sh
-pod install --project-directory=ios
+cd example; pod install --project-directory=ios
 yarn ios
 ```
 
@@ -40,7 +40,8 @@ The iOS example app will be built, the Metro bundler will launch, and the exampl
 #### For macOS:
 
 ```sh
-pod install --project-directory=macos
+yarn add:macos
+cd example; pod install --project-directory=macos
 yarn macos
 ```
 


### PR DESCRIPTION
## Summary:

In iOS 16.4/macOS 13.3/tvOS 16.4 Apple added a new flag to WKWebView (named `isInspectable` (Swift), `inspectable` (Objective C)). This flag defaults to false which now disallows inspecting the webview.  Details here: https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/

This PR fixes the WKWebView's created in this project so that they're inspectable when the `DEBUG` flag is set.

Fixes: #2914

## Test plan:

I verified this change by installing the `react-native-webview` npm package into an existing project that I had and then applying the changes in this PR to the code in `node_modules/react-native-webview`. 

I then ran my app and navigated to one of the web views. I was able to see the web view in the Safari Debug menu and attach to it.