### PR TITLE
revert (e8f3c0e) fix(iOS): preload WebView on initial render in background tabs

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -504,12 +504,9 @@ RCTAutoInsetsProtocol>
   return wkWebViewConfig;
 }
 
-- (void)initializeWebView
+- (void)didMoveToWindow
 {
-  @synchronized (self) {
-    if (_webView != nil) {
-      return;
-    }
+  if (self.window != nil && _webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     [self setBackgroundColor: _savedBackgroundColor];
@@ -561,23 +558,6 @@ RCTAutoInsetsProtocol>
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
     [self visitSource];
-  }
-}
-
-// react-native-mac os does not support didMoveToSuperView
-#if !TARGET_OS_OSX
-- (void)didMoveToSuperview
-{
-  if (self.superview != nil && _webView == nil) {
-    [self initializeWebView];
-  }
-}
-#endif // !TARGET_OS_OSX
-
-- (void)didMoveToWindow
-{
-  if (self.window != nil && _webView == nil) {
-    [self initializeWebView];
   }
 
 #if !TARGET_OS_OSX


### PR DESCRIPTION
PR #3559 which was committed by e8f3c0e causes a regression in a patch release (v13.12.3).
Issue #3578 is open for more than a month and there's even another patch release released after that (v13.12.4).
I'm worried that this regression would be buried and stay unnoticed if we continue ignoring it and don't address.

For more context, Expo DOM (use dom) just started to gain some traction and it relies on RNWV.
Expo managed version of RNWV is 13.12.4 and it'd definitely hit much more people very soon when people start to use it more often.
Maybe pre-13.12.3, this regression wasn't a wild-spread issue but I think we're about to see a lot more people facing it.

Let's revert this relatively small and easy to undo PR and try again another day in another attempt to fix the original issue?