### PR TITLE
Update escape-string-regexp to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "escape-string-regexp": "2.0.0",
+    "escape-string-regexp": "^4.0.0",
     "invariant": "2.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This is the last version of escape-string-regexp before it's rewritten to ES modules.

Updating past 3.x requires at least node 10, but that is already a very old node version.

https://github.com/sindresorhus/escape-string-regexp/releases