### PR TITLE
Fix missing hook dependency in Android back press example

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -645,7 +645,7 @@ useEffect(() => {
       BackHandler.removeEventListener('hardwareBackPress', onAndroidBackPress);
     };
   }
-}, []);
+}, [onAndroidBackPress]);
 ```
 
 And add these prop to your `WebView` component:


### PR DESCRIPTION
I was trying out this section of the guide and was surprised to find it didn't work. After adding some log statements, I observed that the issue is that while the `useCallback` correctly sets `canGoBack` as a dependency, the `useEffect` wasn't depending on the `onAndroidBackPress` value which changes whenever `canGoBack` changes, thus the registered event listener always had the initial `false` value for `canGoBack`.