### PR TITLE
fix: remove overflow:hidden on iOS to fix webview on EXPO ^51

### DIFF
--- a/src/WebView.styles.ts
+++ b/src/WebView.styles.ts
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    overflow: 'hidden',
   },
   loadingOrErrorView: {
     position: 'absolute',


### PR DESCRIPTION
Related to: https://github.com/expo/expo/issues/31850

Fix WebView on iOS - Expo ^51:

- Remove hidden overflow by default on the container;
- Requires minHeight to be set, in order to see the webview.

<img width="481" alt="Screenshot 2024-10-10 at 17 19 00" src="https://github.com/user-attachments/assets/c8b6678a-eaa0-4501-bec1-eb15e4d46af1">

```
import { useWindowDimensions } from "react-native";
import React from "react";
import { WebView } from "react-native-webview";

export default function App() {
  const {height} = useWindowDimensions();

  return (
    <>
      <WebView style={{minHeight: height}} originWhitelist={["*"]} source={{ uri: 'https://reactnative.dev/' }} />
    </>
  );
}

```