### PR TITLE
fix(ios): call clearCache from webview implementation in new arch

### DIFF
--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -564,7 +564,7 @@ Class<RCTComponentViewProtocol> RNCWebViewCls(void)
 }
 
 - (void)clearCache:(BOOL)includeDiskFiles {
-    // android only
+    [_view clearCache:includeDiskFiles];
 }
 
 - (void)clearHistory {


### PR DESCRIPTION
It seems that after clearCache support was added for iOS in #3119, the new architecture file RNCWebView.mm wasn't updated to call the clearCache implementation in RNCWebViewImpl. It still performs a no-op with the android-only comment from before the change was introduced
<img width="1264" height="457" alt="Issue" src="https://github.com/user-attachments/assets/2a3b46b3-9251-4016-a9dc-aaa7de930fb6" />

After patch:
<img width="1246" height="472" alt="Fix" src="https://github.com/user-attachments/assets/44928a7d-4924-4dbd-8171-f6fc89ef9719" />

<img width="1260" height="439" alt="Post-fix implementation called" src="https://github.com/user-attachments/assets/a7023040-6abc-4416-9397-4179cd2d5b05" />