### PR TITLE
fix(ios): Allow keyboard accessory view to be toggled after initialization using `hideKeyboardAccessoryView` prop

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -910,12 +910,14 @@ RCTAutoInsetsProtocol>
 
 -(void)setHideKeyboardAccessoryView:(BOOL)hideKeyboardAccessoryView
 {
+  _savedHideKeyboardAccessoryView = hideKeyboardAccessoryView;
+
   if (_webView == nil) {
-    _savedHideKeyboardAccessoryView = hideKeyboardAccessoryView;
     return;
   }
 
   if (_savedHideKeyboardAccessoryView == false) {
+    [self __addInputAccessoryView];
     return;
   }
 
@@ -941,6 +943,21 @@ RCTAutoInsetsProtocol>
 
     objc_registerClassPair(newClass);
   }
+
+  object_setClass(subview, newClass);
+}
+
+- (void)__addInputAccessoryView {
+  UIView* subview;
+
+  for (UIView* view in _webView.scrollView.subviews) {
+    if([[view.class description] hasSuffix:@"_SwizzleHelperWK"])
+      subview = view;
+  }
+
+  if(subview == nil) return;
+
+  Class newClass = subview.superclass;
 
   object_setClass(subview, newClass);
 }


### PR DESCRIPTION
fixes #3339 