### PR TITLE
feat: add support for onUrlRejected prop

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -57,6 +57,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   onHttpError: onHttpErrorProp,
   onRenderProcessGone: onRenderProcessGoneProp,
   onMessage: onMessageProp,
+  onUrlRejected: onUrlRejectedProp,
   renderLoading,
   renderError,
   style,
@@ -93,6 +94,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     originWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
+    onUrlRejectedProp,
   })
 
   useImperativeHandle(ref, () => ({

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -69,6 +69,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   onFileDownload,
   onHttpError: onHttpErrorProp,
   onMessage: onMessageProp,
+  onUrlRejected: onUrlRejectedProp,
   renderLoading,
   renderError,
   style,
@@ -108,6 +109,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
     onContentProcessDidTerminateProp,
+    onUrlRejectedProp,
   });
 
   useImperativeHandle(ref, () => ({

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -52,6 +52,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
   onLoadProgress,
   onHttpError: onHttpErrorProp,
   onMessage: onMessageProp,
+  onUrlRejected: onUrlRejectedProp,
   renderLoading,
   renderError,
   style,
@@ -88,6 +89,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
     originWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
+    onUrlRejectedProp,
   });
 
   useImperativeHandle(ref, () => ({

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -45,6 +45,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   onLoadProgress,
   onHttpError: onHttpErrorProp,
   onMessage: onMessageProp,
+  onUrlRejected: onUrlRejectedProp,
   renderLoading,
   renderError,
   style,
@@ -84,7 +85,8 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
     originWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
-  })
+    onUrlRejectedProp,
+  });
 
   useImperativeHandle(ref, () => ({
     goForward: () => Commands.goForward(webViewRef.current),

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -259,6 +259,10 @@ export type OnShouldStartLoadWithRequest = (
   event: ShouldStartLoadRequest,
 ) => boolean;
 
+export type OnUrlRejectedCallback = (
+  url: string,
+) => void;
+
 export interface BasicAuthCredential {
   /**
    * A username used for basic authentication.
@@ -1232,4 +1236,8 @@ export interface WebViewSharedProps extends ViewProps {
    * Enables WebView remote debugging using Chrome (Android) or Safari (iOS).
    */
   webviewDebuggingEnabled?: boolean;
+  /**
+   * Optional function that allows custom handling of any urls that are not whitelisted
+   */
+  onUrlRejected?: (url: string) => void;
 }


### PR DESCRIPTION
Make it possible to override how rejected urls are handled. 
Example use case: When a link is opened in a webview and it should open a native screen, be downloaded or silently rejected.