### PR TITLE
Suppress menu items

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -221,7 +221,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
     }
 
     @Override
-    @ReactProp(name = "setSuppressMenuItems ")
+    @ReactProp(name = "suppressMenuItems ")
     public void setSetSuppressMenuItems(RNCWebView view, @Nullable ReadableArray items) {}
 
     @Override

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -222,7 +222,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
 
     @Override
     @ReactProp(name = "suppressMenuItems ")
-    public void setSetSuppressMenuItems(RNCWebView view, @Nullable ReadableArray items) {}
+    public void setSuppressMenuItems(RNCWebView view, @Nullable ReadableArray items) {}
 
     @Override
     @ReactProp(name = "messagingEnabled")

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -221,6 +221,10 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView>
     }
 
     @Override
+    @ReactProp(name = "setSuppressMenuItems ")
+    public void setSetSuppressMenuItems(RNCWebView view, @Nullable ReadableArray items) {}
+
+    @Override
     @ReactProp(name = "messagingEnabled")
     public void setMessagingEnabled(RNCWebView view, boolean value) {
         mRNCWebViewManagerImpl.setMessagingEnabled(view, value);

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -374,6 +374,15 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
         }
         [_view setMenuItems:newMenuItems];
     }
+    if(oldViewProps.suppressMenuItems != newViewProps.suppressMenuItems) {
+        NSMutableArray *suppressMenuItems = [NSMutableArray array];
+
+        for (const auto &menuItem: newViewProps.suppressMenuItems) {
+            [suppressMenuItems addObject: RCTNSStringFromString(menuItem)];
+        }
+        
+        [_view setSuppressMenuItems:suppressMenuItems];
+    }
     if (oldViewProps.hasOnFileDownload != newViewProps.hasOnFileDownload) {
         if (newViewProps.hasOnFileDownload) {
             _view.onFileDownload = [self](NSDictionary* dictionary) {

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -99,6 +99,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL enableApplePay;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
+@property (nonatomic, copy) NSArray<NSString *> * _Nullable suppressMenuItems;
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
 #if !TARGET_OS_OSX
 @property (nonatomic, assign) WKDataDetectorTypes dataDetectorTypes;

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -51,13 +51,42 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 @interface RNCWKWebView : WKWebView
 #if !TARGET_OS_OSX
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
+@property (nonatomic, copy) NSArray<NSString *> * _Nullable suppressMenuItems;
 #endif // !TARGET_OS_OSX
 @end
 @implementation RNCWKWebView
 #if !TARGET_OS_OSX
+- (NSString *)stringFromAction:(SEL) action {
+  NSString *sel = NSStringFromSelector(action);
+
+  NSDictionary *map = @{
+      @"cut:":               @"cut",
+      @"copy:":              @"copy",
+      @"paste:":             @"paste",
+      @"delete:":            @"delete",
+      @"select:":             @"select",
+      @"selectAll:":         @"selectAll",
+      @"_promptForReplace:": @"replace",
+      @"_define:":           @"lookup",
+      @"_translate:":        @"translate",
+      @"toggleBoldface:":    @"bold",
+      @"toggleItalics:":     @"italic",
+      @"toggleUnderline:":   @"underline",
+      @"_share:":            @"share",
+  };
+    
+  return map[sel] ?: sel;
+}
+
 - (BOOL)canPerformAction:(SEL)action
               withSender:(id)sender{
-
+  if(self.suppressMenuItems) {
+      NSString * sel = [self stringFromAction:action];
+      if ([self.suppressMenuItems containsObject: sel]) {
+          return NO;
+      }
+  }
+  
   if (!self.menuItems) {
       return [super canPerformAction:action withSender:sender];
   }
@@ -452,6 +481,7 @@ RCTAutoInsetsProtocol>
     [self setBackgroundColor: _savedBackgroundColor];
 #if !TARGET_OS_OSX
     _webView.menuItems = _menuItems;
+    _webView.suppressMenuItems = _suppressMenuItems;
     _webView.scrollView.delegate = self;
 #endif // !TARGET_OS_OSX
     _webView.UIDelegate = self;
@@ -797,6 +827,11 @@ RCTAutoInsetsProtocol>
 -(void)setMenuItems:(NSArray<NSDictionary *> *)menuItems {
     _menuItems = menuItems;
     _webView.menuItems = menuItems;
+}
+
+-(void)setSuppressMenuItems:(NSArray<NSString *> *)suppressMenuItems {
+    _suppressMenuItems = suppressMenuItems;
+    _webView.suppressMenuItems = suppressMenuItems;
 }
 
 -(void)setKeyboardDisplayRequiresUserAction:(BOOL)keyboardDisplayRequiresUserAction

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -121,6 +121,7 @@ RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(enableApplePay, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(menuItems, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(suppressMenuItems, NSArray);
 
 // New arch only
 RCT_CUSTOM_VIEW_PROPERTY(hasOnFileDownload, BOOL, RNCWebViewImpl) {}

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -77,6 +77,7 @@ This document lays out the current public properties and methods for the React N
 - [`onFileDownload`](Reference.md#onFileDownload)
 - [`limitsNavigationsToAppBoundDomains`](Reference.md#limitsNavigationsToAppBoundDomains)
 - [`textInteractionEnabled`](Reference.md#textInteractionEnabled)
+- [`suppressMenuItems`](Reference.md#suppressMenuItems)
 - [`mediaCapturePermissionGrantType`](Reference.md#mediaCapturePermissionGrantType)
 - [`autoManageStatusBarEnabled`](Reference.md#autoManageStatusBarEnabled)
 - [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows)
@@ -1419,6 +1420,30 @@ Example:
 ```
 
 ---
+
+### `suppressMenuItems`[⬆](#props-index)
+
+Allowes to suppress menu item from the default context menu.
+
+Possible values are:
+
+- `cut`
+- `copy`
+- `paste`
+- `delete`
+- `select`
+- `selectAll`
+- `replace`
+- `lookup`
+- `translate`
+- `bold`
+- `italic`
+- `underline`
+- `share`
+
+| Type             | Required | Default      | Platform |
+| ---------------- | -------- | ------------ | -------- |
+| array of strings | No       | []           | iOS      |
 
 ### `mediaCapturePermissionGrantType`[⬆](#props-index)
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1423,7 +1423,7 @@ Example:
 
 ### `suppressMenuItems`[⬆](#props-index)
 
-Allowes to suppress menu item from the default context menu.
+Allows to suppress menu item from the default context menu.
 
 Possible values are:
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -22,6 +22,7 @@ import NativeWebpage from './examples/NativeWebpage';
 import ApplePay from './examples/ApplePay';
 import CustomMenu from './examples/CustomMenu';
 import OpenWindow from './examples/OpenWindow';
+import SuppressMenuItems from './examples/Suppress';
 
 const TESTS = {
   Messaging: {
@@ -119,6 +120,14 @@ const TESTS = {
     render() {
       return <OpenWindow />;
     },
+  },
+  SuppressMenuItems: {
+    title: 'SuppressMenuItems',
+    testId: 'SuppressMenuItems',
+    description: 'SuppressMenuItems in editable content',
+    render() {
+      return <SuppressMenuItems />;
+    }
   }
 };
 
@@ -221,6 +230,11 @@ export default class App extends Component<Props, State> {
             testID="testType_openwindow"
             title="OpenWindow"
             onPress={() => this._changeTest('OpenWindow')}
+          />
+          <Button
+            testID="testType_suppressMenuItems"
+            title="SuppressMenuItems"
+            onPress={() => this._changeTest('SuppressMenuItems')}
           />
         </View>
 

--- a/example/examples/Suppress.tsx
+++ b/example/examples/Suppress.tsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { View } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+interface Props {}
+interface State {}
+
+const HTML = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Context Menu</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=320, user-scalable=no">
+  </head>
+  <body>
+    <p contenteditable autofocus>
+      Select text to see the context menu.
+    </p>
+  </body>
+</html>
+`
+
+export default class NativeWebpage extends Component<Props, State> {
+  state = {};
+
+  render() {
+    return (
+      <View style={{ height: 400 }}>
+        <WebView
+          source={{ html: HTML }}
+          style={{ width: '100%', height: '100%' }}
+          onShouldStartLoadWithRequest={(event) => {
+            console.log("onShouldStartLoadWithRequest", event);
+            return true;
+          }}
+          onLoadStart={(event) => {
+            console.log("onLoadStart", event.nativeEvent);
+          }}
+          suppressMenuItems={["cut", "copy", "paste", "replace", "bold", "italic", "underline", "select", "share", "lookup"]}
+        />
+      </View>
+    );
+  }
+}

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -207,6 +207,7 @@ export interface NativeProps extends ViewProps {
   onFileDownload?: DirectEventHandler<WebViewDownloadEvent>;
   // eslint-disable-next-line @typescript-eslint/array-type
   menuItems?: ReadonlyArray<Readonly<{label: string, key: string}>>;
+  suppressMenuItems?: Readonly<string>[];
   // Workaround to watch if listener if defined
   hasOnFileDownload?: boolean;
   fraudulentWebsiteWarningEnabled?: boolean;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -236,6 +236,20 @@ export interface WebViewCustomMenuItems {
   label: string;
 }
 
+export declare type SuppressMenuItem = 
+  | "cut"
+  | "copy"
+  | "paste"
+  | "replace"
+  | "bold"
+  | "italic"
+  | "underline"
+  | "select"
+  | "selectAll"
+  | "translate"
+  | "lookup"
+  | "share";
+
 export type WebViewSource = WebViewSourceUri | WebViewSourceHtml;
 
 export interface ViewManager {
@@ -682,6 +696,12 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios, android
    */
   menuItems?: WebViewCustomMenuItems[];
+
+  /**
+   * An array of strings which will be suppressed from the menu.
+   * @platform ios
+   */
+  suppressMenuItems?: SuppressMenuItem[];
 
   /**
    * The function fired when selecting a custom menu item created by `menuItems`.


### PR DESCRIPTION
This is a followup on https://github.com/react-native-webview/react-native-webview/pull/2845

Implemented the `suppressMenuItems` prop (iOS only) to suppress menu items from the long press context menu.