### PR TITLE
implement injectJavaScriptBeforeContentLoaded method

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -273,6 +273,7 @@ class RNCWebViewManagerImpl {
     val COMMAND_INJECT_JAVASCRIPT = 6
     val COMMAND_LOAD_URL = 7
     val COMMAND_FOCUS = 8
+    val COMMAND_INJECT_JAVASCRIPT_BEFORE_CONTENT_LOADED = 9
 
     // android commands
     val COMMAND_CLEAR_FORM_DATA = 1000
@@ -289,6 +290,7 @@ class RNCWebViewManagerImpl {
         .put("injectJavaScript", COMMAND_INJECT_JAVASCRIPT)
         .put("loadUrl", COMMAND_LOAD_URL)
         .put("requestFocus", COMMAND_FOCUS)
+        .put("injectJavaScriptBeforeContentLoaded", COMMAND_INJECT_JAVASCRIPT_BEFORE_CONTENT_LOADED)
         .put("clearFormData", COMMAND_CLEAR_FORM_DATA)
         .put("clearCache", COMMAND_CLEAR_CACHE)
         .put("clearHistory", COMMAND_CLEAR_HISTORY)
@@ -321,6 +323,7 @@ class RNCWebViewManagerImpl {
           throw RuntimeException(e)
         }
         "injectJavaScript" -> webView.evaluateJavascriptWithFallback(args.getString(0))
+        "injectJavaScriptBeforeContentLoaded" -> setInjectedJavaScriptBeforeContentLoaded(webView, args.getString(0))
         "loadUrl" -> {
           if (args == null) {
             throw RuntimeException("Arguments for loading an url are null!")

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -416,6 +416,11 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
   }
 
   @Override
+  public void injectJavaScriptBeforeContentLoaded(RNCWebView view, String javascript) {
+    mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, value);
+  }
+
+  @Override
   public void requestFocus(RNCWebView view) {
       view.requestFocus();
   }

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -417,7 +417,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
   @Override
   public void injectJavaScriptBeforeContentLoaded(RNCWebView view, String javascript) {
-    mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, value);
+    mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, javascript);
   }
 
   @Override

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -466,6 +466,10 @@ Class<RCTComponentViewProtocol> RNCWebViewCls(void)
     [_view injectJavaScript:javascript];
 }
 
+- (void)injectJavaScriptBeforeContentLoaded:(nonnull NSString *)javascript {
+    [_view injectJavaScriptBeforeContentLoaded:javascript];
+}
+
 - (void)loadUrl:(nonnull NSString *)url {
     // android only
 }

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -127,6 +127,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;
 - (void)postMessage:(NSString *_Nullable)message;
 - (void)injectJavaScript:(NSString *_Nullable)script;
+- (void)injectJavaScriptBeforeContentLoaded:(NSString *_Nullable)script;
 - (void)goForward;
 - (void)goBack;
 - (void)reload;

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1394,6 +1394,11 @@ didFinishNavigation:(WKNavigation *)navigation
   [self evaluateJS: script thenCall: nil];
 }
 
