### PR TITLE
fix(android): userAgent disables goBack to first url

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -54,6 +54,9 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     String injectedJS;
     protected @Nullable
     String injectedJSBeforeContentLoaded;
+    protected @Nullable
+    String userAgentString;
+
     protected static final String JAVASCRIPT_INTERFACE = "ReactNativeWebView";
 
     /**
@@ -254,6 +257,11 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         if (reactContext != null) {
             mCatalystInstance = reactContext.getCatalystInstance();
         }
+    }
+
+    public @Nullable
+    String getUserAgentString() {
+        return this.userAgentString;
     }
 
     @SuppressLint("AddJavascriptInterface")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -81,6 +81,8 @@ public class RNCWebViewClient extends WebViewClient {
       mLastLoadFailed = false;
 
       RNCWebView reactWebView = (RNCWebView) webView;
+      
+      reactWebView.getSettings().setUserAgentString(reactWebView.getUserAgentString());
       reactWebView.callInjectedJavaScriptBeforeContentLoaded();
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -223,12 +223,12 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setUserAgent(view: WebView, userAgent: String?) {
+    fun setUserAgent(view: RNCWebView, userAgent: String?) {
         mUserAgent = userAgent
         setUserAgentString(view)
     }
 
-    fun setApplicationNameForUserAgent(view: WebView, applicationName: String?) {
+    fun setApplicationNameForUserAgent(view: RNCWebView, applicationName: String?) {
         when {
             applicationName != null -> {
                 val defaultUserAgent = WebSettings.getDefaultUserAgent(view.context)
@@ -241,20 +241,20 @@ class RNCWebViewManagerImpl {
         setUserAgentString(view)
     }
 
-    private fun setUserAgentString(view: WebView) {
+    private fun setUserAgentString(view: RNCWebView) {
+
         when {
             mUserAgent != null -> {
-                view.settings.userAgentString = mUserAgent
+                view.userAgentString = mUserAgent
             }
             mUserAgentWithApplicationName != null -> {
-                view.settings.userAgentString = mUserAgentWithApplicationName
+                view.userAgentString = mUserAgentWithApplicationName
             }
             else -> {
-                view.settings.userAgentString = WebSettings.getDefaultUserAgent(view.context)
+                view.userAgentString =  WebSettings.getDefaultUserAgent(view.context)
             }
         }
     }
-
     fun setBasicAuthCredential(view: WebView, credential: ReadableMap?) {
         var basicAuthCredential: RNCBasicAuthCredential? = null
         if (credential != null) {


### PR DESCRIPTION
https://github.com/react-native-webview/react-native-webview/issues/2949

When set with `injectedJavaScript` and `userAgent`, `history.back()` or `history.go(-1)` does not work in webview.

It seems that there is a conflict as it is set up at the same time.
I kept the user agent and set the user agent when the page started.