### PR TITLE
fix(ios): add try-catch guard to History API shim notify function

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1843,7 +1843,7 @@ didFinishNavigation:(WKNavigation *)navigation
                                            @"(function(history) {\n"
                                          "  function notify(type) {\n"
                                          "    setTimeout(function() {\n"
-                                         "      window.webkit.messageHandlers.%@.postMessage(type)\n"
+                                         "      try { window.webkit.messageHandlers.%@.postMessage(type) } catch(e) {}\n"
                                          "    }, 0)\n"
                                          "  }\n"
                                          "  function shim(f) {\n"


### PR DESCRIPTION
## Summary

- Wraps `postMessage` call in the History API shim's `notify` function with try-catch to prevent `TypeError` when the WKWebView message handler is deallocated before the `setTimeout` callback executes.

Fixes #3944

## Changes

`apple/RNCWebViewImpl.m` — 1 line changed:

```diff
  function notify(type) {
    setTimeout(function() {
-     window.webkit.messageHandlers.ReactNativeHistoryShim.postMessage(type)
+     try { window.webkit.messageHandlers.ReactNativeHistoryShim.postMessage(type) } catch(e) {}
    }, 0)
  }
```

## Why this is safe

- `notify` is called via `setTimeout(fn, 0)`, making it asynchronous
- If the handler is already removed (via `removeScriptMessageHandlerForName:` in `removeFromSuperview`/`destroyWebView`), the WebView is being torn down — the navigation notification is irrelevant
- No behavior change for the normal case where the handler exists