### PR TITLE
fix(types): Make `clearCache` method required instead of optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      /**
      * Clears the resource cache. Note that the cache is per-application, so this will clear the cache for all WebViews used.
      */
-    clearCache?: (includeDiskFiles: boolean) => void;
+    clearCache: (includeDiskFiles: boolean) => void;
 
      /**
      * (Android only)


### PR DESCRIPTION
## Purpose

Since `clearCache` is available on Android, Apple and Windows platforms, we should remove the optional modifier for `clearCache`