### PR TITLE
Support for visionOS

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -171,8 +171,10 @@ RCTAutoInsetsProtocol>
     _contentInset = UIEdgeInsetsZero;
     _savedKeyboardDisplayRequiresUserAction = YES;
 #if !TARGET_OS_OSX
+#if !TARGET_OS_VISION
     _savedStatusBarStyle = RCTSharedApplication().statusBarStyle;
     _savedStatusBarHidden = RCTSharedApplication().statusBarHidden;
+#endif
 #endif // !TARGET_OS_OSX
     _injectedJavaScript = nil;
     _injectedJavaScriptForMainFrameOnly = YES;
@@ -250,7 +252,9 @@ RCTAutoInsetsProtocol>
     if (self.menuItems.count == 0) {
         UIMenuController *menuController = [UIMenuController sharedMenuController];
         menuController.menuItems = nil;
+#if !TARGET_OS_VISION
         [menuController setMenuVisible:NO animated:YES];
+#endif
         return;
     }
     UIMenuController *menuController = [UIMenuController sharedMenuController];
@@ -266,7 +270,9 @@ RCTAutoInsetsProtocol>
     }
 
     menuController.menuItems = menuControllerItems;
+#if !TARGET_OS_VISION
     [menuController setMenuVisible:YES animated:YES];
+#endif
 }
 
 #endif // !TARGET_OS_OSX
@@ -603,9 +609,11 @@ RCTAutoInsetsProtocol>
   }
 
   _isFullScreenVideoOpen = YES;
+#if !TARGET_OS_VISION
   RCTUnsafeExecuteOnMainQueueSync(^{
     [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
   });
+#endif
 #pragma clang diagnostic pop
 }
 
@@ -617,10 +625,12 @@ RCTAutoInsetsProtocol>
   }
 
   _isFullScreenVideoOpen = NO;
+#if !TARGET_OS_VISION
   RCTUnsafeExecuteOnMainQueueSync(^{
     [RCTSharedApplication() setStatusBarHidden:self->_savedStatusBarHidden animated:YES];
     [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
   });
+#endif
 #pragma clang diagnostic pop
 }
 

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => ios_platform, :osx => "10.13" }
+  s.platforms    = { :ios => ios_platform, :visionos => "1.0", :osx => "10.13" }
 
   s.source       = { :git => "https://github.com/react-native-webview/react-native-webview.git", :tag => "v#{s.version}" }
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -12,6 +12,9 @@ const project = (() => {
       ios: {
         sourceDir: 'example/ios',
       },
+      visionos: {
+        sourceDir: 'example/ios',
+      },
       windows: fs.existsSync('example/windows/WebviewExample.sln') && {
         sourceDir: path.join('example', 'windows'),
         solutionFile: path.join('example', 'windows', 'WebviewExample.sln'),


### PR DESCRIPTION
This was not compatible with https://github.com/callstack/react-native-visionos 

- Marked package as supporting visionOS
- Avoid api's that xcode says are not available on visionos

Tested by following:
https://callstack.github.io/react-native-visionos-docs/docs/getting-started/create-first-app 