### PR TITLE
[#3168] Performance optimization

### DIFF
--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -14,6 +14,7 @@ import {
   defaultOriginWhitelist,
   defaultRenderError,
   defaultRenderLoading,
+  noop,
   useWebViewLogic,
 } from './WebViewShared';
 import {
@@ -68,7 +69,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   onContentProcessDidTerminate: onContentProcessDidTerminateProp,
   onFileDownload,
   onHttpError: onHttpErrorProp,
-  onMessage: onMessageProp,
+  onMessage,
   onOpenWindow: onOpenWindowProp,
   renderLoading,
   renderError,
@@ -95,7 +96,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     RNCWebViewModule.shouldStartLoadWithLockIdentifier(shouldStart, lockIdentifier);
   }, []);
 
-  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onOpenWindow, onContentProcessDidTerminate } = useWebViewLogic({
+  const { onLoadingStart, onShouldStartLoadWithRequest, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onOpenWindow, onContentProcessDidTerminate } = useWebViewLogic({
     onNavigationStateChange,
     onLoad,
     onError,
@@ -103,7 +104,6 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     onLoadEnd,
     onLoadProgress,
     onLoadStart,
-    onMessageProp,
     onOpenWindowProp,
     startInLoadingState,
     originWhitelist,
@@ -184,7 +184,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       useSharedProcessPool={useSharedProcessPool}
       textInteractionEnabled={textInteractionEnabled}
       decelerationRate={decelerationRate}
-      messagingEnabled={typeof onMessageProp === 'function'}
+      messagingEnabled={!!onMessage}
       messagingModuleName="" // android ONLY
       onLoadingError={onLoadingError}
       onLoadingFinish={onLoadingFinish}
@@ -192,7 +192,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       onFileDownload={onFileDownload}
       onLoadingStart={onLoadingStart}
       onHttpError={onHttpError}
-      onMessage={onMessage}
+      onMessage={onMessage || noop}
       onOpenWindow={onOpenWindowProp && onOpenWindow}
       hasOnOpenWindowEvent={onOpenWindowProp !== undefined}
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}

--- a/src/WebView.macos.tsx
+++ b/src/WebView.macos.tsx
@@ -13,6 +13,7 @@ import {
   defaultOriginWhitelist,
   defaultRenderError,
   defaultRenderLoading,
+  noop,
   useWebViewLogic,
 } from './WebViewShared';
 import {
@@ -51,7 +52,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
   onLoadEnd,
   onLoadProgress,
   onHttpError: onHttpErrorProp,
-  onMessage: onMessageProp,
+  onMessage,
   renderLoading,
   renderError,
   style,
@@ -75,7 +76,7 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
     RNCWebViewModule.shouldStartLoadWithLockIdentifier(!!shouldStart, lockIdentifier);
   }, []);
 
-  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onContentProcessDidTerminate } = useWebViewLogic({
+  const { onLoadingStart, onShouldStartLoadWithRequest, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onContentProcessDidTerminate } = useWebViewLogic({
     onNavigationStateChange,
     onLoad,
     onError,
@@ -83,7 +84,6 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
     onLoadEnd,
     onLoadProgress,
     onLoadStart,
-    onMessageProp,
     startInLoadingState,
     originWhitelist,
     onShouldStartLoadWithRequestProp,
@@ -138,13 +138,13 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(({
       javaScriptEnabled={javaScriptEnabled}
       cacheEnabled={cacheEnabled}
       useSharedProcessPool={useSharedProcessPool}
-      messagingEnabled={typeof onMessageProp === 'function'}
+      messagingEnabled={!!onMessage}
       onLoadingError={onLoadingError}
       onLoadingFinish={onLoadingFinish}
       onLoadingProgress={onLoadingProgress}
       onLoadingStart={onLoadingStart}
       onHttpError={onHttpError}
-      onMessage={onMessage}
+      onMessage={onMessage || noop}
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
       onContentProcessDidTerminate={onContentProcessDidTerminate}
       injectedJavaScript={injectedJavaScript}

--- a/src/WebView.windows.tsx
+++ b/src/WebView.windows.tsx
@@ -20,7 +20,15 @@ import {
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import invariant from 'invariant';
 import {RCTWebView, RCTWebView2} from "./WebViewNativeComponent.windows";
-import { useWebViewLogic, defaultOriginWhitelist, defaultRenderError, defaultRenderLoading, } from './WebViewShared';
+
+import {
+  defaultOriginWhitelist,
+  defaultRenderError,
+  defaultRenderLoading,
+  noop,
+  useWebViewLogic,
+} from './WebViewShared';
+
 import {
   NativeWebViewWindows,
   WindowsWebViewProps,
@@ -44,7 +52,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   onLoadEnd,
   onLoadProgress,
   onHttpError: onHttpErrorProp,
-  onMessage: onMessageProp,
+  onMessage,
   renderLoading,
   renderError,
   style,
@@ -71,7 +79,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
     }
   }, [RCTWebViewString]);
 
-  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress } = useWebViewLogic({
+  const { onLoadingStart, onShouldStartLoadWithRequest, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress } = useWebViewLogic({
     onNavigationStateChange,
     onLoad,
     onError,
@@ -79,7 +87,6 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
     onLoadEnd,
     onLoadProgress,
     onLoadStart,
-    onMessageProp,
     startInLoadingState,
     originWhitelist,
     onShouldStartLoadWithRequestProp,
@@ -123,13 +130,13 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(({
   const webView = <NativeWebView
     key="webViewKey"
     {...otherProps}
-    messagingEnabled={typeof onMessageProp === 'function'}
+    messagingEnabled={!!onMessage}
     onLoadingError={onLoadingError}
     onLoadingFinish={onLoadingFinish}
     onLoadingProgress={onLoadingProgress}
     onLoadingStart={onLoadingStart}
     onHttpError={onHttpError}
-    onMessage={onMessage}
+    onMessage={onMessage || noop}
     onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     ref={webViewRef}
     // TODO: find a better way to type this.

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -7,7 +7,6 @@ import {
   WebViewError,
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
-  WebViewMessageEvent,
   WebViewNavigation,
   WebViewNavigationEvent,
   WebViewOpenWindowEvent,
@@ -23,6 +22,8 @@ const extractOrigin = (url: string): string => {
   const result = /^[A-Za-z][A-Za-z0-9+\-.]+:(\/\/)?[^/]*/.exec(url);
   return result === null ? '' : result[0];
 };
+
+export function noop() {}
 
 const originWhitelistToRegex = (originWhitelist: string): string =>
   `^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}`;
@@ -106,7 +107,6 @@ export const useWebViewLogic = ({
   onLoadEnd,
   onError,
   onHttpErrorProp,
-  onMessageProp,
   onOpenWindowProp,
   onRenderProcessGoneProp,
   onContentProcessDidTerminateProp,
@@ -122,7 +122,6 @@ export const useWebViewLogic = ({
   onLoadEnd?: (event: WebViewNavigationEvent | WebViewErrorEvent) => void;
   onError?: (event: WebViewErrorEvent) => void;
   onHttpErrorProp?: (event: WebViewHttpErrorEvent) => void;
-  onMessageProp?: (event: WebViewMessageEvent) => void;
   onOpenWindowProp?: (event: WebViewOpenWindowEvent) => void;
   onRenderProcessGoneProp?: (event: WebViewRenderProcessGoneEvent) => void;
   onContentProcessDidTerminateProp?: (event: WebViewTerminatedEvent) => void;
@@ -190,10 +189,6 @@ export const useWebViewLogic = ({
     updateNavigationState(event);
   }, [onLoad, onLoadEnd, updateNavigationState]);
 
-  const onMessage = useCallback((event: WebViewMessageEvent) => {
-    onMessageProp?.(event);
-  }, [onMessageProp]);
-
   const onLoadingProgress = useCallback((event: WebViewProgressEvent) => {
     const { nativeEvent: { progress } } = event;
     // patch for Android only
@@ -226,7 +221,6 @@ export const useWebViewLogic = ({
     onHttpError,
     onRenderProcessGone,
     onContentProcessDidTerminate,
-    onMessage,
     onOpenWindow,
     viewState,
     setViewState,


### PR DESCRIPTION
See #3168 

It removes a bunch of unnecessary code, including one `useCallback()` hook that was anyway re-evaluated on each render if the prop it was related to was an unstable function (like it is in all examples in the library Guide), and a block of code for Android, which was doing nothing (it just works the same without it, I believe), but was causing a memory leak.