### PR TITLE
feat(android): Add custom WebView support for New Architecture

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -62,6 +62,10 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
+    protected RNCWebViewWrapper createViewInstance(@NonNull ThemedReactContext context, @NonNull RNCWebView view) {
+        return mRNCWebViewManagerImpl.createViewInstance(context, view);
+    }
+
     @Override
     @ReactProp(name = "allowFileAccess")
     public void setAllowFileAccess(RNCWebViewWrapper view, boolean value) {


### PR DESCRIPTION
## Summary

The approach for customizing WebView instances described in **Custom-Android.md** was previously limited to the Old Architecture.  
This PR adds support for creating custom WebView instances in the **New Architecture**.

## Changes
- Added `createViewInstance` in **RNCWebViewManager.java** (New Architecture).

## Testing

- Verified the change by applying the same patch to the sample project:  
  https://github.com/deka0106/custom-react-native-webview-example
