### PR TITLE
fix(android): fix injectedJavaScriptBeforeContentLoaded and injectedJavaScriptObject

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -54,10 +54,11 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     protected @Nullable
     String injectedJSBeforeContentLoaded;
     protected static final String JAVASCRIPT_INTERFACE = "ReactNativeWebView";
+    protected static final String MESSAGE_LISTENER_INTERFACE = "__RNCWebViewMessageListener";
     protected @Nullable
-    RNCWebViewBridge fallbackBridge;
+    RNCWebViewBridge bridge;
     protected @Nullable
-    WebViewCompat.WebMessageListener bridgeListener = null;
+    WebViewCompat.WebMessageListener webMessageListener = null;
 
     /**
      * android.webkit.WebChromeClient fundamentally does not support JS injection into frames other
@@ -248,38 +249,43 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     }
 
     protected void createRNCWebViewBridge(RNCWebView webView) {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)){
-          if (this.bridgeListener == null) {
-            this.bridgeListener = new WebViewCompat.WebMessageListener() {
-              @Override
-              public void onPostMessage(@NonNull WebView view, @NonNull WebMessageCompat message, @NonNull Uri sourceOrigin, boolean isMainFrame, @NonNull JavaScriptReplyProxy replyProxy) {
-                RNCWebView.this.onMessage(message.getData(), sourceOrigin.toString());
-              }
-            };
-            WebViewCompat.addWebMessageListener(
-              webView,
-              JAVASCRIPT_INTERFACE,
-              Set.of("*"),
-              this.bridgeListener
-            );
-          }
-        } else {
-          if (fallbackBridge == null) {
-            fallbackBridge = new RNCWebViewBridge(webView);
-            addJavascriptInterface(fallbackBridge, JAVASCRIPT_INTERFACE);
-          }
+        if (bridge == null) {
+            bridge = new RNCWebViewBridge(webView);
+            addJavascriptInterface(bridge, JAVASCRIPT_INTERFACE);
         }
-        injectJavascriptObject();
+
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            if (webMessageListener == null) {
+                webMessageListener = new WebViewCompat.WebMessageListener() {
+                    @Override
+                    public void onPostMessage(@NonNull WebView view, @NonNull WebMessageCompat message, @NonNull Uri sourceOrigin, boolean isMainFrame, @NonNull JavaScriptReplyProxy replyProxy) {
+                        RNCWebView.this.onMessage(message.getData(), sourceOrigin.toString());
+                    }
+                };
+                WebViewCompat.addWebMessageListener(
+                    webView, MESSAGE_LISTENER_INTERFACE, Set.of("*"), webMessageListener);
+            }
+        }
     }
 
-    private void injectJavascriptObject() {
-      if (getSettings().getJavaScriptEnabled()) {
-        String js = "(function(){\n" +
-          "    window." + JAVASCRIPT_INTERFACE + " = window." + JAVASCRIPT_INTERFACE + " || {};\n" +
-          "    window." + JAVASCRIPT_INTERFACE + ".injectedObjectJson = function () { return " + (injectedJavaScriptObject == null ? null : ("`" + injectedJavaScriptObject + "`")) + "; };\n" +
-          "})();";
-        evaluateJavascriptWithFallback(js);
-      }
+    private String buildPostMessageOverrideScript() {
+        return "(function() {\n" +
+            "  var nb = window." + JAVASCRIPT_INTERFACE + ";\n" +
+            "  var wml = window." + MESSAGE_LISTENER_INTERFACE + ";\n" +
+            "  if (nb && wml) {\n" +
+            "    window." + JAVASCRIPT_INTERFACE + " = Object.assign({}, nb, {\n" +
+            "      postMessage: function(msg) { wml.postMessage(msg); },\n" +
+            "      injectedObjectJson: function() { return nb.injectedObjectJson(); }\n" +
+            "    });\n" +
+            "  }\n" +
+            "})();";
+    }
+
+    private void overridePostMessageWithMessageListener() {
+        if (webMessageListener == null) {
+            return;
+        }
+        evaluateJavascriptWithFallback(buildPostMessageOverrideScript());
     }
 
     @SuppressLint("AddJavascriptInterface")
@@ -300,20 +306,22 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     }
 
     public void callInjectedJavaScript() {
-        if (getSettings().getJavaScriptEnabled() &&
-                injectedJS != null &&
-                !TextUtils.isEmpty(injectedJS)) {
+        if (!getSettings().getJavaScriptEnabled()) {
+            return;
+        }
+        overridePostMessageWithMessageListener();
+        if (injectedJS != null && !TextUtils.isEmpty(injectedJS)) {
             evaluateJavascriptWithFallback("(function() {\n" + injectedJS + ";\n})();");
-            injectJavascriptObject(); // re-inject the Javascript object in case it has been overwritten.
         }
     }
 
     public void callInjectedJavaScriptBeforeContentLoaded() {
-        if (getSettings().getJavaScriptEnabled() &&
-                injectedJSBeforeContentLoaded != null &&
-                !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
+        if (!getSettings().getJavaScriptEnabled()) {
+            return;
+        }
+        overridePostMessageWithMessageListener();
+        if (injectedJSBeforeContentLoaded != null && !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
             evaluateJavascriptWithFallback("(function() {\n" + injectedJSBeforeContentLoaded + ";\n})();");
-            injectJavascriptObject();  // re-inject the Javascript object in case it has been overwritten.
         }
     }
 
@@ -321,7 +329,6 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
     public void setInjectedJavaScriptObject(String obj) {
       this.injectedJavaScriptObject = obj;
-      injectJavascriptObject();
     }
 
     public void onMessage(String message, String sourceUrl) {
@@ -445,11 +452,15 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         @JavascriptInterface
         public void postMessage(String message) {
             if (mWebView.getMessagingEnabled()) {
-                // Post to main thread because `mWebView.getUrl()` requires to be executed on main.
                 mWebView.post(() -> mWebView.onMessage(message, mWebView.getUrl()));
             } else {
                 FLog.w(TAG, "ReactNativeWebView.postMessage method was called but messaging is disabled. Pass an onMessage handler to the WebView.");
             }
+        }
+
+        @JavascriptInterface
+        public String injectedObjectJson() {
+          return mWebView.injectedJavaScriptObject;
         }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -269,6 +269,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
     }
 
     fun onAfterUpdateTransaction(viewWrapper: RNCWebViewWrapper) {
+        viewWrapper.webView.setupDocumentStartScript()
         mPendingSource?.let { source ->
             loadSource(viewWrapper, source)
         }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -16,6 +16,7 @@ import Background from './examples/Background';
 import Downloads from './examples/Downloads';
 import Uploads from './examples/Uploads';
 import Injection from './examples/Injection';
+import InjectedObjectJson from './examples/InjectedObjectJson';
 import LocalPageLoad from './examples/LocalPageLoad';
 import Messaging from './examples/Messaging';
 import MultiMessaging from './examples/MultiMessaging';
@@ -99,6 +100,14 @@ const TESTS = {
     description: 'Injection test',
     render() {
       return <Injection />;
+    },
+  },
+  InjectedObjectJson: {
+    title: 'InjectedObjectJson',
+    testId: 'injectedObjectJson',
+    description: 'injectedJavaScriptObject availability test',
+    render() {
+      return <InjectedObjectJson />;
     },
   },
   PageLoad: {
@@ -228,6 +237,11 @@ export default class App extends Component<Props, State> {
             testID="testType_injection"
             title="Injection"
             onPress={() => this._changeTest('Injection')}
+          />
+          <Button
+            testID="testType_injectedObjectJson"
+            title="InjectedObjectJson"
+            onPress={() => this._changeTest('InjectedObjectJson')}
           />
           <Button
             testID="testType_pageLoad"

--- a/example/examples/InjectedObjectJson.tsx
+++ b/example/examples/InjectedObjectJson.tsx
@@ -1,0 +1,83 @@
+import React, {Component} from 'react';
+import {Text, View, ScrollView} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>injectedJavaScriptObject test</title>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var ele = document.createElement('p');
+        ele.id = "domContentLoadedResult";
+        try {
+          var json = window.ReactNativeWebView.injectedObjectJson();
+          if (json) {
+            ele.textContent = "DOMContentLoaded: " + json;
+            ele.style.color = "green";
+          } else {
+            ele.textContent = "DOMContentLoaded: null";
+            ele.style.color = "red";
+          }
+        } catch (e) {
+          ele.textContent = "DOMContentLoaded: FAILED - " + e.message;
+          ele.style.color = "red";
+        }
+        document.body.appendChild(ele);
+      });
+    </script>
+  </head>
+  <body>
+    <p>Testing injectedJavaScriptObject availability:</p>
+  </body>
+</html>
+`;
+
+type Props = {};
+type State = {};
+
+export default class InjectedObjectJson extends Component<Props, State> {
+  render() {
+    return (
+      <ScrollView>
+        <View style={{height: 300}}>
+          <WebView
+            source={{html: HTML}}
+            onMessage={() => {}}
+            injectedJavaScriptObject={{hello: 'world'}}
+            injectedJavaScript={`
+              var ele = document.createElement('p');
+              ele.id = "afterContentLoadedResult";
+              try {
+                var json = window.ReactNativeWebView.injectedObjectJson();
+                if (json) {
+                  ele.textContent = "afterContentLoaded: " + json;
+                  ele.style.color = "green";
+                } else {
+                  ele.textContent = "afterContentLoaded: null";
+                  ele.style.color = "red";
+                }
+              } catch (e) {
+                ele.textContent = "afterContentLoaded: FAILED - " + e.message;
+                ele.style.color = "red";
+              }
+              document.body.appendChild(ele);
+            `}
+          />
+        </View>
+        <Text>
+          This test verifies that injectedJavaScriptObject is accessible via
+          window.ReactNativeWebView.injectedObjectJson() at both
+          DOMContentLoaded and afterContentLoaded times.
+        </Text>
+        <Text>
+          Both lines should be green showing the JSON object.
+        </Text>
+      </ScrollView>
+    );
+  }
+}


### PR DESCRIPTION
# Why

Fixing two issues on Android:
- Unreliable `injectedJavaScriptBeforeContentLoaded` on Android. This is a known issue as #1609 and #1099.
- `injectedJavaScriptObject` doesn't work in some cases. fixes #3326.

# How

## injectedJavaScriptObject — Revamp bridge architecture

The old bridge architecture used `addWebMessageListener` (WML) on `"ReactNativeWebView"` for messaging and `addJavascriptInterface` on a separate name as fallback. `injectedObjectJson()` was injected via `evaluateJavascript` with backtick interpolation, which was fragile and not running synchronously.

The new design flips the relationship:

- `addJavascriptInterface` is **always** registered on `"ReactNativeWebView"`, making `injectedObjectJson()` a native `@JavascriptInterface` method — available before DOMContentLoaded, no JS aliasing needed.
- WML is registered on an internal name (`"__RNCWebViewMessageListener"`) for origin security.
- When WML is available, `window.ReactNativeWebView` is replaced with a wrapper (via `Object.assign`) that routes `postMessage` through WML while preserving all other properties including `injectedObjectJson()`.

| Android WebView feature | postMessage | injectedObjectJson | beforeContentLoaded |
|------------------------|------------|-------------------|-------------------|
| WML + DSS (modern) | WML (sourceOrigin) | RNCWebViewBridge | DSS |
| WML only (mid) | WML after override runs; @JavascriptInterface before that | RNCWebViewBridge | evaluateJavascript (unreliable) |
| Neither (old) | @JavascriptInterface | RNCWebViewBridge | evaluateJavascript (unreliable) |

## injectedJavaScriptBeforeContentLoaded — Document Start Scripts

Use `WebViewCompat.addDocumentStartJavaScript()` API to inject `injectedJavaScriptBeforeContentLoaded` before any page content loads. This is similar to `WKUserScriptInjectionTimeAtDocumentStart` on iOS but only available in newer WebView (when `WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)` is available).

For older Android WebView (e.g. factory Android 9 WebView), DSS is not supported and `injectedJavaScriptBeforeContentLoaded` falls back to the existing `evaluateJavascript` path (which remains unreliable on those devices — a known platform limitation).

# Test Plan

A new **InjectedObjectJson** example has been added to the example app to verify `injectedObjectJson()` availability at both DOMContentLoaded and afterContentLoaded. Also verified the existing **Messaging** example to ensure `postMessage` continues to work correctly.

- **Modern Android (WML + DSS)**: Run the Injection and InjectedObjectJson examples
  - `injectedObjectJson()` should be available at both DOMContentLoaded and afterContentLoaded
  - `postMessage` should work (messaging example)
  - `beforeContentLoaded` injection should succeed (injection example)

- **Android 9 / old WebView (no WML, no DSS)**: Run same examples
  - `injectedObjectJson()` should work (RNCWebViewBridge, always available)
  - `postMessage` should work via `@JavascriptInterface`
  - `beforeContentLoaded` may be unreliable (known platform limitation)

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>