### PR TITLE
fix(iOS): replace nullish coalescing operator for older iOS versions

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1683,10 +1683,10 @@ didFinishNavigation:(WKNavigation *)navigation
     initWithSource: [
       NSString
       stringWithFormat:
-       @"window.%@ ??= {};"
+       @"window.%@ = window.%@ || {};"
       "window.%@.injectedObjectJson = function () {"
       "  return `%@`;"
-      "};", MessageHandlerName, MessageHandlerName, source
+      "};", MessageHandlerName, MessageHandlerName, MessageHandlerName, source
     ]
     injectionTime:WKUserScriptInjectionTimeAtDocumentStart
     /* TODO: For a separate (minor) PR: use logic like this (as react-native-wkwebview does) so that messaging can be used in all frames if desired.
@@ -1734,10 +1734,10 @@ didFinishNavigation:(WKNavigation *)navigation
     initWithSource: [
       NSString
       stringWithFormat:
-       @"window.%@ ??= {};"
+       @"window.%@ = window.%@ || {};"
       "window.%@.postMessage = function (data) {"
       "  window.webkit.messageHandlers.%@.postMessage(String(data));"
-      "};", MessageHandlerName, MessageHandlerName, MessageHandlerName
+      "};", MessageHandlerName, MessageHandlerName, MessageHandlerName, MessageHandlerName
     ]
     injectionTime:WKUserScriptInjectionTimeAtDocumentStart
     /* TODO: For a separate (minor) PR: use logic like this (as react-native-wkwebview does) so that messaging can be used in all frames if desired.


### PR DESCRIPTION
During my recent work with react-native-webview, I encountered an issue with the postMessage function not functioning correctly on older iOS devices, notably iOS 13.7. 
Upon investigation, it became apparent that this issue stems from the WKUserScript initialization code changed in react-native-webview 13.8 (#3157)

Considering that iOS versions 13.7 and below do not support the Nullish coalescing assignment (??=) operator, I propose exploring alternatives to this operator for compatibility purposes. 
Your review and feedback on this matter would be greatly appreciated.

Thank you!