### PR TITLE
Update debugging instructions

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -51,6 +51,7 @@ It's possible to debug WebView contents in the iOS simulator or on a device usin
 
 #### Steps:
 
+1. Mark the WebView as being "inspectable" using the [`webviewDebuggingEnabled`](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#webviewDebuggingEnabled) prop
 1. Open Safari Preferences -> "Advanced" tab -> enable checkbox "Show Develop menu in menu bar"
 2. Start app with React Native WebView in iOS simulator or iOS device
 3. Safari -> Develop -> [device name] -> [app name] -> [url - title]
@@ -68,19 +69,7 @@ Also, if you don't see your device in the Develop menu, and you started Safari b
 
 It's possible to debug WebView contents in the Android emulator or on a device using Chrome DevTools.
 
-1. You will need to make the following change to `MainApplication.java` to enabled web contents debugging:
-
-```java
-  import android.webkit.WebView;
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-	  ...
-    WebView.setWebContentsDebuggingEnabled(true);
-  }
-```
-
+1. You will need to set the [`webviewDebuggingEnabled`](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#webviewDebuggingEnabled) prop on the WebView
 2. Start app with React Native WebView in Android emulator or Android device
 3. Open `chrome://inspect/#devices` on Chrome (Reference: [Remote debug Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/))
 4. Select your device on the left and select "Inspect" on the WebView contents you'd like to inspect


### PR DESCRIPTION
A new `webviewDebuggingEnabled` prop has been added in https://github.com/react-native-webview/react-native-webview/pull/2937. However, the debugging instructions were still mentioning the old ways:
- Android: `setWebContentsDebuggingEnabled`
- iOS: not working on iOS 16.4+

I updated the relevant parts of the instructions to mention the new prop.