### PR TITLE
feat(onScroll): useNativeDriver

### DIFF
--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -79,7 +79,6 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
-RCT_REMAP_VIEW_PROPERTY(contentOffset, scrollView.contentOffset, CGPoint)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -79,6 +79,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_REMAP_VIEW_PROPERTY(contentOffset, scrollView.contentOffset, CGPoint)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -7,14 +7,14 @@ import React, {
   useRef,
 } from 'react';
 
-import { Image, View, ImageSourcePropType, HostComponent } from 'react-native';
+import { Image, View, ImageSourcePropType, HostComponent, Animated } from 'react-native';
 
 import BatchedBridge from 'react-native/Libraries/BatchedBridge/BatchedBridge';
 import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import invariant from 'invariant';
 
-import RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
+import _RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
 import RNCWebViewModule from './NativeRNCWebViewModule';
 import {
   defaultOriginWhitelist,
@@ -31,6 +31,7 @@ import {
 
 import styles from './WebView.styles';
 
+const RNCWebView = Animated.createAnimatedComponent(_RNCWebView)
 const { resolveAssetSource } = Image;
 
 const directEventEmitter = new EventEmitter();

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -7,14 +7,23 @@ import React, {
   useRef,
 } from 'react';
 
-import { Image, View, ImageSourcePropType, HostComponent, Animated } from 'react-native';
+import {
+  Image,
+  View,
+  ImageSourcePropType,
+  HostComponent,
+  Animated,
+} from 'react-native';
 
 import BatchedBridge from 'react-native/Libraries/BatchedBridge/BatchedBridge';
 import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import invariant from 'invariant';
 
-import _RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
+import _RNCWebView, {
+  Commands,
+  NativeProps,
+} from './RNCWebViewNativeComponent';
 import RNCWebViewModule from './NativeRNCWebViewModule';
 import {
   defaultOriginWhitelist,

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -31,7 +31,7 @@ import {
 
 import styles from './WebView.styles';
 
-const RNCWebView = Animated.createAnimatedComponent(_RNCWebView)
+const RNCWebView = Animated.createAnimatedComponent(_RNCWebView);
 const { resolveAssetSource } = Image;
 
 const directEventEmitter = new EventEmitter();

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -4,10 +4,10 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { Image, View, ImageSourcePropType, HostComponent } from 'react-native';
+import { Image, View, ImageSourcePropType, HostComponent, Animated } from 'react-native';
 import invariant from 'invariant';
 
-import RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
+import _RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
 import RNCWebViewModule from './NativeRNCWebViewModule';
 
 import {
@@ -24,6 +24,7 @@ import {
 
 import styles from './WebView.styles';
 
+const RNCWebView = Animated.createAnimatedComponent(_RNCWebView)
 const { resolveAssetSource } = Image;
 const processDecelerationRate = (
   decelerationRate: DecelerationRateConstant | number | undefined

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -4,10 +4,19 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { Image, View, ImageSourcePropType, HostComponent, Animated } from 'react-native';
+import {
+  Image,
+  View,
+  ImageSourcePropType,
+  HostComponent,
+  Animated,
+} from 'react-native';
 import invariant from 'invariant';
 
-import _RNCWebView, { Commands, NativeProps } from './RNCWebViewNativeComponent';
+import _RNCWebView, {
+  Commands,
+  NativeProps,
+} from './RNCWebViewNativeComponent';
 import RNCWebViewModule from './NativeRNCWebViewModule';
 
 import {

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -24,7 +24,7 @@ import {
 
 import styles from './WebView.styles';
 
-const RNCWebView = Animated.createAnimatedComponent(_RNCWebView)
+const RNCWebView = Animated.createAnimatedComponent(_RNCWebView);
 const { resolveAssetSource } = Image;
 const processDecelerationRate = (
   decelerationRate: DecelerationRateConstant | number | undefined


### PR DESCRIPTION
Enables using the native driver for onScroll events:

```jsx
<AnimatedWebView
 onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: animatedScrollYRef.current } } }], {
   useNativeDriver: true
})} />
```



