### PR TITLE
This fixes the a href of data passed thru onMessage

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -94,48 +94,61 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         webView.setDownloadListener(DownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
             webView.setIgnoreErrFailedForThisURL(url)
             val module = webView.reactApplicationContext.getNativeModule(RNCWebViewModule::class.java) ?: return@DownloadListener
-            val request: DownloadManager.Request = try {
-                DownloadManager.Request(Uri.parse(url))
-            } catch (e: IllegalArgumentException) {
-                Log.w(TAG, "Unsupported URI, aborting download", e)
-                return@DownloadListener
-            }
-            var fileName = URLUtil.guessFileName(url, contentDisposition, mimetype)
+            if (!url.startsWith("data:")) {
+                val request: DownloadManager.Request = try {
+                    DownloadManager.Request(Uri.parse(url))
+                } catch (e: IllegalArgumentException) {
+                    Log.w(TAG, "Unsupported URI, aborting download", e)
+                    return@DownloadListener
+                }
+                var fileName = URLUtil.guessFileName(url, contentDisposition, mimetype)
 
-            // Sanitize filename by replacing invalid characters with "_"
-            fileName = fileName.replace(invalidCharRegex, "_")
+                // Sanitize filename by replacing invalid characters with "_"
+                fileName = fileName.replace(invalidCharRegex, "_")
 
-            val downloadMessage = "Downloading $fileName"
+                val downloadMessage = "Downloading $fileName"
 
-            //Attempt to add cookie, if it exists
-            var urlObj: URL? = null
-            try {
-                urlObj = URL(url)
-                val baseUrl = urlObj.protocol + "://" + urlObj.host
-                val cookie = CookieManager.getInstance().getCookie(baseUrl)
-                request.addRequestHeader("Cookie", cookie)
-            } catch (e: MalformedURLException) {
-                Log.w(TAG, "Error getting cookie for DownloadManager", e)
-            }
+                //Attempt to add cookie, if it exists
+                var urlObj: URL? = null
+                try {
+                    urlObj = URL(url)
+                    val baseUrl = urlObj.protocol + "://" + urlObj.host
+                    val cookie = CookieManager.getInstance().getCookie(baseUrl)
+                    request.addRequestHeader("Cookie", cookie)
+                } catch (e: MalformedURLException) {
+                    Log.w(TAG, "Error getting cookie for DownloadManager", e)
+                }
 
-            //Finish setting up request
-            request.addRequestHeader("User-Agent", userAgent)
-            request.setTitle(fileName)
-            request.setDescription(downloadMessage)
-            request.allowScanningByMediaScanner()
-            request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
-            module.setDownloadRequest(request)
-            if (module.grantFileDownloaderPermissions(
-                    getDownloadingMessageOrDefault(),
-                    getLackPermissionToDownloadMessageOrDefault()
-                )
-            ) {
-                module.downloadFile(
-                    getDownloadingMessageOrDefault()
-                )
+                //Finish setting up request
+                request.addRequestHeader("User-Agent", userAgent)
+                request.setTitle(fileName)
+                request.setDescription(downloadMessage)
+                request.allowScanningByMediaScanner()
+                request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+                module.setDownloadRequest(request)
+                if (module.grantFileDownloaderPermissions(
+                        getDownloadingMessageOrDefault(),
+                        getLackPermissionToDownloadMessageOrDefault()
+                    )
+                ) {
+                    module.downloadFile(
+                        getDownloadingMessageOrDefault()
+                    )
+                }
+            } else {
+                Log.w(TAG, "Unsupported URI, sending data to onMessage $url")
+                if (webView.getMessagingEnabled()) {
+                    webView.onMessage(url)
+                } else {
+                    Log.w(
+                        TAG,
+                        "webView. getMessagingEnabled not enabled"
+                    )
+                }
             }
         })
+
         return RNCWebViewWrapper(context, webView)
     }
 


### PR DESCRIPTION
This patches react-native-webview to add ability to pass <a href="data:...."> instead of an URL. I could not get onShouldStartLoadWithRequest to work on Android. This is on old setup - not new arch.

This will pass the onMessage as below:

```
  const [isHiding, setHiding] = useState<boolean>(false);
  const [pdfData, setPdfData] = useState<string>();
  const webViewRef = useRef<WebView>(null);

  useEffect(() => {
    setHiding(false);
  }, []);


  // This is used for handling the PDF data from the WebView for Android
  const onMessage = (event: WebViewMessageEvent) => {
    const { data } = event.nativeEvent;

    if (data && data.indexOf('data:application/pdf;base64,') >= 0) {
      if (Platform.OS === 'android') {
        setPdfData(data);
        setHiding(true);
        return false;
      }
    }

    return true;
  };

  const downloadPdf = async (base64String: string, filename: string) => {
    try {
      const downloadDir = `${RNFS.DocumentDirectoryPath}`;
      const pdfPath = `${downloadDir + filename}.pdf`;
      await RNFS.writeFile(pdfPath, base64String, 'base64');
      await FileViewer.open(pdfPath, { showOpenWithDialog: true });
    } catch (err) {
      log.error('downloadPdf', err);
    }
  };

  // This is used for handling the PDF data from the WebView for IOS
  const onShouldStartLoadWithRequest = (event: ShouldStartLoadRequest) => {
    const { url } = event;

    if (url && url.indexOf('data:application/pdf;base64,') >= 0) {
      const base64String = url.split('data:application/pdf;base64,').pop();
      if (base64String) {
        downloadPdf(base64String, 'pdf');
      } else {
        log.error('Failed to extract base64 string from URL');
      }
      return false;
    }

    return true;
  };

 return !isHiding ? (
    <View style={styles.main}>
      <View style={{ flex: 1 }}>
          <WebView
            originWhitelist={['*']}
            nestedScrollEnabled
            source={
                { uri: currentUrl }
            }
            key={`${rUrl}${new Date().getDay()}`}
            javaScriptEnabled
            onMessage={onMessage}
            onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
            pullToRefreshEnabled
            allowsInlineMediaPlayback
            thirdPartyCookiesEnabled
            ref={webViewRef}
            style={{
              flex: 1,
              width,
            }}
            mixedContentMode="compatibility"
          />
      </View>
    </View>
  ) : (
    <View style={styles.main}>
      <View style={{ flex: 1, backgroundColor: colors.white }}>
      <TouchableOpacity onPress={() => setHiding(false)}>
          <Button title="Close" onPress={() => setHiding(false)} />
      </TouchableOpacity>
      <Pdf style={{ flex: 1, backgroundColor: colors.white, width: '100%' }} source={{ uri: pdfData }} trustAllCerts={Platform.OS === 'ios'} />
      </View>
    </View>)
};
```

This is tested and works...



