### PR TITLE
fix(android): messaging regression for multiple webviews

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,7 @@ import Uploads from './examples/Uploads';
 import Injection from './examples/Injection';
 import LocalPageLoad from './examples/LocalPageLoad';
 import Messaging from './examples/Messaging';
+import MultiMessaging from './examples/MultiMessaging';
 import NativeWebpage from './examples/NativeWebpage';
 import ApplePay from './examples/ApplePay';
 import CustomMenu from './examples/CustomMenu';
@@ -32,6 +33,14 @@ const TESTS = {
     description: 'js-webview postMessage messaging test',
     render() {
       return <Messaging />;
+    },
+  },
+  MultiMessaging: {
+    title: 'MultiMessaging',
+    testId: 'multimessaging',
+    description: 'Multi js-webview postMessage messaging test',
+    render() {
+      return <MultiMessaging />;
     },
   },
   Alerts: {
@@ -223,6 +232,11 @@ export default class App extends Component<Props, State> {
             testID="testType_messaging"
             title="Messaging"
             onPress={() => this._changeTest('Messaging')}
+          />
+          <Button
+            testID="testType_multimessaging"
+            title="MultiMessaging"
+            onPress={() => this._changeTest('MultiMessaging')}
           />
           <Button
             testID="testType_nativeWebpage"

--- a/example/examples/MultiMessaging.tsx
+++ b/example/examples/MultiMessaging.tsx
@@ -1,0 +1,104 @@
+/* eslint-disable react-native/no-inline-styles */
+import React from 'react';
+import { View, Alert, TextInput } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `<!DOCTYPE html>\n
+<html>
+  <head>
+    <title>Messaging</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=160, user-scalable=no">
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 0;
+        font: 62.5% arial, sans-serif;
+        background: #ccc;
+      }
+    </style>
+  </head>
+  <body>
+    <button onclick="sendPostMessage()">Send post message from JS to WebView</button>
+    <p id="demo"></p>
+    <p id="test">Nothing received yet</p>
+
+    <script>
+      function sendPostMessage() {
+        window.ReactNativeWebView.postMessage('Message from JS');
+      }
+
+      window.addEventListener('message',function(event){
+        document.getElementById('test').innerHTML = event.data;
+        console.log("Message received from RN: ",event.data);
+      },false);
+      document.addEventListener('message',function(event){
+        document.getElementById('test').innerHTML = event.data;
+        console.log("Message received from RN: ",event.data);
+      },false);
+
+    </script>
+  </body>
+</html>`;
+
+export default function MultiMessaging() {
+  const webView = React.useRef<WebView | null>(null);
+  const webView2 = React.useRef<WebView | null>(null);
+
+  return (
+    <View style={{ flex: 1, flexDirection: 'row' }}>
+      <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
+        <TextInput
+          style={{
+            height: 40,
+            borderColor: 'gray',
+            borderWidth: 1,
+            margin: 8,
+          }}
+          onSubmitEditing={(e) => {
+            webView.current?.postMessage(e.nativeEvent.text);
+          }}
+        />
+        <WebView
+          ref={webView}
+          source={{ html: HTML }}
+          onLoadEnd={() => {
+            webView.current?.postMessage('Hello from RN');
+          }}
+          automaticallyAdjustContentInsets={false}
+          onMessage={(e: { nativeEvent: { data?: string } }) => {
+            Alert.alert('Message received from JS: ', e.nativeEvent.data);
+          }}
+        />
+      </View>
+
+      <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
+        <TextInput
+          style={{
+            height: 40,
+            borderColor: 'gray',
+            borderWidth: 1,
+            margin: 8,
+          }}
+          onSubmitEditing={(e) => {
+            webView2.current?.postMessage(e.nativeEvent.text);
+          }}
+        />
+        <WebView
+          ref={webView2}
+          source={{
+            html: HTML.replace(/from JS/g, 'from JS2'),
+          }}
+          onLoadEnd={() => {
+            webView2.current?.postMessage('Hello from RN2');
+          }}
+          automaticallyAdjustContentInsets={false}
+          onMessage={(e: { nativeEvent: { data?: string } }) => {
+            Alert.alert('Message received from JS2: ', e.nativeEvent.data);
+          }}
+        />
+      </View>
+    </View>
+  );
+}

--- a/example/examples/MultiMessaging.windows.tsx
+++ b/example/examples/MultiMessaging.windows.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable react-native/no-inline-styles */
+import React from 'react';
+import { View, Alert, TextInput } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `<!DOCTYPE html>\n
+<html>
+  <head>
+    <title>Messaging</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=160, user-scalable=no">
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 0;
+        font: 62.5% arial, sans-serif;
+        background: #ccc;
+      }
+    </style>
+  </head>
+  <body>
+    <button onclick="sendPostMessage()">Send post message from JS to WebView</button>
+    <p id="demo"></p>
+    <p id="test">Nothing received yet</p>
+
+    <script>
+      function sendPostMessage() {
+        window.postMessage('Message from JS');
+      }
+
+      window.addEventListener('message',function(event){
+        document.getElementById('test').innerHTML = event.data;
+        console.log("Message received from RN: ",event.data);
+      },false);
+      document.addEventListener('message',function(event){
+        document.getElementById('test').innerHTML = event.data;
+        console.log("Message received from RN: ",event.data);
+      },false);
+
+    </script>
+  </body>
+</html>`;
+
+export default function MultiMessaging() {
+  const webView = React.useRef<WebView | null>(null);
+  const webView2 = React.useRef<WebView | null>(null);
+
+  return (
+    <View style={{ flex: 1, flexDirection: 'row' }}>
+      <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
+        <TextInput
+          style={{
+            height: 40,
+            borderColor: 'gray',
+            borderWidth: 1,
+            margin: 8,
+          }}
+          onSubmitEditing={(e) => {
+            webView.current?.postMessage(e.nativeEvent.text);
+          }}
+        />
+        <WebView
+          ref={webView}
+          source={{ html: HTML }}
+          onLoadEnd={() => {
+            webView.current?.postMessage('Hello from RN');
+          }}
+          automaticallyAdjustContentInsets={false}
+          onMessage={(e: { nativeEvent: { data?: string } }) => {
+            Alert.alert('Message received from JS: ', e.nativeEvent.data);
+          }}
+          useWebView2
+        />
+      </View>
+
+      <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
+        <TextInput
+          style={{
+            height: 40,
+            borderColor: 'gray',
+            borderWidth: 1,
+            margin: 8,
+          }}
+          onSubmitEditing={(e) => {
+            webView2.current?.postMessage(e.nativeEvent.text);
+          }}
+        />
+        <WebView
+          ref={webView2}
+          source={{
+            html: HTML.replace(/from JS/g, 'from JS2'),
+          }}
+          onLoadEnd={() => {
+            webView2.current?.postMessage('Hello from RN2');
+          }}
+          automaticallyAdjustContentInsets={false}
+          onMessage={(e: { nativeEvent: { data?: string } }) => {
+            Alert.alert('Message received from JS2: ', e.nativeEvent.data);
+          }}
+          useWebView2
+        />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
# Why

Fixes #3368 which is my regression from #3352

# How

JSModule `registerCallableModule()` does not support multiple listeners. The newer WebView will overwrite the previously registered callbacks.
This PR tries to move `registerCallableModule()` at top as a module singleton. With an intermediate EventEmitter to dispatch events to each WebViews. I tries to import the internal vendored EventEmitter from react-native. If that is not ideal, we could replace as third-party EventEmitter such as [fbemitter](https://www.npmjs.com/package/fbemitter).

# Test Plan

extend the Messsaging.tsx example as two WebViews and check whether messages are sent correctly.

```tsx
import React, { Component } from 'react';
import { View, Alert, TextInput } from 'react-native';

import WebView from 'react-native-webview';

const HTML = `<!DOCTYPE html>\n
<html>
  <head>
    <title>Messaging</title>
    <meta http-equiv="content-type" content="text/html; charset=utf-8">
    <meta name="viewport" content="width=320, user-scalable=no">
    <style type="text/css">
      body {
        margin: 0;
        padding: 0;
        font: 62.5% arial, sans-serif;
        background: #ccc;
      }
    </style>
  </head>
  <body>
    <button onclick="sendPostMessage()">Send post message from JS to WebView</button>
    <p id="demo"></p>
    <p id="test">Nothing received yet</p>

    <script>
      function sendPostMessage() {
        window.ReactNativeWebView.postMessage('Message from JS');
      }

      window.addEventListener('message',function(event){
        document.getElementById('test').innerHTML = event.data;
        console.log("Message received from RN: ",event.data);
      },false);
      document.addEventListener('message',function(event){
        document.getElementById('test').innerHTML = event.data;
        console.log("Message received from RN: ",event.data);
      },false);

    </script>
  </body>
</html>`;

type Props = {};
type State = {};

export default class Messaging extends Component<Props, State> {
  state = {};

  constructor(props) {
    super(props);
    this.webView = React.createRef();
    this.webView2 = React.createRef();
  }

  render() {
    return (
      <View style={{ flex: 1, flexDirection: 'row' }}>
        <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
          <TextInput
            style={{
              height: 40,
              borderColor: 'gray',
              borderWidth: 1,
              margin: 8,
            }}
            onSubmitEditing={(e) => {
              this.webView.current.postMessage(e.nativeEvent.text);
            }}
          />
          <WebView
            ref={this.webView}
            source={{ html: HTML }}
            onLoadEnd={() => {
              this.webView.current.postMessage('Hello from RN');
            }}
            automaticallyAdjustContentInsets={false}
            onMessage={(e: { nativeEvent: { data?: string } }) => {
              Alert.alert('Message received from JS: ', e.nativeEvent.data);
            }}
          />
        </View>

        <View style={{ flexDirection: 'column', flex: 1, margin: 4 }}>
          <TextInput
            style={{
              height: 40,
              borderColor: 'gray',
              borderWidth: 1,
              margin: 8,
            }}
            onSubmitEditing={(e) => {
              this.webView2.current.postMessage(e.nativeEvent.text);
            }}
          />
          <WebView
            ref={this.webView2}
            source={{
              html: HTML.replace(/from JS/g, 'from JS2'),
            }}
            onLoadEnd={() => {
              this.webView2.current.postMessage('Hello from RN2');
            }}
            automaticallyAdjustContentInsets={false}
            onMessage={(e: { nativeEvent: { data?: string } }) => {
              Alert.alert('Message received from JS2: ', e.nativeEvent.data);
            }}
          />
        </View>
      </View>
    );
  }
}

```

demo video: 
[Screen_recording_20240411_013607.webm](https://github.com/react-native-webview/react-native-webview/assets/46429/67a079cd-de1a-4023-ad59-3e5e400a12bd)
