### PR TITLE
fix(ios): add missing ignoreSilentHardwareSwitch

### DIFF
--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -79,6 +79,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(ignoreSilentHardwareSwitch, BOOL)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)


### PR DESCRIPTION
Added missing RCT_EXPORT_VIEW_PROPERTY declaration for ignoreSilentHardwareSwitch in RNCWebViewManager.m.

ignoreSilentHardwareSwitch functionality was not working because of the missing prop declaration in view manager.