### PR TITLE
feat(android) add support for enabling the Payment Request API (#2278)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 ReactNativeWebView_kotlinVersion=1.6.0
-ReactNativeWebView_webkitVersion=1.4.0
+ReactNativeWebView_webkitVersion=1.14.0-alpha01
 ReactNativeWebView_compileSdkVersion=31
 ReactNativeWebView_targetSdkVersion=31
 ReactNativeWebView_minSdkVersion=21

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.reactnativecommunity.webview">
 
+  <queries>
+    <intent>
+      <action android:name="org.chromium.intent.action.PAY"/>
+    </intent>
+    <intent>
+      <action android:name="org.chromium.intent.action.IS_READY_TO_PAY"/>
+    </intent>
+    <intent>
+      <action android:name="org.chromium.intent.action.UPDATE_PAYMENT_DETAILS"/>
+    </intent>
+  </queries>
+
   <application>
     <provider
       android:name=".RNCWebViewFileProvider"

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,4 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <queries>
+    <intent>
+      <action android:name="org.chromium.intent.action.PAY"/>
+    </intent>
+    <intent>
+      <action android:name="org.chromium.intent.action.IS_READY_TO_PAY"/>
+    </intent>
+    <intent>
+      <action android:name="org.chromium.intent.action.UPDATE_PAYMENT_DETAILS"/>
+    </intent>
+  </queries>
+   
   <application>
     <provider
       android:name=".RNCWebViewFileProvider"

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -715,4 +715,11 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
     fun setWebviewDebuggingEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
         RNCWebView.setWebContentsDebuggingEnabled(enabled)
     }
+
+    fun setPaymentRequestEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.PAYMENT_REQUEST)) {
+            WebSettingsCompat.setPaymentRequestEnabled(view.settings, enabled)
+        }
+    }
 }

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -331,6 +331,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         mRNCWebViewManagerImpl.setWebviewDebuggingEnabled(view, value);
     }
 
+    @Override
+    @ReactProp(name = "paymentRequestEnabled")
+    public void setPaymentRequestEnabled(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
+    }
+
     /* iOS PROPS - no implemented here */
     @Override
     public void setAllowingReadAccessToURL(RNCWebViewWrapper view, @Nullable String value) {}

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -273,6 +273,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setUserAgent(view, value);
     }
 
+    @ReactProp(name = "paymentRequestEnabled")
+    public void setPaymentRequestEnabled(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
+    }
+
     @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
         // Do not register default touch emitter and let WebView implementation handle touches

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -93,6 +93,7 @@ This document lays out the current public properties and methods for the React N
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
 - [`webviewDebuggingEnabled`](Reference.md#webviewDebuggingEnabled)
+- [`paymentRequestEnabled`](Reference.md#paymentRequestEnabled)
 
 ## Methods Index
 
@@ -1026,8 +1027,8 @@ Boolean value that indicates whether HTML5 videos can play Picture in Picture. T
 
 > **NOTE**
 >
-> In order to restrict playing video in picture in picture mode this props need to be set to `false`
-.
+> In order to restrict playing video in picture in picture mode this props need to be set to `false`.
+
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | iOS      |
@@ -1717,6 +1718,15 @@ Default is `false`. Supported on iOS as of 16.4, previous versions always allow 
 | Type    | Required | Platform |
 | ------- | -------- | -------- |
 | boolean | No       | iOS & Android  |
+
+### `paymentRequestEnabled`[⬆](#props-index)
+
+Whether or not the webview has the Payment Request API enabled. Default is `true`.
+This is needed for Google Pay to work within the WebView.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Android  |
 
 ## Methods
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -21,6 +21,7 @@ import Messaging from './examples/Messaging';
 import MultiMessaging from './examples/MultiMessaging';
 import NativeWebpage from './examples/NativeWebpage';
 import ApplePay from './examples/ApplePay';
+import GooglePay from './examples/GooglePay';
 import CustomMenu from './examples/CustomMenu';
 import OpenWindow from './examples/OpenWindow';
 import SuppressMenuItems from './examples/Suppress';
@@ -121,6 +122,14 @@ const TESTS = {
     description: 'Test to open a apple pay supported page',
     render() {
       return <ApplePay />;
+    },
+  },
+  GooglePay: {
+    title: 'Google Pay ',
+    testId: 'GooglePay',
+    description: 'Test to open a Google Pay supported page',
+    render() {
+      return <GooglePay />;
     },
   },
   CustomMenu: {
@@ -248,6 +257,13 @@ export default class App extends Component<Props, State> {
               testID="testType_applePay"
               title="ApplePay"
               onPress={() => this._changeTest('ApplePay')}
+            />
+          )}
+          {Platform.OS === 'android' && (
+            <Button
+              testID="testType_googlePay"
+              title="GooglePay"
+              onPress={() => this._changeTest('GooglePay')}
             />
           )}
           <Button

--- a/example/examples/GooglePay.tsx
+++ b/example/examples/GooglePay.tsx
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {View} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+type Props = {};
+type State = {};
+
+export default class Alerts extends Component<Props, State> {
+    state = {};
+
+    render() {
+        return (
+            <View style={{ flex: 1 }}>
+                <WebView                    
+                    source={{uri: "https://rsolomakhin.github.io/pr/gp2-test"}}
+                    paymentRequestEnabled={true}
+                />
+            </View>
+        );
+    }
+}

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -281,6 +281,7 @@ export interface NativeProps extends ViewProps {
   onShouldStartLoadWithRequest: DirectEventHandler<ShouldStartLoadRequestEvent>;
   showsHorizontalScrollIndicator?: WithDefault<boolean, true>;
   showsVerticalScrollIndicator?: WithDefault<boolean, true>;
+  paymentRequestEnabled?: boolean;
   newSource: Readonly<{
     uri?: string;
     method?: string;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -306,6 +306,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
   onShouldStartLoadWithRequest: (event: ShouldStartLoadRequestEvent) => void;
   showsHorizontalScrollIndicator?: boolean;
   showsVerticalScrollIndicator?: boolean;
+  paymentRequestEnabled?: boolean;
   // TODO: find a better way to type this.
 
   source: any;
@@ -1329,4 +1330,9 @@ export interface WebViewSharedProps extends ViewProps {
    * Enables WebView remote debugging using Chrome (Android) or Safari (iOS).
    */
   webviewDebuggingEnabled?: boolean;
+
+  /**
+   * Enables support for the Payment Request API for the WebView
+   */
+  paymentRequestEnabled?: boolean;
 }


### PR DESCRIPTION
**Summary:**
This PR enables the Payment Request API for the WebView. This is needed in order for Google Pay to work:

https://developers.google.com/pay/api/android/guides/recipes/using-android-webview

Note: The `androidx.webkit:webkit` dependency is currently only available in `1.14.0-alpha01`. So this PR might has to wait until a stable release.

Fixes #2278

**Testing Instructions:**
Before testing, check the [User device requirements](https://developers.google.com/pay/api/android/guides/recipes/using-android-webview#userrequirements) and [Early testing](https://developers.google.com/pay/api/android/guides/recipes/using-android-webview#early-testing) sections of the above guide.

- Run the example app on an Android device.
- Tap the "GOOGLEPAY" button
- Tap the "Buy" button. Observe that the "native" Google Pay bottom sheet will come up.
- Tap the "Continue" button to complete the transaction

**Video Demonstration:**

https://github.com/user-attachments/assets/74f5872e-9654-4540-8c06-804f6d4b2e2c

