### PR TITLE
fix(android): Support video upload with capture attribute

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -268,6 +268,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
         ArrayList<Parcelable> extraIntents = new ArrayList<>();
         Intent photoIntent = null;
+        Intent videoIntent = null;
         if (!needsCameraPermission()) {
             if (acceptsImages(acceptTypes)) {
                 photoIntent = getPhotoIntent();
@@ -276,7 +277,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
                 }
             }
             if (acceptsVideo(acceptTypes)) {
-                Intent videoIntent = getVideoIntent();
+                videoIntent = getVideoIntent();
                 if (videoIntent != null) {
                     extraIntents.add(videoIntent);
                 }
@@ -285,7 +286,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
         if (isCaptureEnabled) {
-            chooserIntent = photoIntent;
+            chooserIntent = photoIntent != null ? photoIntent : videoIntent;
         } else {
             Intent fileSelectionIntent = getFileChooserIntent(acceptTypes, allowMultiple);
 


### PR DESCRIPTION
My first time contributing, so any feedback is welcome!

---

Currently, when you use a file input for videos with the `capture` attribute in the webview, it does not appear to work as intended.

In my specific situation, I have a file input that look like this:
```html
<input type="file" accept="video/*" capture="user">
```

On Android 14, this will result in the `there is no Camera permission` error, since it will look for a `photoIntent, but no photoIntent is requested.

I made a fairly simple change that will first check for a `photoIntent` and then check for the `videoIntent`.

