### PR TITLE
fix(android): compilation issues with lambda and nullable string

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,6 +61,11 @@ android {
             }
         }
     }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 def reactNativePath = findNodeModulePath(projectDir, "react-native")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -334,7 +334,7 @@ class RNCWebViewManagerImpl {
             throw RuntimeException("Arguments for loading an url are null!")
           }
           webView.progressChangedFilter.setWaitingForCommandLoadUrl(false)
-          webView.loadUrl(args.getString(0))
+          webView.loadUrl(args.getString(0) ?: "")
         }
         "requestFocus" -> webView.requestFocus()
         "clearFormData" -> webView.clearFormData()


### PR DESCRIPTION
Fixed the following:
- Lambda expressions require explicit declaration of Java 8 support.
- Nullable string in RNCWebViewManagerImpl.kt was passed to a function that expects @NonNull String.