### PR TITLE
update podspec to use install_modules_dependencies

### DIFF
--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    s.platforms = { :ios => "10.0", :osx => "10.13" }
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
@@ -28,11 +29,6 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
 
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
   end
 end

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -1,8 +1,9 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+ios_platform = new_arch_enabled ? '11.0' : '9.0'
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = package['name']
@@ -12,23 +13,34 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :osx => "10.13" }
+  s.platforms    = { :ios => ios_platform, :osx => "10.13" }
 
   s.source       = { :git => "https://github.com/react-native-webview/react-native-webview.git", :tag => "v#{s.version}" }
 
   s.source_files    = "apple/**/*.{h,m,mm,swift}"
 
-  s.dependency "React-Core"
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    if new_arch_enabled
+      folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.platforms = { :ios => "10.0", :osx => "10.13" }
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
 
-    install_modules_dependencies(s)
+      s.pod_target_xcconfig = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
+
+      s.dependency "React-RCTFabric"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    else
+      s.dependency "React-Core"
+    end
   end
 end


### PR DESCRIPTION
This change updates the react-native-webview.podspec to consume the
`install_modules_dependencies` function provided by React Native to
configure the pods dependencies.

Thanks to using this function, whenever we update the function in React
Native, the library will automatically benefit from it.
This will make the library more future proof and more resilient to
changes in React Native.

This changes fixes building errors on new architecture on RN 0.72.