### PR TITLE
Android injectJavaScriptObject

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -219,7 +219,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         }
     }
 
-    public void injectJSObject(String obj) {
+    public void injectJavaScriptObject(String obj) {
         if (getSettings().getJavaScriptEnabled()) {
             WebView webView = this;
             webView.addJavascriptInterface(new JsObject(obj), "injectedObject");

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -37,6 +37,15 @@ import com.reactnativecommunity.webview.events.TopMessageEvent;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
+ class JsObject {
+    protected String value;
+    public JsObject(String newValue) {
+        value = newValue;
+    }
+    @JavascriptInterface
+    public String toString() { return value; }
+ }
+
 public class RNCWebView extends WebView implements LifecycleEventListener {
     protected @Nullable
     String injectedJS;
@@ -207,6 +216,13 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
                 injectedJSBeforeContentLoaded != null &&
                 !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
             evaluateJavascriptWithFallback("(function() {\n" + injectedJSBeforeContentLoaded + ";\n})();");
+        }
+    }
+
+    public void injectJSObject(String obj) {
+        if (getSettings().getJavaScriptEnabled()) {
+            WebView webView = this;
+            webView.addJavascriptInterface(new JsObject(obj), "injectedObject");
         }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -478,7 +478,7 @@ class RNCWebViewManagerImpl {
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
-    fun setInjectJavaScriptObject(view: RNCWebView, value: String?) {
+    fun setInjectedJavaScriptObject(view: RNCWebView, value: String?) {
         view.injectJavaScriptObject(value)
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -478,8 +478,8 @@ class RNCWebViewManagerImpl {
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
-    fun setInjectJSObject(view: RNCWebView, value: String?) {
-        view.injectJSObject(value)
+    fun setInjectJavaScriptObject(view: RNCWebView, value: String?) {
+        view.injectJavaScriptObject(value)
     }
 
     fun setJavaScriptCanOpenWindowsAutomatically(view: RNCWebView, value: Boolean) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -478,6 +478,10 @@ class RNCWebViewManagerImpl {
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
+    fun setInjectJSObject(view: RNCWebView, value: String?) {
+        view.injectJSObject(value)
+    }
+
     fun setJavaScriptCanOpenWindowsAutomatically(view: RNCWebView, value: Boolean) {
         view.settings.javaScriptCanOpenWindowsAutomatically = value
     }

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -181,6 +181,11 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     }
 
+    @ReactProp(name = "injectJSObject")
+    public void setInjectJSObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectJSObject(view, value);
+    }
+
     @Override
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
     public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean value) {

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -182,8 +182,8 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
     }
 
     @ReactProp(name = "injectJavaScriptObject")
-    public void setInjectJavaScriptObject(RNCWebView view, @Nullable String value) {
-        mRNCWebViewManagerImpl.setInjectJavaScriptObject(view, value);
+    public void setInjectedJavaScriptObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectedJavaScriptObject(view, value);
     }
 
     @Override

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -181,9 +181,9 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     }
 
-    @ReactProp(name = "injectJSObject")
-    public void setInjectJSObject(RNCWebView view, @Nullable String value) {
-        mRNCWebViewManagerImpl.setInjectJSObject(view, value);
+    @ReactProp(name = "injectJavaScriptObject")
+    public void setInjectJavaScriptObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectJavaScriptObject(view, value);
     }
 
     @Override

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -154,7 +154,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
     }
 
-    @ReactProp(name = "avaOcriptbject")
+    @ReactProp(name = "injectJavaScriptObject")
     public void setInjectJavaScriptObject(RNCWebView view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectJavaScriptObject(view, value);
     }

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -155,8 +155,8 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @ReactProp(name = "injectJavaScriptObject")
-    public void setInjectJavaScriptObject(RNCWebView view, @Nullable String value) {
-        mRNCWebViewManagerImpl.setInjectJavaScriptObject(view, value);
+    public void setInjectedJavaScriptObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectedJavaScriptObject(view, value);
     }
 
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -154,9 +154,9 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
     }
 
-    @ReactProp(name = "injectJSObject")
-    public void setInjectJSObject(RNCWebView view, @Nullable String value) {
-        mRNCWebViewManagerImpl.setInjectJSObject(view, value);
+    @ReactProp(name = "avaOcriptbject")
+    public void setInjectJavaScriptObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectJavaScriptObject(view, value);
     }
 
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -154,6 +154,11 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
     }
 
+    @ReactProp(name = "injectJSObject")
+    public void setInjectJSObject(RNCWebView view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectJSObject(view, value);
+    }
+
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
     public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean value) {
         mRNCWebViewManagerImpl.setJavaScriptCanOpenWindowsAutomatically(view, value);

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -415,6 +415,10 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
         }
     }
 #endif
