### PR TITLE
Add sub resource SSL error handling on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
+import com.reactnativecommunity.webview.events.SubResourceErrorEvent;
 import com.reactnativecommunity.webview.events.TopHttpErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingFinishEvent;
@@ -173,12 +174,6 @@ public class RNCWebViewClient extends WebViewClient {
         // Undesired behavior: Return value of WebView.getUrl() may be the current URL instead of the failing URL.
         handler.cancel();
 
-        if (!topWindowUrl.equalsIgnoreCase(failingUrl)) {
-            // If error is not due to top-level navigation, then do not call onReceivedError()
-            Log.w(TAG, "Resource blocked from loading due to SSL error. Blocked URL: "+failingUrl);
-            return;
-        }
-
         int code = error.getPrimaryError();
         String description = "";
         String descriptionPrefix = "SSL error: ";
@@ -210,12 +205,38 @@ public class RNCWebViewClient extends WebViewClient {
 
         description = descriptionPrefix + description;
 
+      if (!topWindowUrl.equalsIgnoreCase(failingUrl)) {
+        // If error is not due to top-level navigation, then do not call onReceivedError()
+        Log.w(TAG, "Resource blocked from loading due to SSL error. Blocked URL: "+failingUrl);
+        this.onReceivedSubResourceSslError(
+          webView,
+          code,
+          description,
+          failingUrl
+        );
+        return;
+      }
+
         this.onReceivedError(
                 webView,
                 code,
                 description,
                 failingUrl
         );
+    }
+
+    public void onReceivedSubResourceSslError(
+      WebView webView,
+      int errorCode,
+      String description,
+      String failingUrl) {
+
+      WritableMap eventData = createWebViewEvent(webView, failingUrl);
+      eventData.putDouble("code", errorCode);
+      eventData.putString("description", description);
+
+      int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
+      UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new SubResourceErrorEvent(reactTag, eventData));
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/webview/events/SubResourceErrorEvent.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/SubResourceErrorEvent.kt
@@ -1,0 +1,25 @@
+package com.reactnativecommunity.webview.events
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+/**
+ * Event emitted when there is an error in loading a subresource
+ */
+class SubResourceErrorEvent(viewId: Int, private val mEventData: WritableMap) :
+  Event<SubResourceErrorEvent>(viewId) {
+  companion object {
+    const val EVENT_NAME = "topLoadingSubResourceError"
+  }
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun canCoalesce(): Boolean = false
+
+  override fun getCoalescingKey(): Short = 0
+
+  override fun dispatch(rctEventEmitter: RCTEventEmitter) =
+    rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
+}

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -15,6 +15,7 @@ import com.facebook.react.viewmanagers.RNCWebViewManagerDelegate;
 import com.facebook.react.viewmanagers.RNCWebViewManagerInterface;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.reactnativecommunity.webview.events.TopCustomMenuSelectionEvent;
+import com.reactnativecommunity.webview.events.SubResourceErrorEvent;
 import com.reactnativecommunity.webview.events.TopHttpErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingFinishEvent;
@@ -524,6 +525,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         export.put(TopLoadingStartEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingStart"));
         export.put(TopLoadingFinishEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingFinish"));
         export.put(TopLoadingErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingError"));
+        export.put(SubResourceErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingSubResourceError"));
         export.put(TopMessageEvent.EVENT_NAME, MapBuilder.of("registrationName", "onMessage"));
         // !Default events but adding them here explicitly for clarity
 

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -11,6 +11,7 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.reactnativecommunity.webview.events.TopCustomMenuSelectionEvent;
+import com.reactnativecommunity.webview.events.SubResourceErrorEvent;
 import com.reactnativecommunity.webview.events.TopHttpErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingFinishEvent;
@@ -294,6 +295,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         export.put(TopLoadingStartEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingStart"));
         export.put(TopLoadingFinishEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingFinish"));
         export.put(TopLoadingErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingError"));
+        export.put(SubResourceErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingSubResourceError"));
         export.put(TopMessageEvent.EVENT_NAME, MapBuilder.of("registrationName", "onMessage"));
         // !Default events but adding them here explicitly for clarity
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -26,6 +26,7 @@ import CustomMenu from './examples/CustomMenu';
 import OpenWindow from './examples/OpenWindow';
 import SuppressMenuItems from './examples/Suppress';
 import ClearData from './examples/ClearData';
+import SslError from './examples/SslError';
 
 const TESTS = {
   Messaging: {
@@ -154,6 +155,14 @@ const TESTS = {
     description: 'SuppressMenuItems in editable content',
     render() {
       return <SuppressMenuItems />;
+    },
+  },
+  SslError: {
+    title: 'SslError',
+    testId: 'SslError',
+    description: 'SSL error test',
+    render() {
+      return <SslError />;
     },
   },
 };
@@ -285,6 +294,11 @@ export default class App extends Component<Props, State> {
             testID="testType_clearData"
             title="ClearData"
             onPress={() => this._changeTest('ClearData')}
+          />
+          <Button
+            testID="testType_sslError"
+            title="SslError"
+            onPress={() => this._changeTest('SslError')}
           />
         </View>
 

--- a/example/examples/SslError.tsx
+++ b/example/examples/SslError.tsx
@@ -1,0 +1,24 @@
+import React, {Component} from 'react';
+import {View} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+type Props = {};
+type State = {};
+
+export default class SslError extends Component<Props, State> {
+    state = {};
+
+    render() {
+        return (
+            <View style={{ flex: 1 }}>
+                <WebView
+                    source={{uri: "https://badssl.com/"}}
+                    onLoadSubResourceError={(event) => {
+                        console.log('onLoadSubResourceError', event.nativeEvent.description);
+                    }}
+                />
+            </View>
+        );
+    }
+}

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -270,6 +270,7 @@ export interface NativeProps extends ViewProps {
   mediaPlaybackRequiresUserAction?: WithDefault<boolean, true>;
   messagingEnabled: boolean;
   onLoadingError: DirectEventHandler<WebViewErrorEvent>;
+  onLoadingSubResourceError: DirectEventHandler<WebViewErrorEvent>;
   onLoadingFinish: DirectEventHandler<WebViewNavigationEvent>;
   onLoadingProgress: DirectEventHandler<WebViewNativeProgressEvent>;
   onLoadingStart: DirectEventHandler<WebViewNavigationEvent>;

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -83,6 +83,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
       onError,
       onLoad,
       onLoadEnd,
+      onLoadSubResourceError,
       onLoadProgress,
       onHttpError: onHttpErrorProp,
       onRenderProcessGone: onRenderProcessGoneProp,
@@ -130,6 +131,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
       lastErrorEvent,
       onHttpError,
       onLoadingError,
+      onLoadingSubResourceError,
       onLoadingFinish,
       onLoadingProgress,
       onOpenWindow,
@@ -139,6 +141,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
       onLoad,
       onError,
       onHttpErrorProp,
+      onLoadSubResourceError,
       onLoadEnd,
       onLoadProgress,
       onLoadStart,
@@ -284,6 +287,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
         messagingModuleName={messagingModuleName}
         hasOnScroll={!!otherProps.onScroll}
         onLoadingError={onLoadingError}
+        onLoadingSubResourceError={onLoadingSubResourceError}
         onLoadingFinish={onLoadingFinish}
         onLoadingProgress={onLoadingProgress}
         onLoadingStart={onLoadingStart}

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -104,6 +104,7 @@ export const useWebViewLogic = ({
   onLoadProgress,
   onLoadEnd,
   onError,
+  onLoadSubResourceError,
   onHttpErrorProp,
   onMessageProp,
   onOpenWindowProp,
@@ -120,6 +121,7 @@ export const useWebViewLogic = ({
   onLoadProgress?: (event: WebViewProgressEvent) => void;
   onLoadEnd?: (event: WebViewNavigationEvent | WebViewErrorEvent) => void;
   onError?: (event: WebViewErrorEvent) => void;
+  onLoadSubResourceError?: (event: WebViewErrorEvent) => void;
   onHttpErrorProp?: (event: WebViewHttpErrorEvent) => void;
   onMessageProp?: (event: WebViewMessageEvent) => void;
   onOpenWindowProp?: (event: WebViewOpenWindowEvent) => void;
@@ -176,6 +178,13 @@ export const useWebViewLogic = ({
       setLastErrorEvent(event.nativeEvent);
     },
     [onError, onLoadEnd]
+  );
+
+  const onLoadingSubResourceError = useCallback(
+    (event: WebViewErrorEvent) => {
+      onLoadSubResourceError?.(event);
+    },
+    [onLoadSubResourceError]
   );
 
   const onHttpError = useCallback(
@@ -270,6 +279,7 @@ export const useWebViewLogic = ({
     onLoadingStart,
     onLoadingProgress,
     onLoadingError,
+    onLoadingSubResourceError,
     onLoadingFinish,
     onHttpError,
     onRenderProcessGone,

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1160,6 +1160,14 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   allowsProtectedMedia?: boolean;
+
+  /**
+   * Function that is invoked when the `WebView` receives an SSL error for a sub-resource.
+   *
+   * @param event
+   * @platform android
+   */
+  onLoadSubResourceError: (event: WebViewErrorEvent) => void;
 }
 
 export interface WebViewSharedProps extends ViewProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1167,7 +1167,7 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @param event
    * @platform android
    */
-  onLoadSubResourceError: (event: WebViewErrorEvent) => void;
+  onLoadSubResourceError?: (event: WebViewErrorEvent) => void;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
This PR adds a new event handler to the `WebView` component for Android: `onLoadSubResourceError`, which is fired when the package receives SSL errors where the failing URL does not match the top window URL.

Currently, `react-native-webview` simply logs these out. But I had a use case where I needed to specifically handle these events. This patch works for my use case, and it seems reasonable other people might want something like this as well.

A simpler change might be to change `TopLoadingErrorEvent` to have some value indicating that `failingUrl !== topWindowUrl`, and just route everything through the existing handler. As a starting proposal, I chose to add a separate handler for this because I figured it was more backwards compatible. Happy to iterate on that if the project prefers a different design.

I also added a test case that points to `https://badssl.com/`. If you run `yarn android` to see the Example app and tap around, you'll see the logs coming through:

https://github.com/user-attachments/assets/ccf59104-fb83-4816-9ba3-b57e7f7afdc2

