### PR TITLE
fix(ios): avoid template literal in injectedObjectJson() to preserve escapes

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1721,6 +1721,12 @@ didFinishNavigation:(WKNavigation *)navigation
 - (void)setInjectedJavaScriptObject:(NSString *)source
 {
   _injectedJavaScriptObject = source;
+  // Embed `source` as a JS expression (JSON is a subset of JS object-literal
+  // syntax) rather than inside a template literal. Template literals unescape
+  // `\"` -> `"`, which corrupts payloads that contain already-stringified JSON
+  // (e.g. `{"state": "{\"k\":\"v\"}"}`). `JSON.stringify(...)` then re-emits a
+  // valid JSON string so existing callers of `injectedObjectJson()` (which
+  // typically `JSON.parse` the result) keep working unchanged.
   self.injectedObjectJsonScript = [
     [WKUserScript alloc]
     initWithSource: [
@@ -1728,7 +1734,7 @@ didFinishNavigation:(WKNavigation *)navigation
       stringWithFormat:
        @"window.%@ = window.%@ || {};"
       "window.%@.injectedObjectJson = function () {"
-      "  return `%@`;"
+      "  return JSON.stringify(%@);"
       "};", MessageHandlerName, MessageHandlerName, MessageHandlerName, source
     ]
     injectionTime:WKUserScriptInjectionTimeAtDocumentStart


### PR DESCRIPTION
## Why

Fixes #3957 — the iOS counterpart of #3942.

On iOS, `setInjectedJavaScriptObject:` injects the already-stringified JSON into a JS **template literal**:

https://github.com/react-native-webview/react-native-webview/blob/eb8ccacd35740af39993725ad1b592d45364a510/apple/RNCWebViewImpl.m#L1721-L1740

```objc
"  return `%@`;"
```

Template literals unescape `\"` to `"`, so payloads that contain nested-JSON string values (e.g. `{ state: '{"root":...}' }`) come back from `injectedObjectJson()` with broken quoting. Consumers calling `JSON.parse(window.ReactNativeWebView.injectedObjectJson())` then throw `SyntaxError: Expected '}'`. Control characters like `\n` / `\r` / `\t` hit the same class of bug (as reported for Android in #3942).

This breaks, among other things, **Lexical editor mounted inside an Expo DOM Component on iOS**: `expo/src/dom/dom-entry.tsx` reads `JSON.parse(injectedObjectJson())` to recover `$$EXPO_DOM_HOST_OS` / `$$EXPO_INITIAL_PROPS`; when that throws, the React tree never mounts and the WebView renders blank.

## How

Minimal one-line change: embed the JSON as a **JS expression** (JSON is a subset of JS object-literal syntax) and re-emit it via `JSON.stringify(...)`:

```diff
-      "  return `%@`;"
+      "  return JSON.stringify(%@);"
```

Because the JSON is parsed by the JS engine as an object/array/string expression rather than scanned as a template literal, the escape handling matches what the JSON spec already guarantees. `JSON.stringify(...)` then re-serializes to the canonical JSON string form, so existing callers of `injectedObjectJson()` (which typically `JSON.parse` the result) keep working without any consumer-side change.

## Relationship to #3929

#3929 fixes Android for the same root cause by switching to `@JavascriptInterface` (a native bridge method) — that approach sidesteps JS string escaping entirely and is the more thorough fix. iOS has no exact equivalent without raising the deployment target to introduce `WKScriptMessageHandlerWithReply` (iOS 14+) and refactoring the bridge architecture, so this PR keeps the existing `WKUserScript` injection but plugs the escape bug with a minimal, reviewable change.

If a follow-up wants to mirror #3929's architecture on iOS, this PR is forward-compatible with that — and in the meantime restores correctness for users on the current code path.

## Test Plan

Manual repro from #3957: render a `WebView` whose `injectedJavaScriptObject` contains a nested-JSON string value, then `JSON.parse(window.ReactNativeWebView.injectedObjectJson())` from the page.

- **Before**: `SyntaxError: Expected '}'`
- **After**: parses successfully, value round-trips intact.

Also verified via the real-world Lexical-inside-Expo-DOM-Component case (Expo SDK 56, iOS 26.3 simulator): editor was rendering blank before this fix, mounts normally after.