### PR TITLE
Update new architecture config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,13 +83,3 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${safeExtGet('kotlinVersion')}"
     implementation "androidx.webkit:webkit:${safeExtGet('webkitVersion')}"
 }
-
-if (isNewArchitectureEnabled()) {
-    react {
-        jsRootDir = file("../src/")
-        libraryName = "rncwebview"
-        codegenJavaPackageName = "com.reactnativecommunity.webview"
-        codegenDir = new File(codegenPath)
-        reactNativeDir = new File(reactNativePath)
-    }
-}

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    s.platforms = { :ios => "10.0", :osx => "10.13" }
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
@@ -28,11 +29,6 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
 
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
   end
 end


### PR DESCRIPTION
- when building on new architecture on RN 0.72 I've got a few build errors about some methods not being available on iOS 9.0, so I bumped the minimum iOS version on the new arch to 10.0
  - I've also replaced the manually listed dependencies with `install_modules_dependencies` (see https://reactnative.dev/docs/new-architecture-library-ios#add-folly-and-other-dependencies, introduced in 0.71).
- I've removed the `react` block from `build.gradle`, since paths are set by default in RNGP (see https://github.com/facebook/react-native/blob/main/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt), and the rest is also declared in `codegenConfig` in `package.json`