### PR TITLE
Fix crashes when null or undefined passed in as source to WebView

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -153,7 +153,7 @@ const TESTS: { [test: string]: Test } = {
   Empty: {
     title: 'Empty',
     testId: 'Empty',
-    description: 'Does not error if passed a null or undefined source',
+    description: "Does not error if passed a null or undefined source. This test shouldn't display anything, but merely should not crash",
     render() {
       return <Empty />;
     }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -8,12 +8,14 @@ import {
   Keyboard,
   Button,
   Platform,
+  PlatformOSType,
 } from 'react-native';
 
 import Alerts from './examples/Alerts';
 import Scrolling from './examples/Scrolling';
 import Background from './examples/Background';
 import Downloads from './examples/Downloads';
+import Empty from './examples/Empty';
 import Uploads from './examples/Uploads';
 import Injection from './examples/Injection';
 import LocalPageLoad from './examples/LocalPageLoad';
@@ -25,7 +27,15 @@ import OpenWindow from './examples/OpenWindow';
 import SuppressMenuItems from './examples/Suppress';
 import ClearData from './examples/ClearData';
 
-const TESTS = {
+interface Test {
+    title: string;
+    testId: string;
+    description: string;
+    render: () => React.ReactNode;
+    platforms?: PlatformOSType[];
+}
+
+const TESTS: { [test: string]: Test } = {
   Messaging: {
     title: 'Messaging',
     testId: 'messaging',
@@ -81,6 +91,7 @@ const TESTS = {
     render() {
       return <Uploads />;
     },
+    platforms: ['android', 'macos'],
   },
   Injection: {
     title: 'Injection',
@@ -113,6 +124,7 @@ const TESTS = {
     render() {
       return <ApplePay />;
     },
+    platforms: ['ios']
   },
   CustomMenu: {
     title: 'Custom Menu',
@@ -136,6 +148,14 @@ const TESTS = {
     description: 'SuppressMenuItems in editable content',
     render() {
       return <SuppressMenuItems />;
+    }
+  },
+  Empty: {
+    title: 'Empty',
+    testId: 'Empty',
+    description: 'Does not error if passed a null or undefined source',
+    render() {
+      return <Empty />;
     }
   }
 };
@@ -176,80 +196,17 @@ export default class App extends Component<Props, State> {
         </TouchableOpacity>
 
         <View style={styles.testPickerContainer}>
-          <Button
-            testID="testType_alerts"
-            title="Alerts"
-            onPress={() => this._changeTest('Alerts')}
-          />
-          <Button
-            testID="testType_scrolling"
-            title="Scrolling"
-            onPress={() => this._changeTest('Scrolling')}
-          />
-          <Button
-            testID="testType_background"
-            title="Background"
-            onPress={() => this._changeTest('Background')}
-          />
-          <Button
-            testID="testType_injection"
-            title="Injection"
-            onPress={() => this._changeTest('Injection')}
-          />
-          <Button
-            testID="testType_pageLoad"
-            title="LocalPageLoad"
-            onPress={() => this._changeTest('PageLoad')}
-          />
-          <Button
-            testID="testType_downloads"
-            title="Downloads"
-            onPress={() => this._changeTest('Downloads')}
-          />
-          {(Platform.OS === 'android' || Platform.OS === 'macos') && (
-            <Button
-              testID="testType_uploads"
-              title="Uploads"
-              onPress={() => this._changeTest('Uploads')}
-            />
-          )}
-          <Button
-            testID="testType_messaging"
-            title="Messaging"
-            onPress={() => this._changeTest('Messaging')}
-          />
-          <Button
-            testID="testType_nativeWebpage"
-            title="NativeWebpage"
-            onPress={() => this._changeTest('NativeWebpage')}
-          />
-          {Platform.OS === 'ios' && (
-              <Button
-                  testID="testType_applePay"
-                  title="ApplePay"
-                  onPress={() => this._changeTest('ApplePay')}
-              />
-          )}
-          <Button
-            testID="testType_customMenu"
-            title="CustomMenu"
-            onPress={() => this._changeTest('CustomMenu')}
-          />
-          <Button
-            testID="testType_openwindow"
-            title="OpenWindow"
-            onPress={() => this._changeTest('OpenWindow')}
-          />
-          <Button
-            testID="testType_suppressMenuItems"
-            title="SuppressMenuItems"
-            onPress={() => this._changeTest('SuppressMenuItems')}
-          />
-          <Button
-            testID="testType_clearData"
-            title="ClearData"
-            onPress={() => this._changeTest('ClearData')}
-          />
+          {Object.values(TESTS).map(test => {
+              if (test.platforms && !test.platforms.includes(Platform.OS)) return null;
+              return (
+                  <Button
+                      key={test.testId}
+                      testID={test.testId}
+                      title={test.title}
+                      onPress={() => this._changeTest(test.testId)}
+                  />
+              )
+          })}
         </View>
 
         {restarting ? null : (

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -173,7 +173,7 @@ export default class App extends Component<Props, State> {
     this.setState({restarting: true}, () => this.setState({restarting: false}));
   };
 
-  _changeTest = (testName) => {
+  _changeTest = (testName: string) => {
     this.setState({currentTest: TESTS[testName]});
   };
 
@@ -196,14 +196,14 @@ export default class App extends Component<Props, State> {
         </TouchableOpacity>
 
         <View style={styles.testPickerContainer}>
-          {Object.values(TESTS).map(test => {
+          {Object.entries(TESTS).map(([key, test]) => {
               if (test.platforms && !test.platforms.includes(Platform.OS)) return null;
               return (
                   <Button
-                      key={test.testId}
+                      key={key}
                       testID={test.testId}
                       title={test.title}
-                      onPress={() => this._changeTest(test.testId)}
+                      onPress={() => this._changeTest(key)}
                   />
               )
           })}

--- a/example/examples/Empty.tsx
+++ b/example/examples/Empty.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {View} from 'react-native';
+import WebView from 'react-native-webview';
+
+/** This test makes sure that when passed an empty source, we don't crash */
+export default function Empty() {
+    return (
+        <View>
+            <WebView source={undefined} />
+            <WebView source={null} />
+        </View>
+    )
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
   - React-jsinspector (0.71.12)
   - React-logger (0.71.12):
     - glog
-  - react-native-webview (13.4.0):
+  - react-native-webview (13.6.2):
     - React-Core
   - React-perflogger (0.71.12)
   - React-RCTActionSheet (0.71.12):
@@ -467,7 +467,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: a78a0e415dc4b786a4308becf3e3bc6dbbc7b92e
   React-jsinspector: ec4dcbfb1f4e72f04f826a0301eceee5fa7ca540
   React-logger: 35538accacf2583693fbc3ee8b53e69a1776fcee
-  react-native-webview: 64c9bf9646e7377240fb87d70f74556af6433143
+  react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
   React-perflogger: 75b0e25075c67565a830985f3c373e2eae5389e0
   React-RCTActionSheet: a0c3e916b327e297d124d9ebe8b0c721840ee04d
   React-RCTAnimation: 3da7025801d7bf0f8cfd94574d6278d5b82a8b88
@@ -488,4 +488,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8344c021910ed9b6a9bb9985ff8f7f05a68b19c1
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -1,9 +1,7 @@
 import React, { forwardRef, ReactElement, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 
 import {
-  Image,
   View,
-  ImageSourcePropType,
   HostComponent,
 } from 'react-native';
 
@@ -17,15 +15,12 @@ import {
   defaultOriginWhitelist,
   defaultRenderError,
   defaultRenderLoading,
+  resolveAssetSourceAndReplaceHeaders,
   useWebViewLogic,
 } from './WebViewShared';
-import {
-  AndroidWebViewProps, WebViewSourceUri,
-} from './WebViewTypes';
+import {AndroidWebViewProps} from './WebViewTypes';
 
 import styles from './WebView.styles';
-
-const { resolveAssetSource } = Image;
 
 /**
  * A simple counter to uniquely identify WebView instances. Do not use this for anything else.
@@ -159,19 +154,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   const NativeWebView
     = (nativeConfig?.component as (typeof RNCWebView | undefined)) || RNCWebView;
 
-  const sourceResolved = resolveAssetSource(source as ImageSourcePropType)
-  const newSource = typeof sourceResolved === "object" ? Object.entries(sourceResolved as WebViewSourceUri).reduce((prev, [currKey, currValue]) => {
-    return {
-      ...prev,
-      [currKey]: currKey === "headers" && currValue && typeof currValue === "object" ? Object.entries(currValue).map(
-        ([key, value]) => {
-          return {
-            name: key,
-            value
-          }
-        }) : currValue
-    }
-  }, {}) : sourceResolved
+  const { newSource, sourceResolved } = resolveAssetSourceAndReplaceHeaders(source)
 
   const webView = <NativeWebView
     key="webViewKey"

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -1,8 +1,6 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import {
-  Image,
   View,
-  ImageSourcePropType,
   HostComponent,
 } from 'react-native';
 import invariant from 'invariant';
@@ -14,19 +12,18 @@ import {
   defaultOriginWhitelist,
   defaultRenderError,
   defaultRenderLoading,
+  resolveAssetSourceAndReplaceHeaders,
   useWebViewLogic,
 } from './WebViewShared';
 import {
   IOSWebViewProps,
   DecelerationRateConstant,
-  WebViewSourceUri,
 } from './WebViewTypes';
 
 import styles from './WebView.styles';
 
 
 
-const { resolveAssetSource } = Image;
 const processDecelerationRate = (
   decelerationRate: DecelerationRateConstant | number | undefined,
 ) => {
@@ -160,19 +157,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   = (nativeConfig?.component as typeof RNCWebView | undefined)
   || RNCWebView;
 
-  const sourceResolved = resolveAssetSource(source as ImageSourcePropType)
-  const newSource = typeof sourceResolved === "object" ? Object.entries(sourceResolved as WebViewSourceUri).reduce((prev, [currKey, currValue]) => {
-    return {
-      ...prev,
-      [currKey]: currKey === "headers" && currValue && typeof currValue === "object" ? Object.entries(currValue).map(
-        ([key, value]) => {
-          return {
-            name: key,
-            value
-          }
-        }) : currValue
-    }
-  }, {}) : sourceResolved
+  const { newSource, sourceResolved } = resolveAssetSourceAndReplaceHeaders(source)
 
   const webView = (
     <NativeWebView


### PR DESCRIPTION
### Motivation

This solves issue: https://github.com/react-native-webview/react-native-webview/issues/2920

Even though Typescript types mention that it should be allowed to pass in `null` or `undefined` to the `source` prop, doing so causes a crash for "Cannot convert null value to object" on https://github.com/react-native-webview/react-native-webview/blob/v13.6.2/src/WebView.ios.tsx#L164 because:

- `const sourceResolved = Image.resolveAssetSource(source as ImageSourcePropType)` returns null, which
- On the next line, causes us to call `Object.entries(sourceResolved)` on `null`

### Changes

- Add a test that passes in null or undefined to `<WebView />` and makes sure that it doesn't crash
  - I also simplified the test definition in example/App.tsx slightly so we can add tests more easily with less code
- Gracefully handle `null` values by changing `typeof sourceResolved === "object" ? ...` to `typeof sourceResolved === "object" && sourceResolved ? ...`

### Testing

Followed instructions to test using the Example app:

| Before | After |
|---|---|
| ![image](https://github.com/react-native-webview/react-native-webview/assets/2924388/90f5057d-870f-4557-a444-7071aca7b31c)  |  ![image](https://github.com/react-native-webview/react-native-webview/assets/2924388/c64443ac-b373-4848-a801-1a62759bbc88) |