### PR TITLE
fix: revert 1221 setIgnoreErrFailedForThisURL

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -91,10 +91,6 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         progressChangedFilter = new ProgressChangedFilter();
     }
 
-    public void setIgnoreErrFailedForThisURL(String url) {
-        mRNCWebViewClient.setIgnoreErrFailedForThisURL(url);
-    }
-
     public void setBasicAuthCredential(RNCBasicAuthCredential credential) {
         mRNCWebViewClient.setBasicAuthCredential(credential);
     }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -42,12 +42,7 @@ public class RNCWebViewClient extends WebViewClient {
 
     protected boolean mLastLoadFailed = false;
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
-    protected @Nullable String ignoreErrFailedForThisURL = null;
     protected @Nullable RNCBasicAuthCredential basicAuthCredential = null;
-
-    public void setIgnoreErrFailedForThisURL(@Nullable String url) {
-        ignoreErrFailedForThisURL = url;
-    }
 
     public void setBasicAuthCredential(@Nullable RNCBasicAuthCredential credential) {
         basicAuthCredential = credential;
@@ -224,20 +219,6 @@ public class RNCWebViewClient extends WebViewClient {
             int errorCode,
             String description,
             String failingUrl) {
-
-        if (ignoreErrFailedForThisURL != null
-                && failingUrl.equals(ignoreErrFailedForThisURL)
-                && errorCode == -1
-                && description.equals("net::ERR_FAILED")) {
-
-            // This is a workaround for a bug in the WebView.
-            // See these chromium issues for more context:
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
-            // This entire commit should be reverted once this bug is resolved in chromium.
-            setIgnoreErrFailedForThisURL(null);
-            return;
-        }
 
         super.onReceivedError(webView, errorCode, description, failingUrl);
         mLastLoadFailed = true;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -92,7 +92,6 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
             WebView.setWebContentsDebuggingEnabled(true)
         }
         webView.setDownloadListener(DownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
-            webView.setIgnoreErrFailedForThisURL(url)
             val module = webView.reactApplicationContext.getNativeModule(RNCWebViewModule::class.java) ?: return@DownloadListener
             val request: DownloadManager.Request = try {
                 DownloadManager.Request(Uri.parse(url))


### PR DESCRIPTION
Hey folks, in https://github.com/react-native-webview/react-native-webview/pull/1221, this code was added as a workaround for some Chromium bugs: https://issues.chromium.org/issues/40658278 and https://issues.chromium.org/issues/40673276.

https://issues.chromium.org/issues/40658278 was marked a duplicate of https://issues.chromium.org/issues/40671896, which is marked as fixed. https://issues.chromium.org/issues/40673276 is also marked as fixed.

I think we're good to revert this, and I am currently working on a project that would like to have this revert sorted out so we can rely on `onReceivedError` to pass all the messages it gets.