### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,7 @@ if (isNewArchitectureEnabled()) {
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "com.reactnativecommunity.webview"
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,8 +43,31 @@ if (isNewArchitectureEnabled()) {
 }
 apply plugin: 'kotlin-android'
 
+def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+def shouldUseNameSpace = agpVersion >= 7
+def PACKAGE_PROP = "package=\"com.reactnativecommunity.webview\""
+def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
+def manifestContent = manifestOutFile.getText()
+if(shouldUseNameSpace){
+      manifestContent = manifestContent.replaceAll(
+        PACKAGE_PROP,
+        ''
+    )  
+} else {
+    if(!manifestContent.contains("$PACKAGE_PROP")){
+        manifestContent = manifestContent.replace(
+            '<manifest',
+            "<manifest $PACKAGE_PROP "
+        )
+    }
+}
+manifestContent.replaceAll("  ", " ")
+manifestOutFile.write(manifestContent)
+
 android {
-    namespace = "com.reactnativecommunity.webview"
+    if(shouldUseNameSpace){
+        namespace = "com.reactnativecommunity.webview"
+    }
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.reactnativecommunity.webview">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
     <provider

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.reactnativecommunity.webview">
 
   <application>
     <provider


### PR DESCRIPTION
# Summary
Starting from React Native v0.73 , all libraries will need to be updated with these two one-liners due to Android Gradle Plugin upgrade
[discussions-671](https://github.com/react-native-community/discussions-and-proposals/issues/671)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |