### PR TITLE
fix(ios): refresh control

### DIFF
--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -114,7 +114,6 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
 #if !TARGET_OS_OSX
 @property (nonatomic, assign) WKDataDetectorTypes dataDetectorTypes;
-@property (nonatomic, weak) UIRefreshControl * _Nullable refreshControl;
 #endif
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1589,11 +1589,10 @@ didFinishNavigation:(WKNavigation *)navigation
 - (void)addPullToRefreshControl
 {
   UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
-  _refreshControl = refreshControl;
   if(_refreshControlLightMode) {
     [refreshControl setTintColor:[UIColor whiteColor]];
   }
-  [_webView.scrollView addSubview: refreshControl];
+  _webView.scrollView.refreshControl = refreshControl;
   [refreshControl addTarget:self action:@selector(pullToRefresh:) forControlEvents: UIControlEventValueChanged];
 }
 
@@ -1611,7 +1610,7 @@ didFinishNavigation:(WKNavigation *)navigation
   if (pullToRefreshEnabled) {
     [self addPullToRefreshControl];
   } else {
-    [_refreshControl removeFromSuperview];
+    _webView.scrollView.refreshControl = nil;
   }
 
   [self setBounces:_bounces];

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -25,6 +25,7 @@ import CustomMenu from './examples/CustomMenu';
 import OpenWindow from './examples/OpenWindow';
 import SuppressMenuItems from './examples/Suppress';
 import ClearData from './examples/ClearData';
+import PullToRefresh from './examples/PullToRefresh';
 
 const TESTS = {
   Messaging: {
@@ -147,6 +148,14 @@ const TESTS = {
       return <SuppressMenuItems />;
     },
   },
+  PullToRefresh: {
+    title: 'PullToRefresh',
+    testId: 'PullToRefresh',
+    description: 'Pull to refresh',
+    render() {
+      return <PullToRefresh />;
+    },
+  },
 };
 
 interface Props {}
@@ -163,7 +172,7 @@ export default class App extends Component<Props, State> {
 
   _simulateRestart = () => {
     this.setState({ restarting: true }, () =>
-      this.setState({ restarting: false }),
+      this.setState({ restarting: false })
     );
   };
 
@@ -269,6 +278,11 @@ export default class App extends Component<Props, State> {
             testID="testType_clearData"
             title="ClearData"
             onPress={() => this._changeTest('ClearData')}
+          />
+          <Button
+            testID="testType_pullToRefresh"
+            title="PullToRefresh"
+            onPress={() => this._changeTest('PullToRefresh')}
           />
         </View>
 

--- a/example/examples/PullToRefresh.tsx
+++ b/example/examples/PullToRefresh.tsx
@@ -1,0 +1,108 @@
+import React, { Component } from 'react';
+import { View } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `
+<!DOCTYPE html>\n
+<html>
+  <head>
+    <title>Alerts</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=320, user-scalable=no">
+    <style>
+    html, body {
+        margin: 0;
+        padding: 0;
+        background-color: gray;
+       
+    }
+  </style>
+  </head>
+   <body>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+   <p>This is the content</p>
+  </body>
+</html>
+`;
+
+type Props = {};
+type State = {};
+
+export default class PullToRefresh extends Component<Props, State> {
+  state = {};
+
+  render() {
+    return (
+      <View style={{ height: 400, backgroundColor: 'green', padding: 10 }}>
+        <WebView
+          source={{ html: HTML }}
+          style={{ backgroundColor: 'red' }}
+          automaticallyAdjustContentInsets={false}
+          pullToRefreshEnabled={true}
+          originWhitelist={['*']}
+          webviewDebuggingEnabled={true}
+        />
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
Assign refresh control to the correct property instead of adding a subview (which causes a jump when insets are set and the user pulls to refresh). 

PS: there's an issue with the reload function when source is inline html, it calls `webview.reload()` which only executes a new navigation (url is `about:blank`) and nothing will happen. It should call visitSource, but separating concerns and creating small PR's