+
+    if (oldViewProps.injectedJavaScriptBeforeContentLoaded != newViewProps.injectedJavaScriptBeforeContentLoaded) {
+        [_view setInjectedJavaScriptBeforeContentLoaded: RCTNSStringFromString(newViewProps.injectedJavaScriptBeforeContentLoaded)];
+    }
     
     NSMutableDictionary* source = [[NSMutableDictionary alloc] init];
     if (!newViewProps.newSource.uri.empty()) {

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -415,10 +415,6 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
         }
     }
 #endif
-
-    if (oldViewProps.injectedJavaScriptBeforeContentLoaded != newViewProps.injectedJavaScriptBeforeContentLoaded) {
-        [_view setInjectedJavaScriptBeforeContentLoaded: RCTNSStringFromString(newViewProps.injectedJavaScriptBeforeContentLoaded)];
-    }
     
     NSMutableDictionary* source = [[NSMutableDictionary alloc] init];
     if (!newViewProps.newSource.uri.empty()) {

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -375,16 +375,16 @@ By setting `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, the J
 > Note on Android Compatibility: For applications targeting `Build.VERSION_CODES.N` or later, JavaScript state from an empty WebView is no longer persisted across navigations like `loadUrl(java.lang.String)`. For example, global variables and functions defined before calling `loadUrl(java.lang.String)` will not exist in the loaded page. Applications should use the Android Native API `addJavascriptInterface(Object, String)` instead to persist JavaScript objects across navigations.
 
 
-#### the `injectJavaScriptObject` prop (Android Only)
+#### The `injectJavaScriptObject` prop (Android Only)
 
-Due to the Android race condition mentioned above, this more reliable prop was added. While you cannot execute arbitrary JavaScript, you can make any JS object available to the JS run in the webview prior to the page load completing.
+Due to the Android race condition mentioned above, this more reliable prop was added. While you cannot execute arbitrary JavaScript, you can make an arbitrary JS object available to the JS run in the webview prior to the page load completing.
 
 ```html
 <html>
   <head>
     <script>
       window.onload = (event) => {
-        document.getElementById('output').innerHTML = JSON.parse(injectedObject.toString()).authToken;
+        document.getElementById('output').innerHTML = JSON.parse(window.RNCWebViewBridge.injectedObject()).customValue;
       }
     </script>
   </head>
@@ -394,7 +394,7 @@ Due to the Android race condition mentioned above, this more reliable prop was a
 </html>
 ```
 
-Note: `injectedObject.toString()` returns the JSON encoded object passed in to `injectJavaScriptObject`. It must be passed to `JSON.parse` before it's properties can be accessed.
+Note: `RNCWebViewBridge.injectedObject()` returns the JSON encoded object passed in to `injectJavaScriptObject`. It must be passed to `JSON.parse` before it's properties can be accessed.
 
 ```jsx
 import React, { Component } from 'react';

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -366,13 +366,56 @@ export default class App extends Component {
 This runs the JavaScript in the `runFirst` string before the page is loaded. In this case, the value of `window.isNativeApp` will be set to true before the web code executes.
 
 > **Warning**
-> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)).
+> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)). Consider using `injectJavaScriptObject` instead.
 
 By setting `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, the JavaScript injection will occur on all frames (not just the top frame) if supported for the given platform. However, although support for `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false` has been implemented for iOS and macOS, [it is not clear](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-600275750) that it is actually possible to inject JS into iframes at this point in the page lifecycle, and so relying on the expected behaviour of this prop when set to `false` is not recommended.
 
 > On iOS, ~~`injectedJavaScriptBeforeContentLoaded` runs a method on WebView called `evaluateJavaScript:completionHandler:`~~ – this is no longer true as of version `8.2.0`. Instead, we use a `WKUserScript` with injection time `WKUserScriptInjectionTimeAtDocumentStart`. As a consequence, `injectedJavaScriptBeforeContentLoaded` no longer returns an evaluation value nor logs a warning to the console. In the unlikely event that your app depended upon this behaviour, please see migration steps [here](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-574919464) to retain equivalent behaviour.
 > On Android, `injectedJavaScript` runs a method on the Android WebView called `evaluateJavascriptWithFallback`
 > Note on Android Compatibility: For applications targeting `Build.VERSION_CODES.N` or later, JavaScript state from an empty WebView is no longer persisted across navigations like `loadUrl(java.lang.String)`. For example, global variables and functions defined before calling `loadUrl(java.lang.String)` will not exist in the loaded page. Applications should use the Android Native API `addJavascriptInterface(Object, String)` instead to persist JavaScript objects across navigations.
+
+
+#### the `injectJavaScriptObject` prop (Android Only)
+
+Due to the Android race condition mentioned above, this more reliable prop was added. While you cannot execute arbitrary JavaScript, you can make any JS object available to the JS run in the webview prior to the page load completing.
+
+```html
+<html>
+  <head>
+    <script>
+      window.onload = (event) => {
+        document.getElementById('output').innerHTML = JSON.parse(injectedObject.toString()).authToken;
+      }
+    </script>
+  </head>
+  <body>
+    <p id="output">undefined</p>
+  </body>
+</html>
+```
+
+Note: `injectedObject.toString()` returns the JSON encoded object passed in to `injectJavaScriptObject`. It must be passed to `JSON.parse` before it's properties can be accessed.
+
+```jsx
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+export default class App extends Component {
+  render() {
+    return (
+      <View style={{ flex: 1 }}>
+        <WebView
+          source={{
+            html: HTML
+          }}
+          injectJavaScriptObject={{ authToken: 'myAuthToken' }}
+        />
+      </View>
+    );
+  }
+}
+```
 
 #### The `injectJavaScript` method
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -257,12 +257,14 @@ Inject any JavaScript object into the webview so it is available to the JS runni
 
 Example:
 
-Set an auth token to be used in JavaScript.
+Set a value to be used in JavaScript.
+
+Note: Any value in the object will be accessible to *all* frames of the webpage. If sensitive values are present please ensure that you have a strict Content Security Policy set up to avoid data leaking.
 
 ```jsx
 <WebView
   source={{ uri: 'https://reactnative.dev' }}
