### PR TITLE
fix(android): handle ACCESS_COARSE_LOCATION Android permission

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -195,18 +195,23 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     @Override
     public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+        String permissionToRequest = null;
 
         if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
+            permissionToRequest = Manifest.permission.ACCESS_FINE_LOCATION;
+        } else if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), Manifest.permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+            permissionToRequest = Manifest.permission.ACCESS_COARSE_LOCATION;
+        }
 
+        if (permissionToRequest != null) {
             /*
              * Keep the trace of callback and origin for the async permission request
              */
             geolocationPermissionCallback = callback;
             geolocationPermissionOrigin = origin;
-
-            requestPermissions(Collections.singletonList(Manifest.permission.ACCESS_FINE_LOCATION));
-
+            requestPermissions(Collections.singletonList(permissionToRequest));
         } else {
             callback.invoke(origin, true, false);
         }
@@ -264,7 +269,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
             String permission = permissions[i];
             boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
 
-            if (permission.equals(Manifest.permission.ACCESS_FINE_LOCATION)
+            if ((permission.equals(Manifest.permission.ACCESS_FINE_LOCATION) || permission.equals(Manifest.permission.ACCESS_COARSE_LOCATION))
                     && geolocationPermissionCallback != null
                     && geolocationPermissionOrigin != null) {
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -3,6 +3,7 @@ package com.reactnativecommunity.webview;
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
@@ -33,6 +34,7 @@ import com.reactnativecommunity.webview.events.TopLoadingProgressEvent;
 import com.reactnativecommunity.webview.events.TopOpenWindowEvent;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -195,23 +197,32 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     @Override
     public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
-        String permissionToRequest = null;
 
-        if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), Manifest.permission.ACCESS_FINE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            permissionToRequest = Manifest.permission.ACCESS_FINE_LOCATION;
-        } else if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), Manifest.permission.ACCESS_COARSE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            permissionToRequest = Manifest.permission.ACCESS_COARSE_LOCATION;
+        boolean fineLocationDeclared = false;
+
+        try {
+            Context context = this.mWebView.getThemedReactContext();
+            String[] requestedPermissions = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS).requestedPermissions;
+            if (Arrays.asList(requestedPermissions).contains(Manifest.permission.ACCESS_FINE_LOCATION)) {
+                fineLocationDeclared = true;
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            fineLocationDeclared = true;
         }
+    
+        // If ACCESS_FINE_LOCATION is available to request, we use that, otherwise fall back to ACCESS_COARSE_LOCATION
+        String locationPermission = fineLocationDeclared
+                ? Manifest.permission.ACCESS_FINE_LOCATION
+                : Manifest.permission.ACCESS_COARSE_LOCATION;
 
-        if (permissionToRequest != null) {
+        if (ContextCompat.checkSelfPermission(this.mWebView.getThemedReactContext(), locationPermission)
+                != PackageManager.PERMISSION_GRANTED) {
             /*
              * Keep the trace of callback and origin for the async permission request
              */
             geolocationPermissionCallback = callback;
             geolocationPermissionOrigin = origin;
-            requestPermissions(Collections.singletonList(permissionToRequest));
+            requestPermissions(Collections.singletonList(locationPermission));
         } else {
             callback.invoke(origin, true, false);
         }


### PR DESCRIPTION

Fixes #2481, #2530 

Many apps legitimately only request `ACCESS_COARSE_LOCATION` for privacy reasons or to comply with Play Store policy, such as the [Financial Services Loans policy](https://support.google.com/googleplay/android-developer/answer/9876821#), so this PR updates the Android location permissions handling to support both `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION`. 

We now check if `ACCESS_FINE_LOCATION` is available in the permissions list, and request it, otherwise we fallback to `ACCESS_COARSE_LOCATION`. This fixes the scenario where the app does not declare `ACCESS_FINE_LOCATION` in the permissions manifest, either by choice or because of a Play Store policy.

When checking if the user already allows the permission request (in `webviewPermissionsListener`), we treat the user providing `ACCESS_COARSE_LOCATION` as a successful permission request (which it is!) - this fixes the scenario described in #2530

The WebView geolocation API doesn't distinguish between fine and coarse location - it simply needs some location permission to be granted. The native platform then returns location data with accuracy based on the permission level. By checking `ACCESS_FINE_LOCATION` first and falling back to `ACCESS_COARSE_LOCATION`, the code correctly handles both scenarios:

 - Apps that have declared precise location permissions
 - Apps that have opted for coarse-only location for privacy or policy compliance