### PR TITLE
Fix mistake in doc for Custom-iOS (RNCWebView -> RNCWebViewImpl)

### DIFF
--- a/docs/Custom-iOS.italian.md
+++ b/docs/Custom-iOS.italian.md
@@ -137,7 +137,7 @@ Una volta esposti i metodi, puoi farvi riferimento nella tua classe di web view 
 Se si aprono pagine web che richiedono un certificato client per l'autenticazione, è possibile creare una credenziale e passarla alla webview:
 
 ```
-[RNCWebView setClientAuthenticationCredential:credential];
+[RNCWebViewImpl setClientAuthenticationCredential:credential];
 ```
 
 Ciò può essere abbinato a una chiamata da JavaScript per passare una stringa etichetta per il certificato memorizzato nel portachiavi iCloud (Keychain) e utilizzare chiamate native per recuperare il certificato e creare un oggetto di credenziale. Questa chiamata può essere effettuata ovunque abbia senso per la tua applicazione (e.g. come parte dello stack di autenticazione dell'utente). L'unico requisito è effettuare questa chiamata prima di visualizzare qualsiasi webview.
@@ -146,6 +146,8 @@ Ciò può essere abbinato a una chiamata da JavaScript per passare una stringa e
 Se è necessario connettersi a un server che ha un certificato firmato o se si desidera eseguire l'SSL Pinning sulle richieste della webview, è necessario passare un dizionario con l'host come chiave e il certificato come valore di ciascun elemento:
 
 ```objc
+#import "RNCWebViewImpl.h"
+
 -(void)installCerts {
 
   // Usa il bundle in cui sono presenti i certificati nel formato DER.
@@ -161,7 +163,7 @@ Se è necessario connettersi a un server che ha un certificato firmato o se si d
   
   [certMap setObject:(__bridge id _Nonnull)(certificate) forKey:@"example.com"];
 
-  [RNCWebView setCustomCertificatesForHost:certMap];
+  [RNCWebViewImpl setCustomCertificatesForHost:certMap];
 }
 
 ```

--- a/docs/Custom-iOS.md
+++ b/docs/Custom-iOS.md
@@ -137,7 +137,7 @@ Once these are exposed, you can reference them in your custom web view class.
 If you open webpages that needs a Client Certificate for Authentication, you can create a credential and pass it to the webview:
 
 ```
-[RNCWebView setClientAuthenticationCredential:credential];
+[RNCWebViewImpl setClientAuthenticationCredential:credential];
 ```
 
 This can be paired with a call from Javascript to pass a string label for the certificate stored in keychain and use native calls to fetch the certificate to create a credential object. This call can be made anywhere that makes sense for your application (e.g. as part of the user authentication stack). The only requirement is to make this call before displaying any webviews.
@@ -148,6 +148,8 @@ If you need to connect to a server which has a self signed certificate, or want 
 
 
 ```objc
+#import "RNCWebViewImpl.h"
+
 -(void)installCerts {
 
   // Get the bundle where the certificates in DER format are present.
@@ -163,7 +165,7 @@ If you need to connect to a server which has a self signed certificate, or want 
   
   [certMap setObject:(__bridge id _Nonnull)(certificate) forKey:@"example.com"];
 
-  [RNCWebView setCustomCertificatesForHost:certMap];
+  [RNCWebViewImpl setCustomCertificatesForHost:certMap];
 }
 
 ```

--- a/docs/Custom-iOS.portuguese.md
+++ b/docs/Custom-iOS.portuguese.md
@@ -137,7 +137,7 @@ Depois que eles forem expostos, você poderá referenciá-los em sua classe de v
 Se você abrir páginas da Web que precisam de um Certificado de Cliente para Autenticação, poderá criar uma credencial e passá-la para a visualização da Web:
 
 ```
-[RNCWebView setClientAuthenticationCredential:credential];
+[RNCWebViewImpl setClientAuthenticationCredential:credential];
 ```
 
 Isso pode ser combinado com uma chamada do Javascript para passar um rótulo de texto para o certificado armazenado no chaveiro e usar chamadas nativas para buscar o certificado e criar um objeto de credencial. Essa chamada pode ser feita em qualquer lugar que faça sentido para seu aplicativo (por exemplo, como parte da pilha de autenticação do usuário). O único requisito é fazer essa chamada antes de exibir qualquer webview.
@@ -148,6 +148,8 @@ Se você precisa se conectar a um servidor que possui um certificado autoassinad
 
 
 ```objc
+#import "RNCWebViewImpl.h"
+
 -(void)installCerts {
 
   // Get the bundle where the certificates in DER format are present.
@@ -163,7 +165,7 @@ Se você precisa se conectar a um servidor que possui um certificado autoassinad
   
   [certMap setObject:(__bridge id _Nonnull)(certificate) forKey:@"example.com"];
 
-  [RNCWebView setCustomCertificatesForHost:certMap];
+  [RNCWebViewImpl setCustomCertificatesForHost:certMap];
 }
 
 ```


### PR DESCRIPTION
There is a mistake in "Setting Client Certificate Authentication Credential" and "Allowing custom CAs"

import of "RNCWebView" doesn't work ("Use of undeclared identifier 'RNCWebView") and only "RNCWebViewImpl" works correctly