### PR TITLE
Update gradle.properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeWebView_kotlinVersion=1.6.0
+ReactNativeWebView_kotlinVersion=1.6.20
 ReactNativeWebView_webkitVersion=1.4.0
 ReactNativeWebView_compileSdkVersion=31
 ReactNativeWebView_targetSdkVersion=31


### PR DESCRIPTION
the Android Gradle plugin supports only kotlin-android-extensions Gradle plugin version 1.6.20 and higher.
The following dependencies do not satisfy the required version:
project ':react-native-webview' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0


when we use react-native-webview along with react-native-camera-kit, it's fails the build.