### PR TITLE
fix: thread safe decision manager

### DIFF
--- a/apple/RNCWebViewDecisionManager.m
+++ b/apple/RNCWebViewDecisionManager.m
@@ -1,7 +1,15 @@
 #import "RNCWebViewDecisionManager.h"
 
-
-
+/**
+ * Thread-safe singleton that manages navigation decision handlers for WKWebView.
+ *
+ * This class bridges async navigation decisions between:
+ * - WKWebView delegate (main thread) - stores decision handlers
+ * - React Native bridge (background thread) - resolves decisions from JS
+ *
+ * All public methods use @synchronized for thread safety since they access
+ * shared state (nextLockIdentifier and decisionHandlers) from different threads.
+ */
 @implementation RNCWebViewDecisionManager
 
 @synthesize nextLockIdentifier;
@@ -16,22 +24,39 @@
     return lockManager;
 }
 
+/**
+ * Stores a decision handler and returns a unique identifier.
+ * Called from the main thread (WKNavigationDelegate).
+ * @synchronized ensures atomic increment + insertion.
+ */
 - (int)setDecisionHandler:(DecisionBlock)decisionHandler {
-    int lockIdentifier = self.nextLockIdentifier++;
-
-    [self.decisionHandlers setObject:decisionHandler forKey:@(lockIdentifier)];
-    return lockIdentifier;
+    @synchronized (self) {
+        int lockIdentifier = self.nextLockIdentifier++;
+        [self.decisionHandlers setObject:decisionHandler forKey:@(lockIdentifier)];
+        return lockIdentifier;
+    }
 }
 
+/**
+ * Resolves a pending navigation decision.
+ * Called from the RN bridge thread (background) when JS responds.
+ *
+ * The handler is invoked OUTSIDE the @synchronized block to prevent deadlocks,
+ * since the handler dispatches to the main queue and could potentially
+ * trigger another navigation that re-enters this class.
+ */
 - (void) setResult:(BOOL)shouldStart
  forLockIdentifier:(int)lockIdentifier {
-    DecisionBlock handler = [self.decisionHandlers objectForKey:@(lockIdentifier)];
-    if (handler == nil) {
-        RCTLogWarn(@"Lock not found");
-        return;
+    DecisionBlock handler;
+    @synchronized (self) {
+        handler = [self.decisionHandlers objectForKey:@(lockIdentifier)];
+        if (handler == nil) {
+            RCTLogWarn(@"Lock not found");
+            return;
+        }
+        [self.decisionHandlers removeObjectForKey:@(lockIdentifier)];
     }
     handler(shouldStart);
-    [self.decisionHandlers removeObjectForKey:@(lockIdentifier)];
 }
 
 - (id)init {


### PR DESCRIPTION
This PR ensures that the decision manager is thread safe, perhaps I'm missing some queue or synchronization magic elsewhere but I suspect this code is being interacted with from multiple different threads yet internally it's not being synchronized to be thread safe.

NSMutableArray is not a thread safe data structure.