### PR TITLE
feat(macos, ios) Allow to autoselect client certificate

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -394,6 +394,9 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebView view, boolean value) {}
+
+    @Override
+    public void setAutoSelectClientCertificateEnabled(RNCWebView view, boolean value) {}
     /* !iOS PROPS - no implemented here */
 
     @Override

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -293,6 +293,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(useSharedProcessPool)
     REMAP_WEBVIEW_STRING_PROP(userAgent)
     REMAP_WEBVIEW_PROP(sharedCookiesEnabled)
+    REMAP_WEBVIEW_PROP(autoSelectClientCertificateEnabled)
     #if !TARGET_OS_OSX
     REMAP_WEBVIEW_PROP(decelerationRate)
     #endif // !TARGET_OS_OSX

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -66,6 +66,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL injectedJavaScriptBeforeContentLoadedForMainFrameOnly;
 @property (nonatomic, assign) BOOL scrollEnabled;
 @property (nonatomic, assign) BOOL sharedCookiesEnabled;
+@property (nonatomic, assign) BOOL autoSelectClientCertificateEnabled;
 @property (nonatomic, assign) BOOL autoManageStatusBarEnabled;
 @property (nonatomic, assign) BOOL pagingEnabled;
 @property (nonatomic, assign) CGFloat decelerationRate;

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -84,6 +84,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(autoSelectClientCertificateEnabled, BOOL)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -207,6 +207,7 @@ export interface NativeProps extends ViewProps {
   // Workaround to watch if listener if defined
   hasOnFileDownload?: boolean;
   fraudulentWebsiteWarningEnabled?: boolean;
+  autoSelectClientCertificateEnabled?: boolean;
   // !iOS only
 
   allowFileAccessFromFileURLs?: boolean;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -327,6 +327,7 @@ export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowsAirPlayForMediaPlayback?: boolean;
   allowsLinkPreview?: boolean;
   automaticallyAdjustContentInsets?: boolean;
+  autoSelectClientCertificateEnabled?: boolean;
   bounces?: boolean;
   contentInset?: ContentInsetProp;
   contentInsetAdjustmentBehavior?: ContentInsetAdjustmentBehavior;
@@ -570,6 +571,18 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   allowUniversalAccessFromFileURLs?: boolean;
+
+  /**
+   * A Boolean value indicating whether auto-selection of the client
+   * certificate is enabled or not. If auto-selection is enabled,
+   * the client certificate selection will be based on the acceptable
+   * certificate-issuing authorities requested from the server.
+   * If multiple certificates are available, the first one will be selected.
+   *
+   * The default value is `false`.
+   * @platform ios
+   */
+  autoSelectClientCertificateEnabled?: boolean;
 
   /**
    * Function that is invoked when the WebKit WebView content process gets terminated.
@@ -839,6 +852,18 @@ export interface MacOSWebViewProps extends WebViewSharedProps {
    * @platform macos
    */
   allowUniversalAccessFromFileURLs?: boolean;
+
+  /**
+   * A Boolean value indicating whether auto-selection of the client
+   * certificate is enabled or not. If auto-selection is enabled,
+   * the client certificate selection will be based on the acceptable
+   * certificate-issuing authorities requested from the server.
+   * If multiple certificates are available, the first one will be selected.
+   *
+   * The default value is `false`.
+   * @platform macos
+   */
+   autoSelectClientCertificateEnabled?: boolean;
 
   /**
    * Function that is invoked when the WebKit WebView content process gets terminated.


### PR DESCRIPTION
WKWebView does not have a certificate picker, and there's no way to autoselect a certificate based on the requested certificate-issuing authorities.
With new flag we will be able to enable the auto-selection of certificates based on distinguishedNames. If there are multiple certificates that pass the filter, the first one will be selected.
