### PR TITLE
feat(iOS): set selection and caret color

### DIFF
--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -104,6 +104,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 #if !TARGET_OS_OSX
 @property (nonatomic, assign) WKDataDetectorTypes dataDetectorTypes;
 @property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
+@property (nonatomic, copy) UIColor* tintColor;
 #endif
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -483,6 +483,7 @@ RCTAutoInsetsProtocol>
     _webView.menuItems = _menuItems;
     _webView.suppressMenuItems = _suppressMenuItems;
     _webView.scrollView.delegate = self;
+    _webView.tintColor = _tintColor;
 #endif // !TARGET_OS_OSX
     _webView.UIDelegate = self;
     _webView.navigationDelegate = self;
@@ -1010,6 +1011,12 @@ RCTAutoInsetsProtocol>
 {
   _showsVerticalScrollIndicator = showsVerticalScrollIndicator;
   _webView.scrollView.showsVerticalScrollIndicator = showsVerticalScrollIndicator;
+}
+
+- (void)setTintColor:(UIColor*)tintColor
+{
+    _tintColor = tintColor;
+    _webView.tintColor = tintColor;
 }
 #endif // !TARGET_OS_OSX
 

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -85,6 +85,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -91,6 +91,7 @@ This document lays out the current public properties and methods for the React N
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
 - [`webviewDebuggingEnabled`](Reference.md#webviewDebuggingEnabled)
+- [`tintColor`](Reference.md#tintColor)
 
 ## Methods Index
 
@@ -1690,6 +1691,14 @@ Default is `false`. Supported on iOS as of 16.4, previous versions always allow 
 | Type    | Required | Platform |
 | ------- | -------- | -------- |
 | boolean | No       | iOS & Android  |
+
+### `tintColor`[⬆](#props-index)
+
+Set background and caret color of selection.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
 
 ## Methods
 

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -212,6 +212,7 @@ export interface NativeProps extends ViewProps {
   // Workaround to watch if listener if defined
   hasOnFileDownload?: boolean;
   fraudulentWebsiteWarningEnabled?: boolean;
+  tintColor?: string;
   // !iOS only
 
   allowFileAccessFromFileURLs?: boolean;

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -74,6 +74,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   renderError,
   style,
   containerStyle,
+  tintColor,
   source,
   nativeConfig,
   allowsInlineMediaPlayback,
@@ -208,6 +209,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
       newSource={newSource}
       style={webViewStyles}
+      tintColor={tintColor}
       hasOnFileDownload={!!onFileDownload}
       ref={webViewRef}
       // @ts-expect-error old arch only

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -724,6 +724,12 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   fraudulentWebsiteWarningEnabled?: boolean;
+
+  /**
+   * A hex color value used to set background and caret color of selection.
+   * @platform ios
+  */
+  tintColor?: string;
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
<img width="263" alt="image" src="https://github.com/react-native-webview/react-native-webview/assets/16725418/597beb83-ef0c-4e6e-8445-45795b1cf5a9">

Adds a prop to set selection and caret color on iOS. (Can use [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection) on Android)

Accepts a string represents a color, like `'#00fff0'`, `'red'`.

It also can accepts an integer represents a rgba value, for example, use `16711680` to represents `'#00ff0000'`, but I think it's not a common usage. 😂