### PR TITLE
Fixes issue with new clearCache method where it doesn't get attached on iOS

### DIFF
--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -127,6 +127,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     postMessage: (data: string) => webViewRef.current && Commands.postMessage(webViewRef.current, data),
     injectJavaScript: (data: string) => webViewRef.current && Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => webViewRef.current && Commands.requestFocus(webViewRef.current),
+    clearCache: (includeDiskFiles: boolean) => webViewRef.current && Commands.clearCache(webViewRef.current, includeDiskFiles),
   }), [setViewState, webViewRef]);
 
 


### PR DESCRIPTION
#3119 was missing one line of code; this adds it in.

Releasing quickly, as this feature is broken without this line of code.

cc @robinheinze 