### PR TITLE
Replace UIKit with RCTUIKit on MacOS for RCT_NEW_ARCH_ENABLED

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -3,7 +3,13 @@
 #import <React/RCTViewComponentView.h>
 #import <React/RCTConversions.h>
 #import <WebKit/WKDataDetectorTypes.h>
+
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#else
+#import <React/RCTUIKit.h>
+#endif // !TARGET_OS_OSX
+
 #import <react/renderer/components/RNCWebViewSpec/Props.h>
 
 #ifndef NativeComponentExampleComponentView_h

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -284,9 +284,10 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(cacheEnabled)
     REMAP_WEBVIEW_PROP(allowsLinkPreview)
     REMAP_WEBVIEW_STRING_PROP(allowingReadAccessToURL)
-    
     REMAP_WEBVIEW_PROP(messagingEnabled)
+    #if !TARGET_OS_OSX
     REMAP_WEBVIEW_PROP(fraudulentWebsiteWarningEnabled)
+    #endif // !TARGET_OS_OSX
     REMAP_WEBVIEW_PROP(enableApplePay)
     REMAP_WEBVIEW_PROP(pullToRefreshEnabled)
     REMAP_WEBVIEW_PROP(bounces)
@@ -310,7 +311,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500 /* iOS 14.5 */
     REMAP_WEBVIEW_PROP(textInteractionEnabled)
 #endif
-    
+
+#if !TARGET_OS_OSX
     if (oldViewProps.dataDetectorTypes != newViewProps.dataDetectorTypes) {
         WKDataDetectorTypes dataDetectorTypes = WKDataDetectorTypeNone;
             if (dataDetectorTypes & RNCWebViewDataDetectorTypes::Address) {
@@ -334,6 +336,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
         }
         [_view setDataDetectorTypes:dataDetectorTypes];
     }
+#endif // !TARGET_OS_OSX
+
     if (oldViewProps.contentInset.top != newViewProps.contentInset.top || oldViewProps.contentInset.left != newViewProps.contentInset.left || oldViewProps.contentInset.right != newViewProps.contentInset.right || oldViewProps.contentInset.bottom != newViewProps.contentInset.bottom) {
         UIEdgeInsets edgesInsets = {
             .top = newViewProps.contentInset.top,
@@ -350,6 +354,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
             @"password": RCTNSStringFromString(newViewProps.basicAuthCredential.password)
         }];
     }
+
+#if !TARGET_OS_OSX
     if (oldViewProps.contentInsetAdjustmentBehavior != newViewProps.contentInsetAdjustmentBehavior) {
         if (newViewProps.contentInsetAdjustmentBehavior == RNCWebViewContentInsetAdjustmentBehavior::Never) {
             [_view setContentInsetAdjustmentBehavior: UIScrollViewContentInsetAdjustmentNever];
@@ -361,6 +367,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
             [_view setContentInsetAdjustmentBehavior: UIScrollViewContentInsetAdjustmentAlways];
         }
     }
+#endif // !TARGET_OS_OSX
 
     if (oldViewProps.menuItems != newViewProps.menuItems) {
         NSMutableArray *newMenuItems = [NSMutableArray array];

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -52,11 +52,13 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     return concreteComponentDescriptorProvider<RNCWebViewComponentDescriptor>();
 }
 
+#if !TARGET_OS_OSX
 // Reproduce the idea from here: https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm#L142
 - (void)prepareForRecycle {
     [super prepareForRecycle];
     [_view destroyWebView];
 }
+#endif // !TARGET_OS_OSX
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -76,10 +76,10 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .navigationType = stringToOnShouldStartLoadWithRequestNavigationTypeEnum(std::string([[dictionary valueForKey:@"navigationType"] UTF8String])),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .isTopFrame = [[dictionary valueForKey:@"isTopFrame"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .isTopFrame = static_cast<bool>([[dictionary valueForKey:@"isTopFrame"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .mainDocumentURL = std::string([[dictionary valueForKey:@"mainDocumentURL"] UTF8String])
                 };
                 webViewEventEmitter->onShouldStartLoadWithRequest(data);
@@ -93,9 +93,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .navigationType = stringToOnLoadingStartNavigationTypeEnum(std::string([[dictionary valueForKey:@"navigationType"] UTF8String])),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .mainDocumentURL = std::string([[dictionary valueForKey:@"mainDocumentURL"] UTF8String], [[dictionary valueForKey:@"mainDocumentURL"] lengthOfBytesUsingEncoding:NSUTF8StringEncoding])
                 };
                 webViewEventEmitter->onLoadingStart(data);
@@ -110,9 +110,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .code = [[dictionary valueForKey:@"code"] intValue],
                     .description = std::string([[dictionary valueForKey:@"description"] UTF8String]),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .domain = std::string([[dictionary valueForKey:@"domain"] UTF8String])
                 };
                 webViewEventEmitter->onLoadingError(data);
@@ -125,9 +125,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .url = std::string([[dictionary valueForKey:@"url"] UTF8String]),
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .data = std::string([[dictionary valueForKey:@"data"] UTF8String])
                 };
                 webViewEventEmitter->onMessage(data);
@@ -141,9 +141,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .navigationType = stringToOnLoadingFinishNavigationTypeEnum(std::string([[dictionary valueForKey:@"navigationType"] UTF8String], [[dictionary valueForKey:@"navigationType"] lengthOfBytesUsingEncoding:NSUTF8StringEncoding])),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .mainDocumentURL = std::string([[dictionary valueForKey:@"mainDocumentURL"] UTF8String], [[dictionary valueForKey:@"mainDocumentURL"] lengthOfBytesUsingEncoding:NSUTF8StringEncoding])
                 };
                 webViewEventEmitter->onLoadingFinish(data);
