### PR TITLE
fix(android, new arch): Do not execute commands twice

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -426,7 +426,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         mRNCWebViewManagerImpl.setUserAgent(view, value);
     }
 
-    // These will never be called because we use the shared impl for now
   @Override
   public void goBack(RNCWebViewWrapper view) {
     view.getWebView().goBack();
@@ -499,7 +498,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
   public void clearHistory(RNCWebViewWrapper view) {
       view.getWebView().clearHistory();
   }
-  // !These will never be called
 
   @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper view) {
@@ -538,7 +536,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
-        mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
     }
 


### PR DESCRIPTION
No need to manually call the methods, the generated delegate already does that for us.

Fixes #3305