### PR TITLE
(fix): add field `"react-native"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "React Native WebView component for iOS, Android, macOS, and Windows",
   "main": "index.js",
   "main-internal": "src/index.ts",
+  "react-native": "src/index.ts",
   "typings": "index.d.ts",
   "author": "Jamon Holmgren <jamon@infinite.red>",
   "contributors": [


### PR DESCRIPTION
Fix https://github.com/reactwg/react-native-releases/discussions/64#discussioncomment-7197584

According to:
- [Metro docs](https://facebook.github.io/metro/docs/package-exports#example-use-conditional-exports-to-target-web-and-react-native)
- [Template of `create-react-native-library`](https://github.com/callstack/react-native-builder-bob/blob/main/packages/create-react-native-library/templates/common/%24package.json#L8)

Libraries should set the field `"react-native"` in `package.json`, so that Metro will correctly resolve the main entry for platform React Native.

Not adding this field will cause the library to be incompatible with RN 73, as RN 73 enhanced requirements for `<FABRIC COMPONENT>NativeComponent` to be either flow-typed or a TypeScript source, and resolving this library from the old `main` would cause Metro to raise an error.