### PR TITLE
fix: Revert to didMoveToWindow #2930

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -436,16 +436,9 @@ RCTAutoInsetsProtocol>
   return wkWebViewConfig;
 }
 
-// react-native-mac os does not support didMoveToSuperView https://github.com/microsoft/react-native-macos/blob/main/React/Base/RCTUIKit.h#L388
-#if !TARGET_OS_OSX
-- (void)didMoveToSuperview
-{
-  if (_webView == nil) {
-#else
 - (void)didMoveToWindow
 {
   if (self.window != nil && _webView == nil) {
-#endif // !TARGET_OS_OSX
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     [self setBackgroundColor: _savedBackgroundColor];


### PR DESCRIPTION
Fixes multiple issues with the iOS new architecture (WebViews failing to render, #3003, possibly more) and occasional crash with the iOS old architecture.

Re: the crashes on old architecture - I don't know the exact reason for this, but I saw the test app crash with EXC_BAD_ACCESS frequently before this change and am unable to repro the crash after the change.

Re: new architecture issues - I don't know the details, but the new architecture rarely calls `didMoveToSuperview`, so initialization code was simply never getting executed. It still calls `didMoveToWindow`. An example of the "WebViews failing to render" is that, if you run the test app, the WebView will initially display, but then if you switch to a different test, or tap "simulate restart," or refresh React Native via cmd+R/etc, the WebView will disappear and never come back until you kill and restart the app. (I repro'd this outside of the test app also)


I'm not opposed to the spirit of #2930 , but I think these issues are serious enough that it's best to revert for now and reevaluate the solution. (perhaps there's a "smart" way to use both methods...)

@Titozzz 