+- (void)injectJavaScriptBeforeContentLoaded:(NSString *)script
+{
+  [self setInjectedJavaScriptBeforeContentLoaded: script];
+}
+
 - (void)goForward
 {
   [_webView goForward];

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -203,6 +203,7 @@ QUICK_RCT_EXPORT_COMMAND_METHOD(requestFocus)
 
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(postMessage, message:(NSString *)message, message)
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(injectJavaScript, script:(NSString *)script, script)
+QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(injectJavaScriptBeforeContentLoaded, script:(NSString *)script, script)
 
 RCT_EXPORT_METHOD(shouldStartLoadWithLockIdentifier:(BOOL)shouldStart
                                         lockIdentifier:(double)lockIdentifier)

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -31,6 +31,7 @@ The Android example app will built, the Metro Bundler will launch, and the examp
 #### For iOS:
 
 ```sh
+cd example
 pod install --project-directory=ios
 yarn ios
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,12 +25,17 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
     /**
      * Stop loading the current page.
      */
-    stopLoading(): void;
+    stopLoading: () => void;
 
     /**
      * Executes the JavaScript string.
      */
     injectJavaScript: (script: string) => void;
+
+    /**
+     * Sets the JavaScript to be injected when the webpage loads.
+     */
+    injectJavaScriptBeforeContentLoaded: (script: string) => void;
 
     /**
      * Focuses on WebView redered page.

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -253,6 +253,7 @@ export interface NativeCommands {
   reload: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   stopLoading: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   injectJavaScript: (viewRef: React.ElementRef<HostComponent<NativeProps>>, javascript: string) => void;
+  injectJavaScriptBeforeContentLoaded: (viewRef: React.ElementRef<HostComponent<NativeProps>>, javascript: string) => void;
   requestFocus: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   postMessage: (viewRef: React.ElementRef<HostComponent<NativeProps>>, data: string) => void;
   // Android Only
@@ -264,7 +265,7 @@ export interface NativeCommands {
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl', 'clearFormData', 'clearCache', 'clearHistory'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'injectJavaScriptBeforeContentLoaded', 'requestFocus', 'postMessage', 'loadUrl', 'clearFormData', 'clearCache', 'clearHistory'],
 });
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -109,6 +109,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     stopLoading: () => webViewRef.current && Commands.stopLoading(webViewRef.current),
     postMessage: (data: string) => webViewRef.current && Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => webViewRef.current && Commands.injectJavaScript(webViewRef.current, data),
+    injectJavaScriptBeforeContentLoaded: (data: string) => webViewRef.current && Commands.injectJavaScriptBeforeContentLoaded(webViewRef.current, data),
     requestFocus: () => webViewRef.current && Commands.requestFocus(webViewRef.current),
     clearFormData: () => webViewRef.current && Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => webViewRef.current && Commands.clearCache(webViewRef.current, includeDiskFiles),

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -123,6 +123,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     stopLoading: () => webViewRef.current && Commands.stopLoading(webViewRef.current),
     postMessage: (data: string) => webViewRef.current && Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => webViewRef.current && Commands.injectJavaScript(webViewRef.current, data),
+    injectJavaScriptBeforeContentLoaded: (data: string) => webViewRef.current && Commands.injectJavaScriptBeforeContentLoaded(webViewRef.current, data),
     requestFocus: () => webViewRef.current && Commands.requestFocus(webViewRef.current),
   }), [setViewState, webViewRef]);
 

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -23,7 +23,7 @@ import {
 import styles from './WebView.styles';
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'injectJavaScriptBeforeContentLoaded', 'requestFocus', 'postMessage', 'loadUrl'],
 });
 
 const { resolveAssetSource } = Image;
@@ -101,6 +101,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
     stopLoading: () => Commands.stopLoading(webViewRef.current),
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
+    injectJavaScriptBeforeContentLoaded: (data: string) => Commands.injectJavaScriptBeforeContentLoaded(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
   }), [setViewState, webViewRef]);
 

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -29,7 +29,7 @@ import {
 import styles from './WebView.styles';
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'injectJavaScriptBeforeContentLoaded', 'requestFocus', 'postMessage', 'loadUrl'],
 });
 const { resolveAssetSource } = Image;
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -20,6 +20,7 @@ type WebViewCommands =
   | 'stopLoading'
   | 'postMessage'
   | 'injectJavaScript'
+  | 'injectJavaScriptBeforeContentLoaded'
   | 'loadUrl'
   | 'requestFocus';
 


### PR DESCRIPTION
Supports iOS, Android, and macOS.

Use case: We're injecting a token into the webview, but when the token nears it's expiration we refresh it and reload the page. `injectJavaScript` is insufficient as the code is lost when the page is reloaded. `injectedJavaScriptBeforeContentLoaded` prop changes appear to be ignored. This new method allows us to set the new token in the webview before reloading, ensuring it will be available the instant the page finishes loading.