### PR TITLE
fix: Remove log statement that breaks react-native-community autolinking config

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -19,12 +19,9 @@ const project = (() => {
       },
     });
   } catch (e) {
-    console.log('Hello?', e);
     return undefined;
   }
 })();
-
-// console.log(project);
 
 module.exports = {
   dependencies: {


### PR DESCRIPTION
When running a build in a project without a **react-native.config.js** with the log in **metro.config.js** catch block:

```
FAILURE: Build failed with an exception.

* Where:
Script '/Users/brent/code/with-webview/node_modules/@react-native-community/cli-platform-android/native_modules.gradle' line: 442

* What went wrong:
A problem occurred evaluating script.
> Calling `[node, /Users/brent/code/with-webview/node_modules/@react-native-community/cli/build/bin.js, config]` finished with an exception. Error message: groovy.json.JsonException: Unable to determine the current character, it is not a string, number, array, or object

  The current character read is 'H' with an int value of 72
  Unable to determine the current character, it is not a string, number, array, or object
  line number 1
  index number 0
  Hello? Error: Failed to find `react-native.config.js`
  ^. Output: Hello? Error: Failed to find `react-native.config.js`
      at configureProjects (/Users/brent/code/with-webview/node_modules/react-native-test-app/scripts/configure-projects.js:169:11)
```

As an aside - I don't know much about react-native-test-app, but I'm somewhat surprised it has anything to do with the config that is being run anywhere outside of the context of when you are building the app.