### PR TITLE
Update Guide.md to link a working static server package

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -56,7 +56,7 @@ class MyWeb extends Component {
 
 ### Loading local HTML files
 
-Note: This is currently not working as discussed in [#428](https://github.com/react-native-webview/react-native-webview/issues/428) and [#518](https://github.com/react-native-webview/react-native-webview/issues/518). Possible workarounds include bundling all assets with webpack or similar, or running a [local webserver](https://github.com/futurepress/react-native-static-server).
+Note: This is currently not working as discussed in [#428](https://github.com/react-native-webview/react-native-webview/issues/428) and [#518](https://github.com/react-native-webview/react-native-webview/issues/518). Possible workarounds include bundling all assets with webpack or similar, or running a [local webserver](https://github.com/birdofpreyru/react-native-static-server).
 
 <details><summary>Show non-working method</summary>
 


### PR DESCRIPTION
The static server package does not seem to work in the later version of React Native. Or, there's a way to make it work but not discussed.  A [fork](https://github.com/birdofpreyru/react-native-static-server) of the library works as expected.  While it may not have many 'stars' the fact that it works and is also maintained, makes it a more suitable candidate.