### PR TITLE
Reference documentation updates for menuItems

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1478,11 +1478,11 @@ Example:
 
 ### `menuItems`[⬆](#props-index)
 
-An array of custom menu item objects that will be appended to the UIMenu that appears when selecting text (will appear after 'Copy' and 'Share...').  Used in tandem with `onCustomMenuSelection`
+An array of custom menu item objects that will be shown when selecting text. An empty array will suppress the menu.  Used in tandem with `onCustomMenuSelection`
 
 | Type                                                               | Required | Platform |
 | ------------------------------------------------------------------ | -------- | -------- |
-| array of objects: {label: string, key: string}                     | No       | iOS      |
+| array of objects: {label: string, key: string}                     | No       | iOS, Android      |
 
 Example:
 
@@ -1496,7 +1496,7 @@ Function called when a custom menu item is selected.  It receives a Native event
 
 | Type                                                               | Required | Platform |
 | ------------------------------------------------------------------ | -------- | -------- |
-| function                                                           | No       | iOS      |
+| function                                                           | No       | iOS, Android      |
 
 ```javascript
 <WebView

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -1465,11 +1465,11 @@ Exemplo:
 ```
 ### `menuItems`
 
-Uma matriz de objetos de itens de menu personalizados que serão anexados ao UIMenu que aparece ao selecionar o texto (aparecerá após 'Copiar' e 'Compartilhar...'). Usado em conjunto com `onCustomMenuSelection`
+Uma matriz de objetos de itens de menu personalizados que serão exibidos ao selecionar o texto. Uma matriz vazia suprimirá o menu. Usado em conjunto com `onCustomMenuSelection`
 
 | Tipo                                                               | Requerido | Plataforma |
 | ------------------------------------------------------------------ | --------  | --------   |
-| array of objects: {label: string, key: string}                     | Não       | iOS        |
+| array of objects: {label: string, key: string}                     | Não       | iOS, Android        |
 
 Exemplo:
 
@@ -1483,7 +1483,7 @@ Função chamada quando um item de menu personalizado é selecionado. Ele recebe
 
 | Tipo                                                               | Requerido | Plataforma |
 | ------------------------------------------------------------------ | --------  | --------   |
-| function                                                           | Não       | iOS        |
+| function                                                           | Não       | iOS, Android        |
 
 ```javascript
 <WebView

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -661,9 +661,9 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   enableApplePay?: boolean;
 
   /**
-   * An array of objects which will be added to the UIMenu controller when selecting text.
+   * An array of objects which will be shown when selecting text. An empty array will suppress the menu.
    * These will appear after a long press to select text.
-   * @platform ios
+   * @platform ios, android
    */
   menuItems?: WebViewCustomMenuItems[];
 
@@ -672,7 +672,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * It passes a WebViewEvent with a `nativeEvent`, where custom keys are passed:
    * `customMenuKey`: the string of the menu item
    * `selectedText`: the text selected on the document
-   * @platform ios
+   * @platform ios, android
    */
   onCustomMenuSelection?: (event: {nativeEvent: {
     label: string;


### PR DESCRIPTION

### What's in this PR
---
- Update reference documentation for `menuItems` and `onCustomMenuSelection` props, to reflect the changes made to it in Release [v12.3.0](https://github.com/react-native-webview/react-native-webview/releases/tag/v12.3.0). <br><br>The changes are described in #2610 

