### PR TITLE
[#3014] Fix for the issue 3014

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -341,6 +341,14 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         return true;
     }
 
+    @Override
+    public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+      var hit = this.getHitTestResult();
+      if (hit.getType() == HitTestResult.EDIT_TEXT_TYPE) {
+        return super.requestFocus(direction, previouslyFocusedRect);
+      } else return false;
+    }
+
     protected void onScrollChanged(int x, int y, int oldX, int oldY) {
         super.onScrollChanged(x, y, oldX, oldY);
 


### PR DESCRIPTION
- #3014:
  **Android:** Adds `requestFocus()` and `onFocusChanged()` methods to the native WebView implementation, to only accept input focus when a focusable element inside the WebView is hit by a touch, and to correctly reset the hit test when WebView loses the focus. It fixes the issue with ScollView jump when a WebView is touched &mdash; the ScrollView automatically scrolls to its child when the child accepts input focus, and before this patch the WebView was accepting the focus on touch anywhere within WebView rect.