### PR TITLE
Ensure compatibility with react-native@0.73.0 on platform Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,6 +74,10 @@ android {
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
     sourceSets {
         main {
             if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
Since AGP v8, the default value of `android.buildFeatures.buildConfig` has been changed to `false`. (See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes)
RN 73 has upgraded AGP to v8.
Since we are using the `buildConfigField()` method, upgrading RN to 73 will cause this module to throw an error during building:
```
A problem occurred configuring project ':react-native-webview'.
> defaultConfig contains custom BuildConfig fields, but the feature is disabled.
  To enable the feature, add the following to your module-level build.gradle:
  `android.buildFeatures.buildConfig true`
```
Therefore, this PR sets the value of `android.buildFeatures.buildConfig` to `true`.