### PR TITLE
Ntlm auth added for ios.

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1087,7 +1087,7 @@ RCTAutoInsetsProtocol>
       }
     }
   }
-  if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic) {
+  if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic || [[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodNTLM) {
     NSString *username = [_basicAuthCredential valueForKey:@"username"];
     NSString *password = [_basicAuthCredential valueForKey:@"password"];
     if (username && password) {


### PR DESCRIPTION
Currently basicAuthCredential is not working for ios but it is working fine with android.

By adding NSURLAuthenticationMethodNTLM in the if block basicAuthCredential can be used for ntlm authentication as well.

Tested for ios.
