### PR TITLE
fix(issue #3001 )

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -436,9 +436,16 @@ RCTAutoInsetsProtocol>
   return wkWebViewConfig;
 }
 
+// react-native-mac os does not support didMoveToSuperView https://github.com/microsoft/react-native-macos/blob/main/React/Base/RCTUIKit.h#L388
+#if !TARGET_OS_OSX
 - (void)didMoveToSuperview
 {
   if (_webView == nil) {
+#else
+- (void)didMoveToWindow
+{
+  if (self.window != nil && _webView == nil) {
+#endif // !TARGET_OS_OSX
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     [self setBackgroundColor: _savedBackgroundColor];


### PR DESCRIPTION
After this [commit](https://github.com/react-native-webview/react-native-webview/commit/40c98078939d486d95c27ce83bb2f378e1d13dd6), the macOS WebView was broken because react-native-macos does not support the didMoveToSuperview [functionality](https://github.com/microsoft/react-native-macos/blob/main/React/Base/RCTUIKit.h#L388).