@@ -156,9 +156,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .url = std::string([[dictionary valueForKey:@"url"] UTF8String]),
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue],
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
                     .progress = [[dictionary valueForKey:@"progress"] doubleValue]
                 };
                 webViewEventEmitter->onLoadingProgress(data);
@@ -171,9 +171,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .url = std::string([[dictionary valueForKey:@"url"] UTF8String]),
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue]
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = std::([[dictionary valueForKey:@"loading"] boolValue])
                 };
                 webViewEventEmitter->onContentProcessDidTerminate(data);
             }
@@ -231,9 +231,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .statusCode = [[dictionary valueForKey:@"statusCode"] intValue],
                     .description = std::string([[dictionary valueForKey:@"description"] UTF8String]),
-                    .canGoBack = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .canGoForward = [[dictionary valueForKey:@"canGoBack"] boolValue],
-                    .loading = [[dictionary valueForKey:@"loading"] boolValue]
+                    .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue])
                 };
                 webViewEventEmitter->onHttpError(data);
             }

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -173,7 +173,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
-                    .loading = std::([[dictionary valueForKey:@"loading"] boolValue])
+                    .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue])
                 };
                 webViewEventEmitter->onContentProcessDidTerminate(data);
             }


### PR DESCRIPTION
Fixes https://github.com/react-native-webview/react-native-webview/issues/3295
Related https://github.com/microsoft/react-native-macos/issues/1534

**This pull request:** 

1. Substitutes **UIKit** with **RCTUIKit** to facilitate compatibility with **MacOS**, mostly using platform-specific conditional statements. Example:
```h
#if !TARGET_OS_OSX
#import <UIKit/UIKit.h>
#else
#import <React/RCTUIKit.h>
#endif // !TARGET_OS_OSX
```  

2. The `static_cast<bool>(` part of this PR fixes the error when building for Release:
```
Non-constant-expression cannot be narrowed from type 'BOOL' (aka 'signed char') to 'bool' in initializer list
```
It seems like implicit narrowing conversions not being allowed in C++11 braced initializer lists. In this initializer list, `bool` fields initialized `BOOL` values. Since `BOOL` is typically a typedef for `signed char` in Objective-C, we need to explicitly cast it to `bool` to satisfy the requirement that there be no narrowing conversions.

Error screenshot (Xcode | Product->Archive):
<img width="1582" alt="Screenshot 2024-01-19 at 10 21 52 PM" src="https://github.com/react-native-webview/react-native-webview/assets/7628774/536b1946-995a-459c-8cc3-9ae5f9fc05a3">




> ~~Update: It's not working as expected.~~
> 
> ~~The main issue is that `source` prop  always results in a map with empty strings:~~
> <img width="562" alt="Screenshot 2024-01-18 at 7 05 00 PM" src="https://github.com/react-native-webview/react-native-webview/assets/7628774/e87a9b03-7545-4c46-9b04-6d4a54656e5e">
> 
> The above issue was caused by property `source` not used in the codebase for new arch and instead is renamed to `newSource`. (Doc ?) 

**Result:**
- fabric: enabled
- RCT_NEW_ARCH_ENABLED=1

```tsx
function App(): React.JSX.Element {
  return (
    <View style={{height: '100%', width: '100%'}}>
      <WebView
        newSource={{
          uri: 'https://reactnative.dev/',
        }}
      />
    </View>
  );
}
```

<img width="1795" alt="Screenshot 2024-01-18 at 8 13 34 PM" src="https://github.com/react-native-webview/react-native-webview/assets/7628774/83c8d992-da6d-4f6c-aeb7-1a03e0b3f791">
