### PR TITLE
fix: Implement missing methods of RNCWebViewManagerInterface

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -342,6 +342,9 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     public void setAllowsInlineMediaPlayback(RNCWebViewWrapper view, boolean value) {}
 
     @Override
+    public void setAllowsPictureInPictureMediaPlayback(RNCWebViewWrapper view, boolean value) {}
+
+    @Override
     public void setAllowsAirPlayForMediaPlayback(RNCWebViewWrapper view, boolean value) {}
 
     @Override
@@ -388,6 +391,9 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setPullToRefreshEnabled(RNCWebViewWrapper view, boolean value) {}
+
+    @Override
+    public void setRefreshControlLightMode(RNCWebViewWrapper view, boolean value) {}
 
     @Override
     public void setScrollEnabled(RNCWebViewWrapper view, boolean value) {}


### PR DESCRIPTION
fix `Class 'RNCWebViewManager' must either be declared abstract or implement abstract method 'setRefreshControlLightMode(T, boolean)' in 'RNCWebViewManagerInterface'` and `Class 'RNCWebViewManager' must either be declared abstract or implement abstract method 'setAllowsPictureInPictureMediaPlayback(T, boolean)' in 'RNCWebViewManagerInterface'` errors.

```
> Task :react-native-webview:compileDebugJavaWithJavac FAILED
projectX/react-native-webview/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java:36: error: RNCWebViewManager is not abstract and does not override abstract method setRefreshControlLightMode(RNCWebViewWrapper,boolean) in RNCWebViewManagerInterface
public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
       ^
Note: projectX/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewPackage.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error
```

<img width="1792" alt="Screenshot 2024-08-23 at 12 09 25" src="https://github.com/user-attachments/assets/9bf33415-ba10-4581-bd1b-f9a996b97d34">
