### PR TITLE
Use latest react-native-cookies/cookies name in Guide.md

### DIFF
--- a/docs/Guide.italian.md
+++ b/docs/Guide.italian.md
@@ -485,7 +485,7 @@ const CustomHeaderWebView = (props) => {
 ```
 
 #### Gestione dei cookie
-Puoi impostare i cookie dal lato React Native utilizzando il pacchetto [@react-native-community/cookies](https://github.com/react-native-community/cookies).
+Puoi impostare i cookie dal lato React Native utilizzando il pacchetto [@react-native-cookies/cookies](https://github.com/react-native-cookies/cookies).
 
 Quando lo fai, dovrai abilitare anche la prop [sharedCookiesEnabled](Reference.italian.md#sharedCookiesEnabled).
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -562,7 +562,7 @@ const CustomHeaderWebView = (props) => {
 
 #### Managing Cookies
 
-You can set cookies on the React Native side using the [@react-native-community/cookies](https://github.com/react-native-community/cookies) package.
+You can set cookies on the React Native side using the [@react-native-cookies/cookies](https://github.com/react-native-cookies/cookies) package.
 
 When you do, you'll likely want to enable the [sharedCookiesEnabled](Reference.md#sharedCookiesEnabled) prop as well.
 

--- a/docs/Guide.portuguese.md
+++ b/docs/Guide.portuguese.md
@@ -502,7 +502,7 @@ const CustomHeaderWebView = (props) => {
 
 #### Gerenciando cookies
 
-Você pode definir cookies no lado React Native usando o pacote [@react-native-community/cookies](https://github.com/react-native-community/cookies).
+Você pode definir cookies no lado React Native usando o pacote [@react-native-cookies/cookies](https://github.com/react-native-cookies/cookies).
 
 Ao fazer isso, você provavelmente desejará habilitar a propriedade [sharedCookiesEnabled](Reference.portuguese.md#sharedCookiesEnabled) também.
 


### PR DESCRIPTION
As of v6.0.0, `react-native-community/cookies` was renamed to `react-native-cookies/cookies`: https://github.com/react-native-cookies/cookies?tab=readme-ov-file#important-notices--breaking-changes