### PR TITLE
fix(android): Jumps with scrollview when pressed

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -101,6 +101,11 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     }
 
     @Override
+    public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+      return true;
+    }
+
+    @Override
     public void onHostResume() {
         // do nothing
     }


### PR DESCRIPTION
Jumps to `WebView` top when first time press inside `WebView` on Android.

Related issues: #2360 #2057 #3014 

Before:

https://github.com/react-native-webview/react-native-webview/assets/16725418/d52e3f45-e1a4-4121-80b8-1ad1166b0e7e

After:

https://github.com/react-native-webview/react-native-webview/assets/16725418/e7c5786e-7460-4ffa-a352-96bbc83b376a

