### PR TITLE
Fix crash when opening 4xx pages with no description.

### DIFF
--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -109,7 +109,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .code = [[dictionary valueForKey:@"code"] intValue],
-                    .description = std::string([[dictionary valueForKey:@"description"] UTF8String]),
+                    .description = std::string([[dictionary valueForKey:@"description"] UTF8String] ?: ""),
                     .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
@@ -230,7 +230,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                     .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                     .statusCode = [[dictionary valueForKey:@"statusCode"] intValue],
-                    .description = std::string([[dictionary valueForKey:@"description"] UTF8String]),
+                    .description = std::string([[dictionary valueForKey:@"description"] UTF8String] ?: ""),
                     .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue])


### PR DESCRIPTION
Hey, at https://freeyourmusic.com we have a weird case, where user is redirected to a page with 404 error that crashes on iOS. After further investigation, we found that this is because of `description=NULL` as seen on screenshot:
![CleanShot 2024-04-25 at 15 24 05@2x](https://github.com/react-native-webview/react-native-webview/assets/1025588/33a28a0b-a61e-408e-991b-ce4f6df684a9)

This PR fixes this issue and possibly https://github.com/react-native-webview/react-native-webview/issues/3412