### PR TITLE
fix(android): Handle null value in setMenuCustomItems method

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -642,9 +642,12 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray) {
+    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray?) {
         val view = viewWrapper.webView
-        view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
+        when (value) {
+            null -> view.setMenuCustomItems(null)
+            else -> view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
+        }
     }
 
     fun setNestedScrollEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {


### PR DESCRIPTION
Following the implementation of menuItems support in Android (#2993), there's been an observed issue within the Android platform where altering menuItems triggers a Null Pointer Exception.

This issue seems to originate from a missing null handling in `RNCWebViewManagerImpl.kt`. I've detailed the specific error encountered below for reference.

This PR introduces modifications to handle cases where value is null in the setMenuCustomItems function.

Your feedback is greatly appreciated.


```
    com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating property 'menuItems' of a view managed by: RNCWebView
         at com.facebook.react.uimanager.v0$b.b(ViewManagerPropertyUpdater.java:123)
         at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:79)
         at com.facebook.react.uimanager.m.updateProperties(NativeViewHierarchyManager.java:15)
         at com.facebook.react.uimanager.r0$t.d(UIViewOperationQueue.java:9)
         at com.facebook.react.uimanager.p0.run(UIViewOperationQueue.java:132)
         at com.facebook.react.uimanager.r0.c(UIViewOperationQueue.java:54)
         at com.facebook.react.uimanager.r0$h.doFrameGuarded(UIViewOperationQueue.java:28)
         at com.facebook.react.uimanager.f.doFrame(GuardedFrameCallback.java:1)
         at com.facebook.react.modules.core.ReactChoreographer$b.doFrame(ReactChoreographer.java:36)
         at com.facebook.react.modules.core.a$a$a.doFrame(ChoreographerCompat.java:3)
         at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1299)
         at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1309)
         at android.view.Choreographer.doCallbacks(Choreographer.java:923)
         at android.view.Choreographer.doFrame(Choreographer.java:847)
         at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1283)
         at android.os.Handler.handleCallback(Handler.java:942)
         at android.os.Handler.dispatchMessage(Handler.java:99)
         at android.os.Looper.loopOnce(Looper.java:226)
         at android.os.Looper.loop(Looper.java:313)
         at android.app.ActivityThread.main(ActivityThread.java:8762)
         at java.lang.reflect.Method.invoke(Native Method)
         at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
    Caused by: java.lang.reflect.InvocationTargetException
         at java.lang.reflect.Method.invoke(Native Method)
         at com.facebook.react.uimanager.v0$b.b(ViewManagerPropertyUpdater.java:65)
         at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:79) 
         at com.facebook.react.uimanager.m.updateProperties(NativeViewHierarchyManager.java:15) 
         at com.facebook.react.uimanager.r0$t.d(UIViewOperationQueue.java:9) 
         at com.facebook.react.uimanager.p0.run(UIViewOperationQueue.java:132) 
         at com.facebook.react.uimanager.r0.c(UIViewOperationQueue.java:54) 
         at com.facebook.react.uimanager.r0$h.doFrameGuarded(UIViewOperationQueue.java:28) 
         at com.facebook.react.uimanager.f.doFrame(GuardedFrameCallback.java:1) 
         at com.facebook.react.modules.core.ReactChoreographer$b.doFrame(ReactChoreographer.java:36) 
         at com.facebook.react.modules.core.a$a$a.doFrame(ChoreographerCompat.java:3) 
         at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1299) 
         at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1309) 
         at android.view.Choreographer.doCallbacks(Choreographer.java:923) 
         at android.view.Choreographer.doFrame(Choreographer.java:847) 
         at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1283) 
         at android.os.Handler.handleCallback(Handler.java:942) 
         at android.os.Handler.dispatchMessage(Handler.java:99) 
         at android.os.Looper.loopOnce(Looper.java:226) 
         at android.os.Looper.loop(Looper.java:313) 
         at android.app.ActivityThread.main(ActivityThread.java:8762) 
         at java.lang.reflect.Method.invoke(Native Method) 
         at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604) 
         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067) 
    Caused by: java.lang.NullPointerException: Parameter specified as non-null is null: method com.reactnativecommunity.webview.RNCWebViewManager.setMenuCustomItems, parameter value
         at com.reactnativecommunity.webview.RNCWebViewManager.setMenuCustomItems(RNCWebViewManager.java:13)
         at java.lang.reflect.Method.invoke(Native Method) 

```