### PR TITLE
chore(docs): Update onOpenWindow documentation

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -626,6 +626,9 @@ Function that is invoked when the `WebView` should open a new window.
 
 This happens when the JS calls `window.open('http://someurl', '_blank')` or when the user clicks on a `<a href="http://someurl" target="_blank">` link.
 
+> **_Note_**
+> This will not be invoked on Android if [`setSupportMultipleWindows`](Reference.md#setSupportMultipleWindows) is `false`.
+
 | Type     | Required |
 | -------- | -------- |
 | function | No       |


### PR DESCRIPTION
Seems worth pointing out that `onOpenWindow` requires multi-window support to be enabled.