### PR TITLE
fix(iOS): WebView initialized with JavaScript disabled

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -507,7 +507,7 @@ RCTAutoInsetsProtocol>
 - (void)initializeWebView
 {
   @synchronized (self) {
-    if (_webView != nil) {
+    if (self.superview == nil || _webView != nil) {
       return;
     }
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
@@ -564,21 +564,9 @@ RCTAutoInsetsProtocol>
   }
 }
 
-// react-native-mac os does not support didMoveToSuperView
-#if !TARGET_OS_OSX
-- (void)didMoveToSuperview
-{
-  if (self.superview != nil && _webView == nil) {
-    [self initializeWebView];
-  }
-}
-#endif // !TARGET_OS_OSX
-
 - (void)didMoveToWindow
 {
-  if (self.window != nil && _webView == nil) {
-    [self initializeWebView];
-  }
+  [self initializeWebView];
 
 #if !TARGET_OS_OSX
   // Allow this object to recognize gestures
@@ -797,6 +785,8 @@ RCTAutoInsetsProtocol>
 {
   if (![_source isEqualToDictionary:source]) {
     _source = [source copy];
+
+    [self initializeWebView];
 
     if (_webView != nil) {
       [self visitSource];


### PR DESCRIPTION
The change in https://github.com/react-native-webview/react-native-webview/pull/3559 added WebView initialization to didMoveToSuperview, but that method seems to be called too early, before properties like `javascriptEnabled` are set from WebView props.

This change moves WebView initialization from didMoveToSuperview to `setSource` which is called from `updateProps:oldProps:` after all RNCWebViewImpl properties are set from WebView props.

Repro:

- with react-native-webview 13.12.2 - https://github.com/mlazari/WebViewRepro/tree/13.12.2 - WebView does not load in the background tab, it loads only when that tab becomes active, despite the `lazy` tab bar navigator option being set to false
https://github.com/user-attachments/assets/cc3a760a-58ff-4636-b47f-1eb6eef895fb

- with react-native-webview 13.12.4 - https://github.com/mlazari/WebViewRepro/tree/13.12.4 - the WebView loads in the background tab (because of the change in https://github.com/react-native-webview/react-native-webview/pull/3559), but with javascript disabled (it should be enabled by default and enabling it explicitly with `javascriptEnabled={true}` does not change anything)
https://github.com/user-attachments/assets/03ab24c8-b62d-4381-803b-aa4b47d93219

- with react-native-webview 13.12.4 plus this fix (applied with a patch) - https://github.com/mlazari/WebViewRepro/tree/13.12.4-fixed - the WebView load in the background tab with Javascript enabled as expected
https://github.com/user-attachments/assets/172ae56f-9d51-4c48-b9cc-65c817db8164

Fixes https://github.com/react-native-webview/react-native-webview/issues/3616, https://github.com/react-native-webview/react-native-webview/issues/3624 and probably others like https://github.com/react-native-webview/react-native-webview/issues/3595, https://github.com/react-native-webview/react-native-webview/issues/3578, https://github.com/react-native-webview/react-native-webview/issues/3612