### PR TITLE
feat(android): add `profile` prop for isolated cookie jars

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -15,7 +15,6 @@ import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.WebSettings
 import android.webkit.WebView
-import androidx.webkit.Profile
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
@@ -499,17 +498,16 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
             return
         }
 
-        // setProfile must be called before any URL is loaded; once a non-default
-        // profile is attached it cannot be reassigned.
-        val current = WebViewCompat.getProfile(view)
-        if (current.name == profileName) return
-        if (current.name != Profile.DEFAULT_PROFILE_NAME) {
-            Log.w(TAG, "Cannot change WebView profile from '${current.name}' to '$profileName' after creation.")
-            return
+        // setProfile must be called before any URL is loaded AND before getProfile
+        // is ever called — calling getProfile itself locks the WebView to its
+        // current profile. The catch covers the case where the prop is changed
+        // after first mount, which the underlying API doesn't allow.
+        try {
+            ProfileStore.getInstance().getOrCreateProfile(profileName)
+            WebViewCompat.setProfile(view, profileName)
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "Cannot change WebView profile to '$profileName': ${e.message}")
         }
-
-        ProfileStore.getInstance().getOrCreateProfile(profileName)
-        WebViewCompat.setProfile(view, profileName)
     }
 
     fun setInjectedJavaScript(viewWrapper: RNCWebViewWrapper, injectedJavaScript: String?) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -15,7 +15,10 @@ import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.WebSettings
 import android.webkit.WebView
+import androidx.webkit.Profile
+import androidx.webkit.ProfileStore
 import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -485,6 +488,28 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         view.clearFormData();
         view.settings.savePassword = false;
         view.settings.saveFormData = false;
+    }
+
+    fun setProfile(viewWrapper: RNCWebViewWrapper, profileName: String?) {
+        val view = viewWrapper.webView
+        if (profileName.isNullOrEmpty()) return
+
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) {
+            Log.w(TAG, "WebView profile '$profileName' ignored: MULTI_PROFILE not supported on this device.")
+            return
+        }
+
+        // setProfile must be called before any URL is loaded; once a non-default
+        // profile is attached it cannot be reassigned.
+        val current = WebViewCompat.getProfile(view)
+        if (current.name == profileName) return
+        if (current.name != Profile.DEFAULT_PROFILE_NAME) {
+            Log.w(TAG, "Cannot change WebView profile from '${current.name}' to '$profileName' after creation.")
+            return
+        }
+
+        ProfileStore.getInstance().getOrCreateProfile(profileName)
+        WebViewCompat.setProfile(view, profileName)
     }
 
     fun setInjectedJavaScript(viewWrapper: RNCWebViewWrapper, injectedJavaScript: String?) {

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -338,6 +338,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
     }
 
+    @Override
+    @ReactProp(name = "profile")
+    public void setProfile(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setProfile(view, value);
+    }
+
     /* iOS PROPS - no implemented here */
     @Override
     public void setAllowingReadAccessToURL(RNCWebViewWrapper view, @Nullable String value) {}

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -279,6 +279,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
     }
 
