### PR TITLE
fix (iOS): sharedCookies bug when webview is nil. Race condition. Bug making Detox tests to wait indefinitely

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1872,7 +1872,9 @@ didFinishNavigation:(WKNavigation *)navigation
       if(!_incognito && !_cacheEnabled) {
         wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
       }
-      [self syncCookiesToWebView:^{}];
+      if (_webView != nil) {
+        [self syncCookiesToWebView:^{}];
+      }
     } else {
       NSMutableString *script = [NSMutableString string];
 


### PR DESCRIPTION
# Issue

Detox identified the issue. Detox keeps waiting/synchronising with 

```
Run loop "Main Run Loop" is awake.
• There are 2 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
12:55:46.905 detox[1109] i The app has not responded to the network requests below:
  (id = 132) invoke: {"type":"action","action":"tap","predicate":{"type":"text","value":"Completed","isRegex":false}}
```
when `sharedCookiesEnabled=true`

https://github.com/react-native-webview/react-native-webview/issues/3877


# Description 

This fix is based on some manual debugging and AI analysis. Here is the AI explanation:

What’s causing the Detox hang
Detox can hang because navigation is gated on the cookie-sync completion, and that completion can never fire.

In visitSource, the actual loadRequest happens only inside the completion passed to syncCookiesToWebView:

```
RNCWebViewImpl.m
Lines 861-884
  [self syncCookiesToWebView:^{
    // ...
    if (request.URL.host) {
      [webView loadRequest:request];
    }
    // ...
  }];
````

But syncCookiesToWebView calls writeCookiesToWebView, which (before the fix) did:
- capture `__weak WKWebView *webView = _webView;`
- `dispatch_async` to main
- `dispatch_group_enter(group)` for each cookie
- call `[webView.configuration.websiteDataStore.httpCookieStore setCookie:... completionHandler:^{ dispatch_group_leave }]`

If webView becomes nil by the time the async block runs (weak ref), setCookie is sent to nil, so the completion handler is never invoked, so the group never leaves, so the dispatch_group_notify never runs, so the navigation completion never runs → Detox waits forever.



# Note
- I am not familiar with the codebase and iOS webviews 
- I was wondering if this also causes some memory leaks/hangs in non-detox, production scenarios