### PR TITLE
fix-android-capture:fix Video Capture is not supported on Android.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -268,6 +268,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
         ArrayList<Parcelable> extraIntents = new ArrayList<>();
         Intent photoIntent = null;
+        Intent videoIntent = null;
         if (!needsCameraPermission()) {
             if (acceptsImages(acceptTypes)) {
                 photoIntent = getPhotoIntent();
@@ -276,7 +277,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
                 }
             }
             if (acceptsVideo(acceptTypes)) {
-                Intent videoIntent = getVideoIntent();
+                videoIntent = getVideoIntent();
                 if (videoIntent != null) {
                     extraIntents.add(videoIntent);
                 }
@@ -285,7 +286,12 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
         if (isCaptureEnabled) {
-            chooserIntent = photoIntent;
+            if (acceptsImages(acceptTypes)) {
+                chooserIntent = photoIntent;
+            }
+            if (acceptsVideo(acceptTypes)) {
+                chooserIntent = videoIntent;
+            }
         } else {
             Intent fileSelectionIntent = getFileChooserIntent(acceptTypes, allowMultiple);
 


### PR DESCRIPTION
When I have to capture video in Webview, like this:

`<input type="file" accept="video/*" capture="user">`

I could't get any response when i click "Choose file" on Android. Then i get "there is no Camera permission" by checking  the Logcat. So I submit some code to fix this issue.