### PR TITLE
fix(ios, macos): Suspend media playback when destroying WebView on iOS/macOS

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -569,6 +569,7 @@ RCTAutoInsetsProtocol>
     [_webView.configuration.userContentController removeScriptMessageHandlerForName:MessageHandlerName];
     [_webView removeObserver:self forKeyPath:@"estimatedProgress"];
     [_webView removeFromSuperview];
+    [_webView pauseAllMediaPlaybackWithCompletionHandler:nil];
 #if !TARGET_OS_OSX
     _webView.scrollView.delegate = nil;
     if (_menuItems) {

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -569,7 +569,11 @@ RCTAutoInsetsProtocol>
     [_webView.configuration.userContentController removeScriptMessageHandlerForName:MessageHandlerName];
     [_webView removeObserver:self forKeyPath:@"estimatedProgress"];
     [_webView removeFromSuperview];
-    [_webView pauseAllMediaPlaybackWithCompletionHandler:nil];
+    if (@available(iOS 15.0, macOS 12.0, *)) {
+        [_webView pauseAllMediaPlaybackWithCompletionHandler:nil];
+    } else if (@available(iOS 14.5, macOS 11.3, *)) {
+        [_webView suspendAllMediaPlayback:nil];
+    }
 #if !TARGET_OS_OSX
     _webView.scrollView.delegate = nil;
     if (_menuItems) {


### PR DESCRIPTION
We had an issue with iOS and macOS where audio and video would continue playing after the WebView was unmounted, the only work around seems to be injecting JavaScript before unmounting, which isn't always easy or guaranteed

This issue has been reported a handful of times, such as in #2449

This PR fixes this issue by pausing all media playback in the webview destroy function