### PR TITLE
fix(apple): Updates how HTTP errors are handled

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1406,11 +1406,10 @@ RCTAutoInsetsProtocol>
                     decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
   WKNavigationResponsePolicy policy = WKNavigationResponsePolicyAllow;
-  if (_onHttpError && navigationResponse.forMainFrame) {
-    if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]]) {
-      NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
-      NSInteger statusCode = response.statusCode;
-
+  if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]]) {
+    NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
+    NSInteger statusCode = response.statusCode;
+    if (_onHttpError && navigationResponse.forMainFrame) {
       if (statusCode >= 400) {
         NSMutableDictionary<NSString *, id> *httpErrorEvent = [self baseEvent];
         [httpErrorEvent addEntriesFromDictionary: @{
@@ -1420,22 +1419,21 @@ RCTAutoInsetsProtocol>
 
         _onHttpError(httpErrorEvent);
       }
+    }
+    NSString *disposition = nil;
+    if (@available(iOS 13, macOS 10.15, *)) {
+      disposition = [response valueForHTTPHeaderField:@"Content-Disposition"];
+    }
+    BOOL isAttachment = disposition != nil && [disposition hasPrefix:@"attachment"];
+    if (isAttachment || !navigationResponse.canShowMIMEType) {
+      if (_onFileDownload) {
+        policy = WKNavigationResponsePolicyCancel;
 
-      NSString *disposition = nil;
-      if (@available(iOS 13, macOS 10.15, *)) {
-        disposition = [response valueForHTTPHeaderField:@"Content-Disposition"];
-      }
-      BOOL isAttachment = disposition != nil && [disposition hasPrefix:@"attachment"];
-      if (isAttachment || !navigationResponse.canShowMIMEType) {
-        if (_onFileDownload) {
-          policy = WKNavigationResponsePolicyCancel;
-
-          NSMutableDictionary<NSString *, id> *downloadEvent = [self baseEvent];
-          [downloadEvent addEntriesFromDictionary: @{
-            @"downloadUrl": (response.URL).absoluteString,
-          }];
-          _onFileDownload(downloadEvent);
-        }
+        NSMutableDictionary<NSString *, id> *downloadEvent = [self baseEvent];
+        [downloadEvent addEntriesFromDictionary: @{
+          @"downloadUrl": (response.URL).absoluteString,
+        }];
+        _onFileDownload(downloadEvent);
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6538,15 +6538,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
On iOS/macOS, the previous code had an issue where HTTP error handling and file download logic in the `webView:decidePolicyForNavigationResponse:decisionHandler:` method was only being executed for main frame responses (due to the navigationResponse.forMainFrame check). This meant that responses from iframes were not being properly handled, potentially leading to security issues or missed file downloads.

This PR (credit to @ugwst-sec for the tip) fixes that issue by changing the conditional logic.

(Tip: turn off "whitespace" in the diff -- it's a pretty minimal change, but the indentation change makes the diff look scarier than it is.)


