### PR TITLE
[#3289] Android: Trigger `onError` callback on asset loading errors

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -156,10 +156,15 @@ export const useWebViewLogic = ({
     } else {
       console.warn('Encountered an error loading page', event.nativeEvent);
     }
+
+    // This block is only entered if the error is for the main source itself,
+    // not for related assets.
+    if (startUrl.current === event.nativeEvent.url) {
     onLoadEnd?.(event);
     if (event.isDefaultPrevented()) { return };
     setViewState('ERROR');
     setLastErrorEvent(event.nativeEvent);
+    }
   }, [onError, onLoadEnd]);
 
   const onHttpError = useCallback((event: WebViewHttpErrorEvent) => {


### PR DESCRIPTION
Here is my PR for #3289:
- Avoids using [the deprecated version of `onReceivedError`](https://developer.android.com/reference/android/webkit/WebViewClient#onReceivedError(android.webkit.WebView,%20int,%20java.lang.String,%20java.lang.String)) for `onError` implementation on Android.
- Fires `onError` callback, if provided, for asset loading errors, in addition to the primary source loading errors.
- Does not alter the logic of other related callbacks (`onLoad`, `onLoadEnd`, _etc._); _i.e._ `onError` signals triggered for page assets do not prevent `onLoad` and `onLoadEnd` to be fired for the page itself, if that was loaded &mdash; thus, the page is signaled to have been loaded successfully, even if its assets failed to load, and that is just the original behavior of those signals before my PR.

Can we merge it, please? :)