### PR TITLE
Update dataDetectorTypes to only allow array values

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -497,7 +497,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    *
    * @platform ios
    */
-  readonly dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
+  readonly dataDetectorTypes?: DataDetectorTypes[];
 
   /**
    * Boolean that determines whether HTML5 videos play inline or use the


### PR DESCRIPTION
This is a quick fix for #3662 which makes the type of `dataDetectorTypes` allow only an array of values. If this is provided a string value instead it will cause crashes on android.

There could be further restrictions added in code to check the type provided at runtime, but this seemed to be the simplest solution for now.