### PR TITLE
fix(android): Fix bridgeless mode support

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
@@ -59,9 +60,9 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     protected @Nullable
     String messagingModuleName;
     protected @Nullable
-    RNCWebViewClient mRNCWebViewClient;
+    RNCWebViewMessagingModule mMessagingJSModule;
     protected @Nullable
-    CatalystInstance mCatalystInstance;
+    RNCWebViewClient mRNCWebViewClient;
     protected boolean sendContentSizeChangeEvents = false;
     private OnScrollDispatchHelper mOnScrollDispatchHelper;
     protected boolean hasScrollEvent = false;
@@ -76,7 +77,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
      */
     public RNCWebView(ThemedReactContext reactContext) {
         super(reactContext);
-        this.createCatalystInstance();
+        mMessagingJSModule = ((ThemedReactContext) this.getContext()).getReactApplicationContext().getJSModule(RNCWebViewMessagingModule.class);
         progressChangedFilter = new ProgressChangedFilter();
     }
 
@@ -248,14 +249,6 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         return bridge;
     }
 
-    protected void createCatalystInstance() {
-      ThemedReactContext reactContext = (ThemedReactContext) this.getContext();
-
-        if (reactContext != null) {
-            mCatalystInstance = reactContext.getCatalystInstance();
-        }
-    }
-
     @SuppressLint("AddJavascriptInterface")
     public void setMessagingEnabled(boolean enabled) {
         if (messagingEnabled == enabled) {
@@ -311,8 +304,8 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
                     WritableMap data = mRNCWebViewClient.createWebViewEvent(webView, webView.getUrl());
                     data.putString("data", message);
 
-                    if (mCatalystInstance != null) {
-                        mWebView.sendDirectMessage("onMessage", data);
+                    if (mMessagingJSModule != null) {
+                        dispatchDirectMessage(data);
                     } else {
                         dispatchEvent(webView, new TopMessageEvent(RNCWebViewWrapper.getReactTagFromWebView(webView), data));
                     }
@@ -322,22 +315,29 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
             WritableMap eventData = Arguments.createMap();
             eventData.putString("data", message);
 
-            if (mCatalystInstance != null) {
-                this.sendDirectMessage("onMessage", eventData);
+            if (mMessagingJSModule != null) {
+                dispatchDirectMessage(eventData);
             } else {
                 dispatchEvent(this, new TopMessageEvent(RNCWebViewWrapper.getReactTagFromWebView(this), eventData));
             }
         }
     }
 
-    protected void sendDirectMessage(final String method, WritableMap data) {
+    protected void dispatchDirectMessage(WritableMap data) {
         WritableNativeMap event = new WritableNativeMap();
         event.putMap("nativeEvent", data);
+        event.putString("messagingModuleName", messagingModuleName);
 
-        WritableNativeArray params = new WritableNativeArray();
-        params.pushMap(event);
+        mMessagingJSModule.onMessage(event);
+    }
 
-        mCatalystInstance.callFunction(messagingModuleName, method, params);
+    protected boolean dispatchDirectShouldStartLoadWithRequest(WritableMap data) {
+        WritableNativeMap event = new WritableNativeMap();
+        event.putMap("nativeEvent", data);
+        event.putString("messagingModuleName", messagingModuleName);
+
+        mMessagingJSModule.onShouldStartLoadWithRequest(event);
+        return true;
     }
 
     protected void onScrollChanged(int x, int y, int oldX, int oldY) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -89,14 +89,14 @@ public class RNCWebViewClient extends WebViewClient {
         final RNCWebView rncWebView = (RNCWebView) view;
         final boolean isJsDebugging = ((ReactContext) view.getContext()).getJavaScriptContextHolder().get() == 0;
 
-        if (!isJsDebugging && rncWebView.mCatalystInstance != null) {
+        if (!isJsDebugging && rncWebView.mMessagingJSModule != null) {
             final Pair<Double, AtomicReference<RNCWebViewModuleImpl.ShouldOverrideUrlLoadingLock.ShouldOverrideCallbackState>> lock = RNCWebViewModuleImpl.shouldOverrideUrlLoadingLock.getNewLock();
             final double lockIdentifier = lock.first;
             final AtomicReference<RNCWebViewModuleImpl.ShouldOverrideUrlLoadingLock.ShouldOverrideCallbackState> lockObject = lock.second;
 
             final WritableMap event = createWebViewEvent(view, url);
             event.putDouble("lockIdentifier", lockIdentifier);
-            rncWebView.sendDirectMessage("onShouldStartLoadWithRequest", event);
+            rncWebView.dispatchDirectShouldStartLoadWithRequest(event);
 
             try {
                 assert lockObject != null;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewMessagingModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewMessagingModule.kt
@@ -1,0 +1,9 @@
+package com.reactnativecommunity.webview
+
+import com.facebook.react.bridge.JavaScriptModule
+import com.facebook.react.bridge.WritableMap
+
+internal interface RNCWebViewMessagingModule : JavaScriptModule {
+  fun onShouldStartLoadWithRequest(event: WritableMap)
+  fun onMessage(event: WritableMap)
+}

--- a/src/NativeRNCWebView.ts
+++ b/src/NativeRNCWebView.ts
@@ -1,14 +1,14 @@
 /* eslint-disable import/no-duplicates */
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import {Int32} from 'react-native/Libraries/Types/CodegenTypes';
+import {Double} from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};
 
   // your module methods go here, for example:
   isFileUploadSupported(): Promise<boolean>;
-  shouldStartLoadWithLockIdentifier(shouldStart: boolean, lockIdentifier: Int32): void;
+  shouldStartLoadWithLockIdentifier(shouldStart: boolean, lockIdentifier: Double): void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNCWebView');

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -30,9 +30,12 @@ import styles from './WebView.styles';
 
 const { resolveAssetSource } = Image;
 
-const registerCallableModule: (name: string, module: Object) => void =
-  require('react-native').registerCallableModule ??
-  BatchedBridge.registerCallableModule.bind(BatchedBridge);
+const registerCallableModule: (name: string, module: Object) => void
+  // `registerCallableModule()` is available in React Native 0.74 and above.
+  // Fallback to use `BatchedBridge.registerCallableModule()` for older versions.
+  // eslint-disable-next-line global-require
+  = require('react-native').registerCallableModule
+  ?? BatchedBridge.registerCallableModule.bind(BatchedBridge);
 
 /**
  * A simple counter to uniquely identify WebView instances. Do not use this for anything else.
@@ -130,16 +133,16 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
       event: ShouldStartLoadRequestEvent & { messagingModuleName?: string },
     ) => {
       if (event.messagingModuleName === messagingModuleName) {
-        delete event.messagingModuleName;
-        onShouldStartLoadWithRequest(event);
+        const { messagingModuleName: _, ...rest } = event;
+        onShouldStartLoadWithRequest(rest);
       }
     },
     onMessage: (
       event: WebViewMessageEvent & { messagingModuleName?: string },
     ) => {
       if (event.messagingModuleName === messagingModuleName) {
-        delete event.messagingModuleName;
-        onMessage(event);
+        const { messagingModuleName: _, ...rest } = event;
+        onMessage(rest);
       }
     },
   }), [messagingModuleName, onMessage, onShouldStartLoadWithRequest]);


### PR DESCRIPTION
# Why

react-native-webview does not work on react-native 0.74 with bridgeless mode

# How

there were two errors actually:
1. build error from override `shouldStartLoadWithLockIdentifier()`. the [newer codegen supports Int32](https://github.com/facebook/react-native/commit/ccd3b047709fda00123e8aec4294dce024b80244) and generates java code as int type. the current code is using double type. the pr tries to use double type as the implementation using double under the hood.
2.  on bridgeless mode, we cannot access `CatalystInstance`. it seems react-native-webview used it for sending direct message. BridgelessReactContext does not have equivalent `callFunction(moduleName: string, ...)`. this pr tries to register a single `RNCWebViewMessagingModule` module and check the underlying `messagingModuleName` inside the event. each webview will only receive events belong its `messagingModuleName`.

# Test Plan

- test example on android
- test example on android (with bumping react-native 0.74 and newArchEnabled=true)
- test on react-native 0.71 old architecture to make sure no regression