### PR TITLE
[Windows][WebView2] Refactor ReactWebView2.cpp to handle optional 'method' parameter

### DIFF
--- a/windows/ReactNativeWebView/ReactWebView2.cpp
+++ b/windows/ReactNativeWebView/ReactWebView2.cpp
@@ -404,8 +404,9 @@ namespace winrt::ReactNativeWebView::implementation {
         if (m_webView.CoreWebView2())
         {
             auto uri = winrt::Uri(winrt::to_hstring(m_request.at("uri").AsString()));
+            auto method = (m_request.find("method") != m_request.end()) ? m_request.at("method").AsString() : "GET";
             auto webResourceRequest = m_webView.CoreWebView2().Environment().CreateWebResourceRequest(
-                uri.ToString(), winrt::to_hstring(m_request.at("method").AsString()), nullptr, L"");
+                uri.ToString(), winrt::to_hstring(method), nullptr, L"");
                 
             SetupRequest(m_request.Copy(), webResourceRequest);
 


### PR DESCRIPTION
## Motivation
PR #3309 (https://github.com/react-native-webview/react-native-webview/pull/3309) introduced a bug whereby the call to create a web resource request would directly access the method property of the request object, however, in Typescript the method object is optional thus people that didn't include it implicitly experienced crashes due to the null reference.


## Solution
### Fixed
- Refactor ReactWebView2.cpp to handle optional 'method' parameter