+    @ReactProp(name = "profile")
+    public void setProfile(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setProfile(view, value);
+    }
+
     @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
         // Do not register default touch emitter and let WebView implementation handle touches

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -71,6 +71,7 @@ This document lays out the current public properties and methods for the React N
 - [`saveFormDataDisabled`](Reference.md#saveFormDataDisabled)
 - [`cacheEnabled`](Reference.md#cacheEnabled)
 - [`cacheMode`](Reference.md#cacheMode)
+- [`profile`](Reference.md#profile)
 - [`pagingEnabled`](Reference.md#pagingEnabled)
 - [`allowsLinkPreview`](Reference.md#allowsLinkPreview)
 - [`sharedCookiesEnabled`](Reference.md#sharedCookiesEnabled)
@@ -1342,6 +1343,28 @@ Possible values are:
 | Type   | Required | Default      | Platform |
 | ------ | -------- | ------------ | -------- |
 | string | No       | LOAD_DEFAULT | Android  |
+
+---
+
+### `profile`[⬆](#props-index)
+
+Name of the [androidx.webkit `Profile`](https://developer.android.com/reference/androidx/webkit/Profile) to use for this WebView. When set, the WebView gets an isolated cookie jar, web storage, geolocation permissions, and service workers scoped to this profile, separate from the default profile used by other WebViews in the app. Useful for embedded auth flows, multi-account support, or any case where a WebView's cookies need to be independent from the rest of the app.
+
+If a profile with the given name does not exist yet, it is created on first use via `ProfileStore.getOrCreateProfile`. Profiles persist across app launches.
+
+Requires `WebViewFeature.MULTI_PROFILE` (androidx.webkit 1.9+, Android 10+ with a recent WebView). On unsupported devices the prop is ignored — the WebView falls back to the default profile and a warning is logged via Logcat.
+
+> **Note**: this prop must be set when the WebView is first mounted. The Android Profile API does not allow changing a WebView's profile after it has loaded; later changes to this prop are ignored with a warning.
+
+```jsx
+// Two WebViews with isolated cookies
+<WebView source={{ uri: 'https://example.com' }} profile="account-a" />
+<WebView source={{ uri: 'https://example.com' }} profile="account-b" />
+```
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
 
 ---
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -26,6 +26,7 @@ import CustomMenu from './examples/CustomMenu';
 import OpenWindow from './examples/OpenWindow';
 import SuppressMenuItems from './examples/Suppress';
 import ClearData from './examples/ClearData';
+import ProfileExample from './examples/Profile';
 import SslError from './examples/SslError';
 
 const TESTS = {
@@ -165,6 +166,14 @@ const TESTS = {
       return <SslError />;
     },
   },
+  Profile: {
+    title: 'Profile (Android)',
+    testId: 'profile',
+    description: 'Isolated cookie jars via androidx.webkit Profile',
+    render() {
+      return <ProfileExample />;
+    },
+  },
 };
 
 interface State {
@@ -296,6 +305,11 @@ export default class App extends Component<unknown, State> {
             testID="testType_sslError"
             title="SslError"
             onPress={() => this._changeTest('SslError')}
+          />
+          <Button
+            testID="testType_profile"
+            title="Profile"
+            onPress={() => this._changeTest('Profile')}
           />
         </View>
 

--- a/example/examples/Profile.tsx
+++ b/example/examples/Profile.tsx
@@ -1,0 +1,116 @@
+import React, { useRef } from 'react';
+import { Button, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const COOKIES_URL = 'https://httpbin.org/cookies';
+const CLEAR_URL = 'https://httpbin.org/cookies/delete?token=';
+
+type WebViewConfig = {
+  id: string;
+  label: string;
+  profile?: string;
+  setUrl: string;
+};
+
+const WEBVIEW_CONFIGS: WebViewConfig[] = [
+  {
+    id: 'alpha',
+    label: 'Profile "alpha"',
+    profile: 'alpha',
+    setUrl: 'https://httpbin.org/cookies/set?token=alpha',
+  },
+  {
+    id: 'beta',
+    label: 'Profile "beta"',
+    profile: 'beta',
+    setUrl: 'https://httpbin.org/cookies/set?token=beta',
+  },
+  {
+    id: 'default-1',
+    label: 'No profile 1 (default jar)',
+    profile: undefined,
+    setUrl: 'https://httpbin.org/cookies/set?token=default',
+  },
+  {
+    id: 'default-2',
+    label: 'No profile 2 (default jar)',
+    profile: undefined,
+    setUrl: 'https://httpbin.org/cookies/set?token=default',
+  },
+];
+
+export default function ProfileExample() {
+  const refs = useRef<Record<string, WebView | null>>({});
+
+  if (Platform.OS !== 'android') {
+    return (
+      <View style={styles.notice}>
+        <Text style={styles.noticeText}>
+          The `profile` prop is Android-only. Run this example on Android to test isolated cookie jars.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.intro}>
+        Each WebView below is bound to a different androidx.webkit Profile (or no profile).
+        Tap "Set cookie" on one row, then "Get cookie" — the other rows should not see it.
+      </Text>
+
+      {WEBVIEW_CONFIGS.map((config) => (
+        <View key={config.id} style={styles.webviewRow}>
+          <Text style={styles.webviewLabel}>{config.label}</Text>
+          <View style={styles.buttonRow}>
+            <Button
+              title="Set cookie"
+              onPress={() =>
+                refs.current[config.id]?.injectJavaScript(
+                  `window.location.href = ${JSON.stringify(config.setUrl)};`,
+                )
+              }
+            />
+            <Button
+              title="Get cookie"
+              onPress={() =>
+                refs.current[config.id]?.injectJavaScript(
+                  `window.location.href = ${JSON.stringify(COOKIES_URL)};`,
+                )
+              }
+            />
+            <Button
+              title="Clear cookie"
+              onPress={() =>
+                refs.current[config.id]?.injectJavaScript(
+                  `window.location.href = ${JSON.stringify(CLEAR_URL)};`,
+                )
+              }
+            />
+          </View>
+          <WebView
+            ref={(r) => {
+              refs.current[config.id] = r;
+            }}
+            profile={config.profile}
+            source={{ uri: COOKIES_URL }}
+            style={styles.webview}
+            textZoom={300}
+          />
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  intro: { padding: 8, fontSize: 16, color: '#444' },
+  webviewRow: { marginBottom: 12, borderTopWidth: 1, borderTopColor: '#ddd', paddingTop: 8 },
+  webviewLabel: { fontWeight: '600', paddingHorizontal: 8 },
+  buttonRow: { flexDirection: 'row', flexWrap: 'wrap', paddingHorizontal: 4 },
+  webview: { height: 220, marginTop: 8 },
+  notice: { padding: 24 },
+  noticeText: { fontSize: 18, color: '#555' },
+});

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -235,6 +235,7 @@ export interface NativeProps extends ViewProps {
   }>;
   cacheEnabled?: WithDefault<boolean, true>;
   incognito?: boolean;
+  profile?: string;
   injectedJavaScript?: string;
   injectedJavaScriptBeforeContentLoaded?: string;
   injectedJavaScriptForMainFrameOnly?: WithDefault<boolean, true>;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -280,6 +280,7 @@ export interface BasicAuthCredential {
 export interface CommonNativeWebViewProps extends ViewProps {
   cacheEnabled?: boolean;
   incognito?: boolean;
+  profile?: string;
   injectedJavaScript?: string;
   injectedJavaScriptBeforeContentLoaded?: string;
   injectedJavaScriptForMainFrameOnly?: boolean;
@@ -965,6 +966,27 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   cacheMode?: CacheMode;
+
+  /**
+   * Name of the [androidx.webkit `Profile`](https://developer.android.com/reference/androidx/webkit/Profile)
+   * to use for this WebView. When set, the WebView gets an isolated cookie jar,
+   * web storage, geolocation permissions, and service workers scoped to this
+   * profile, separate from the default profile used by other WebViews.
+   *
+   * Useful for embedded auth flows, multi-account support, or any case where
+   * you want a WebView's cookies to be independent of the rest of the app.
+   *
+   * Requires `WebViewFeature.MULTI_PROFILE` (androidx.webkit 1.9+, Android 10+
+   * with a recent WebView). On unsupported devices the prop is ignored and
+   * the default profile is used (a warning is logged via Logcat).
+   *
+   * Note: must be set when the WebView is first mounted. The Profile API does
+   * not allow changing profile after the WebView has loaded; later changes
+   * to this prop will be ignored with a warning.
+   *
+   * @platform android
+   */
+  profile?: string;
 
   /**
    * https://developer.android.com/reference/android/view/View#setOverScrollMode(int)


### PR DESCRIPTION
## Summary

Adds a `profile` prop on Android that binds a WebView to an [androidx.webkit `Profile`](https://developer.android.com/reference/androidx/webkit/Profile), giving it an isolated cookie jar, web storage, geolocation permissions, and service workers - separate from the default profile shared by the rest of the app's WebViews.

Useful for any case where a WebView's cookies need to be independent from everything else. Two `<WebView>`s with different `profile` values can be logged into the same site as different users at the same time.

```jsx
<WebView source={{ uri: 'https://example.com' }} profile="profile-a" />
<WebView source={{ uri: 'https://example.com' }} profile="profile-b" />
```

## Behavior

- **Android with `MULTI_PROFILE` support** (androidx.webkit 1.9+, Android 10+ with a recent WebView): the named profile is created on first use via `ProfileStore.getOrCreateProfile` and attached with `WebViewCompat.setProfile`. Profiles persist across app launches.
- **Android without `MULTI_PROFILE` support**: the prop is ignored, the WebView falls back to the default profile, and a warning is logged via Logcat. No crash.
- **iOS**: the prop is typed as Android-only and is a no-op natively. The codegen field exists in the shared spec but is never read by the iOS view.

The Android Profile API does not allow reassigning a WebView's profile after it has loaded, so changing the prop value after mount is ignored with a Logcat warning. This is documented on the prop.

## Changes

- `android/.../RNCWebViewManagerImpl.kt` - `setProfile` with feature gate, get-or-create, and idempotency check
- `android/.../RNCWebViewManager.java` (newarch + oldarch) - `@ReactProp("profile")` wiring
- `src/RNCWebViewNativeComponent.ts`, `src/WebViewTypes.ts` - codegen + TS types (Android-only at the public API)
- `docs/Reference.md` - prop documentation
- `example/examples/Profile.tsx` + `example/App.tsx` - demo screen with multiple WebViews on different profiles, plus controls to set/get/clear cookies so you can verify isolation against `httpbin.org/cookies`

## Recording

https://github.com/user-attachments/assets/14274b7f-c474-4919-8456-8fa97297feee