-  injectJavaScriptObject={{ authToken: 'myAuthToken' }}
+  injectJavaScriptObject={{ customValue: 'myCustomValue' }}
 />;
 ```
 
@@ -271,7 +273,7 @@ Set an auth token to be used in JavaScript.
   <head>
     <script>
       window.onload = (event) => {
-        const authToken = JSON.parse(injectedObject.toString()).authToken;
+        const customValue = JSON.parse(window.RNCWebViewBridge.injectedObject()).customValue;
         ...
       }
     </script>

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -197,7 +197,7 @@ Make sure the string evaluates to a valid type (`true` works) and doesn't otherw
 On iOS, see [`WKUserScriptInjectionTimeAtDocumentStart`](https://developer.apple.com/documentation/webkit/wkuserscriptinjectiontime/wkuserscriptinjectiontimeatdocumentstart?language=objc)
 
 > **Warning**
-> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)).
+> On Android, this may work, but it is not 100% reliable (see [#1609](https://github.com/react-native-webview/react-native-webview/issues/1609) and [#1099](https://github.com/react-native-webview/react-native-webview/pull/1099)). Consider `injectJavaScriptObject` instead.
 
 | Type   | Required | Platform                           |
 | ------ | -------- | ---------------------------------- |
@@ -244,6 +244,40 @@ If `false`, (only supported on iOS and macOS), loads it into all frames (e.g. if
 | Type | Required | Platform                                          |
 | ---- | -------- | ------------------------------------------------- |
 | bool | No       | iOS and macOS (only `true` supported for Android) |
+
+---
+
+### `injectJavaScriptObject`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Inject any JavaScript object into the webview so it is available to the JS running on the page.
+
+| Type | Required | Platform                                          |
+| ---- | -------- | ------------------------------------------------- |
+| obj | No       | Android only |
+
+Example:
+
+Set an auth token to be used in JavaScript.
+
+```jsx
+<WebView
+  source={{ uri: 'https://reactnative.dev' }}
+  injectJavaScriptObject={{ authToken: 'myAuthToken' }}
+/>;
+```
+
+```html
+<html>
+  <head>
+    <script>
+      window.onload = (event) => {
+        const authToken = JSON.parse(injectedObject.toString()).authToken;
+        ...
+      }
+    </script>
+  </head>
+</html>
+```
 
 ---
 

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -162,7 +162,7 @@ export interface NativeProps extends ViewProps {
   thirdPartyCookiesEnabled?: boolean;
   // Workaround to watch if listener if defined
   hasOnScroll?: boolean;
-  injectJSObject?: string;
+  injectJavaScriptObject?: string;
   // !Android only
 
   // iOS only

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -162,6 +162,7 @@ export interface NativeProps extends ViewProps {
   thirdPartyCookiesEnabled?: boolean;
   // Workaround to watch if listener if defined
   hasOnScroll?: boolean;
+  injectJSObject?: string;
   // !Android only
 
   // iOS only

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -64,6 +64,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   source,
   nativeConfig,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
+  injectJSObject,
   ...otherProps
 }, ref) => {
   const messagingModuleName = useRef<string>(`WebViewMessageHandler${uniqueRef += 1}`).current;
@@ -204,6 +205,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     setBuiltInZoomControls={setBuiltInZoomControls}
     setDisplayZoomControls={setDisplayZoomControls}
     nestedScrollEnabled={nestedScrollEnabled}
+    injectJSObject={JSON.stringify(injectJSObject)}
     {...nativeConfig?.props}
   />
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -64,7 +64,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   source,
   nativeConfig,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
-  injectJSObject,
+  injectJavaScriptObject,
   ...otherProps
 }, ref) => {
   const messagingModuleName = useRef<string>(`WebViewMessageHandler${uniqueRef += 1}`).current;
@@ -205,7 +205,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     setBuiltInZoomControls={setBuiltInZoomControls}
     setDisplayZoomControls={setDisplayZoomControls}
     nestedScrollEnabled={nestedScrollEnabled}
-    injectJSObject={JSON.stringify(injectJSObject)}
+    injectJavaScriptObject={JSON.stringify(injectJavaScriptObject)}
     {...nativeConfig?.props}
   />
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1219,4 +1219,9 @@ export interface WebViewSharedProps extends ViewProps {
    * An object that specifies the credentials of a user to be used for basic authentication.
    */
   basicAuthCredential?: BasicAuthCredential;
+
+  /**
+   * Inject a JSON object to be accessed via JavaScript in the WebView.
+   */
+  injectJSObject?: object;
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1221,7 +1221,7 @@ export interface WebViewSharedProps extends ViewProps {
   basicAuthCredential?: BasicAuthCredential;
 
   /**
-   * Inject a JSON object to be accessed via JavaScript in the WebView.
+   * Inject a JavaScript object to be accessed as a JSON string via JavaScript in the WebView.
    */
-  injectJSObject?: object;
+  injectJavaScriptObject?: object;
 }


### PR DESCRIPTION
I've added an injectJavaScriptObject prop for Android that allows passing any object from the JSX/TSX through the native code and into the browser. In my testing it was consistently available before the webpage loaded, unlike injectedJavaScriptBeforeContentLoaded on Android. I'm open to adjusting the naming, etc.

Usage:
```tsx
<WebView
    injectJavaScriptObject={{authToken: 'myValue'}}
/>
```

```js
<script>
    window.onload = (event) => {
        JSON.parse(injectedObject.toString()).authToken;
    }
</script>
```

My Java-foo is not all that fantastic, so I was not able to figure out how to bypass the `.toString()` requirement and just have the contents be available directly, but open to suggestions.

Thanks to @morganick for assisting.