### PR TITLE
fix(android): allowFileAccess does not apply to initial loading

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -41,7 +41,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     public RNCWebViewManager() {
         mDelegate = new RNCWebViewManagerDelegate<>(this);
-        mRNCWebViewManagerImpl = new RNCWebViewManagerImpl();
+        mRNCWebViewManagerImpl = new RNCWebViewManagerImpl(true);
     }
 
     @Nullable
@@ -310,7 +310,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     @ReactProp(name = "newSource")
     public void setNewSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
-        mRNCWebViewManagerImpl.setSource(view, value, true);
+        mRNCWebViewManagerImpl.setSource(view, value);
     }
 
     @Override
@@ -537,6 +537,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         super.receiveCommand(reactWebView, commandId, args);
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull RNCWebViewWrapper view) {
+        super.onAfterUpdateTransaction(view);
+        mRNCWebViewManagerImpl.onAfterUpdateTransaction(view);
     }
 
     @Override

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -250,7 +250,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
 
     @ReactProp(name = "source")
     public void setSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
-        mRNCWebViewManagerImpl.setSource(view, value, false);
+        mRNCWebViewManagerImpl.setSource(view, value);
     }
 
     @ReactProp(name = "textZoom")
@@ -312,6 +312,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
+    }
+
+    @Override
+    protected void onAfterUpdateTransaction(@NonNull RNCWebViewWrapper view) {
+        super.onAfterUpdateTransaction(view);
+        mRNCWebViewManagerImpl.onAfterUpdateTransaction(view);
     }
 
     @Override


### PR DESCRIPTION
# Why

on android and react-native new architecture mode, even with `allowFileAccess`, the initial loading to `file:///` will fail with `net:ERR_ACCESS_DENIED` error.

# How

on new architecture mode updating `source` will go first before `allowFileAccess` in the `RNStylesDiffMap`. we cannot always ensure the order of updating props. on ios implementation, the webview will delay its call to `loadRequest:`. this pr tries to add a similar mechanism on android. we will try to load URL after all updates are finalized.

# Test Plan

- i have a repro at https://github.com/Kudo/repro-webview-late-props
- test react-native-webview's example to check for any regressions