### PR TITLE
fix(android): increase SHOULD_OVERRIDE_URL_LOADING_TIMEOUT for slower devices

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class RNCWebViewClient extends WebViewClient {
     private static String TAG = "RNCWebViewClient";
-    protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 250;
+    protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 60000;
 
     protected boolean mLastLoadFailed = false;
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;


### PR DESCRIPTION
### Description

On slower/older Android devices, `onShouldStartLoadWithRequest` would not be respected if the JS thread was busy.

This is because the mechanism to decide whether to load new urls has a default timeout of 250ms for the JS side to return a value. See https://github.com/react-native-webview/react-native-webview/blob/5e73b2089fc80c2be7aa6eff291b18c81ad4030d/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L921-L967

This PR increases the timeout to 60secs which should be way more than enough for slower/older Android devices to respond.

Note: we've been successfully using this new value in production for almost 3 years now.
See https://github.com/valora-inc/wallet/pull/2307

