### PR TITLE
chore(apple): fix some Xcode warnings caught internally

### DIFF
--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -45,7 +45,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @end
 
 #if !TARGET_OS_OSX
-@interface RNCWebViewImpl : RCTView <UIEditMenuInteractionDelegate>
+@interface RNCWebViewImpl : RCTView <UIEditMenuInteractionDelegate, UIGestureRecognizerDelegate>
 
 @property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
 #else

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -796,22 +796,25 @@ RCTAutoInsetsProtocol>
   }
 }
 
-#if !TARGET_OS_OSX
 - (void)setContentInset:(UIEdgeInsets)contentInset
 {
+#if !TARGET_OS_OSX
   _contentInset = contentInset;
   [RCTView autoAdjustInsetsForView:self
                     withScrollView:_webView.scrollView
                       updateOffset:NO];
+#endif // !TARGET_OS_OSX
 }
 
 - (void)refreshContentInset
 {
+#if !TARGET_OS_OSX
   [RCTView autoAdjustInsetsForView:self
                     withScrollView:_webView.scrollView
                       updateOffset:YES];
-}
 #endif // !TARGET_OS_OSX
+}
+
 
 - (void)visitSource
 {
@@ -878,6 +881,7 @@ RCTAutoInsetsProtocol>
 #if TARGET_OS_IOS
 -(void)setKeyboardDisplayRequiresUserAction:(BOOL)keyboardDisplayRequiresUserAction
 {
+  _keyboardDisplayRequiresUserAction = keyboardDisplayRequiresUserAction;
   if (_webView == nil) {
     _savedKeyboardDisplayRequiresUserAction = keyboardDisplayRequiresUserAction;
     return;
@@ -910,7 +914,7 @@ RCTAutoInsetsProtocol>
     SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:");
     method = class_getInstanceMethod(class, selector);
     IMP original = method_getImplementation(method);
-    override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+    override = imp_implementationWithBlock(^void(id me, void* arg0, __unused BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
       ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
     });
   }
@@ -919,7 +923,7 @@ RCTAutoInsetsProtocol>
     SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
     method = class_getInstanceMethod(class, selector);
     IMP original = method_getImplementation(method);
-    override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+    override = imp_implementationWithBlock(^void(id me, void* arg0, __unused BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
       ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
     });
   }
@@ -928,7 +932,7 @@ RCTAutoInsetsProtocol>
     SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
     method = class_getInstanceMethod(class, selector);
     IMP original = method_getImplementation(method);
-    override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+    override = imp_implementationWithBlock(^void(id me, void* arg0, __unused BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
       ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
     });
   } else {
@@ -936,7 +940,7 @@ RCTAutoInsetsProtocol>
     SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
     method = class_getInstanceMethod(class, selector);
     IMP original = method_getImplementation(method);
-    override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
+    override = imp_implementationWithBlock(^void(id me, void* arg0, __unused BOOL arg1, BOOL arg2, id arg3) {
       ((void (*)(id, SEL, void*, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3);
     });
   }
@@ -946,6 +950,7 @@ RCTAutoInsetsProtocol>
 
 -(void)setHideKeyboardAccessoryView:(BOOL)hideKeyboardAccessoryView
 {
+  _hideKeyboardAccessoryView = hideKeyboardAccessoryView;
   _savedHideKeyboardAccessoryView = hideKeyboardAccessoryView;
 
   if (_webView == nil) {
@@ -1168,7 +1173,7 @@ RCTAutoInsetsProtocol>
 {
 #if !TARGET_OS_OSX
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
-  [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+  [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
     completionHandler();
   }]];
   [[self topViewController] presentViewController:alert animated:YES completion:NULL];
@@ -1187,10 +1192,10 @@ RCTAutoInsetsProtocol>
 - (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler{
 #if !TARGET_OS_OSX
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
-  [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+  [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
     completionHandler(YES);
   }]];
-  [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+  [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *action) {
     completionHandler(NO);
   }]];
   [[self topViewController] presentViewController:alert animated:YES completion:NULL];
@@ -1215,11 +1220,11 @@ RCTAutoInsetsProtocol>
   [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
     textField.text = defaultText;
   }];
-  UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+  UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
     completionHandler([[alert.textFields lastObject] text]);
   }];
   [alert addAction:okAction];
-  UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+  UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *action) {
     completionHandler(nil);
   }];
   [alert addAction:cancelAction];
@@ -1328,7 +1333,6 @@ RCTAutoInsetsProtocol>
     }
 
     if (_onShouldStartLoadWithRequest) {
-        NSMutableDictionary<NSString *, id> *event = [self baseEvent];
         int lockIdentifier = [[RNCWebViewDecisionManager getInstance] setDecisionHandler: ^(BOOL shouldStart){
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (!shouldStart) {
@@ -1352,6 +1356,7 @@ RCTAutoInsetsProtocol>
             });
 
         }];
+        NSMutableDictionary<NSString *, id> *event = [self baseEvent];
         if (request.mainDocumentURL) {
           [event addEntriesFromDictionary: @{
             @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
@@ -1685,6 +1690,7 @@ didFinishNavigation:(WKNavigation *)navigation
 
 - (void)setInjectedJavaScriptObject:(NSString *)source
 {
+  _injectedJavaScriptObject = source;
   self.injectedObjectJsonScript = [
     [WKUserScript alloc]
     initWithSource: [
@@ -1823,8 +1829,8 @@ didFinishNavigation:(WKNavigation *)navigation
                                          "  })\n"
                                          "})(window.history)\n", HistoryShimName
   ];
-  WKUserScript *script = [[WKUserScript alloc] initWithSource:html5HistoryAPIShimSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-  [wkWebViewConfig.userContentController addUserScript:script];
+  WKUserScript *userScript = [[WKUserScript alloc] initWithSource:html5HistoryAPIShimSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+  [wkWebViewConfig.userContentController addUserScript:userScript];
 
   if(_sharedCookiesEnabled) {
     // More info to sending cookies with WKWebView


### PR DESCRIPTION
At my side of Microsoft, we have recently "vendored" a couple of libraries. Which means, we started building them from source using our own generated Xcode project (not the one cocoapods generates), which has much stricter build flags / treats warnings as errors. In doing so, I caught a couple of issues in React Native Webview I'd like to push back up!

Namely:
- `RNCWebViewImpl` should implement the protocol `UIGestureRecognizerDelegate`. It already was, but it wasn't listed so at the header.
  - Without this,I got the error `Assigning to 'id<UIGestureRecognizerDelegate> _Nullable' from incompatible type 'RNCWebViewImpl *const __strong' ` on line 565 when we try to set `self` as a `UILongPressGestureRecognizer` delegate. 
- Move some macOS ifdefs around so that RNWWebViewImpl conforms to the `RCTAutoInsetsProtocol`
  - I need to look into more whether RCTView on macOS should maybe not conform to this protocol. It looks iOS specific. 
- Add some `__unused` cland macros to unused arguments     
- Fix a couple of "declaration of variable shadows a local variable" by either moving the variable declation or renaming the variable so it longer conflicts
- Fixed a couple of "setter doesn't set the autogenerated property" issues by renaming `_savedHideKeyboardAccessoryView` and `_savedKeyboardDisplayRequiresUserAction` to `_hideKeyboardAccessoryView` and `_keyboardDisplayRequiresUserAction`