### PR TITLE
[fix][android] Fix suppressMenuItems native view config name with extra space causing StaticViewConfigValidator to fail

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -226,7 +226,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @Override
-    @ReactProp(name = "suppressMenuItems ")
+    @ReactProp(name = "suppressMenuItems")
     public void setSuppressMenuItems(RNCWebViewWrapper view, @Nullable ReadableArray items) {}
 
     @Override


### PR DESCRIPTION
When running the StaticViewConfig validator on Bridgeless, it fails with this error:

```js
import * as NativeComponentRegistry from 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
...
  if (global.RN$Bridgeless === true && __DEV__) {
    NativeComponentRegistry.setRuntimeConfigProvider(name => ({
      native: false,
      verify: true,
    }));
  }
```

```log
console.js:655 Warning: StaticViewConfigValidator: Invalid static view config for 'RNCWebView'.
- 'validAttributes.suppressMenuItems ' is missing.
```
The spec has the prop:
https://github.com/react-native-webview/react-native-webview/blob/87b2265d6e5e700ca607ddd64e75997c9e6ca35a/src/RNCWebViewNativeComponent.ts#L245

The issue is due to an extra space in the Prop Name for `suppressMenuItems` in the Android Native View Config.
Thus causing the `StaticViewConfigValidator` to not find the match.
https://github.com/react-native-webview/react-native-webview/blob/87b2265d6e5e700ca607ddd64e75997c9e6ca35a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java#L229
