### PR TITLE
fix(android): request CAMERA permission for capture file inputs

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -50,6 +50,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     public static final int PICKER = 1;
     public static final int PICKER_LEGACY = 3;
     public static final int FILE_DOWNLOAD_PERMISSION_REQUEST = 1;
+    public static final int CAMERA_PERMISSION_REQUEST = 2;
 
     final private ReactApplicationContext mContext;
 
@@ -263,6 +264,44 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     }
 
     public boolean startPhotoPickerIntent(final String[] acceptTypes, final boolean allowMultiple, final ValueCallback<Uri[]> callback, final boolean isCaptureEnabled) {
+        // A capture-enabled file input (e.g. <input type="file" accept="image/*" capture>) needs
+        // the camera. When the app declares CAMERA but it isn't granted yet, request it and launch
+        // once the user responds. Without this the capture intent is silently dropped (see
+        // needsCameraPermission / "there is no Camera permission" below) and nothing opens.
+        if (isCaptureEnabled && needsCameraPermission()) {
+            try {
+                getPermissionAwareActivity().requestPermissions(
+                        new String[]{Manifest.permission.CAMERA},
+                        CAMERA_PERMISSION_REQUEST,
+                        getCameraPermissionListener(acceptTypes, allowMultiple, callback, isCaptureEnabled));
+                return true;
+            } catch (IllegalStateException e) {
+                // Host Activity doesn't implement PermissionAwareActivity — fall back to the
+                // previous behaviour instead of crashing.
+                Log.w("RNCWebViewModule", "Unable to request CAMERA permission", e);
+            }
+        }
+
+        return launchPhotoPickerIntent(acceptTypes, allowMultiple, callback, isCaptureEnabled);
+    }
+
+    private PermissionListener getCameraPermissionListener(final String[] acceptTypes, final boolean allowMultiple, final ValueCallback<Uri[]> callback, final boolean isCaptureEnabled) {
+        return new PermissionListener() {
+            @Override
+            public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+                if (requestCode == CAMERA_PERMISSION_REQUEST) {
+                    // Launch regardless of the result: if granted, the capture intent is now built;
+                    // if denied, needsCameraPermission() stays true and the existing "no Camera
+                    // permission" branch handles it — so there is no re-request loop.
+                    launchPhotoPickerIntent(acceptTypes, allowMultiple, callback, isCaptureEnabled);
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    private boolean launchPhotoPickerIntent(final String[] acceptTypes, final boolean allowMultiple, final ValueCallback<Uri[]> callback, final boolean isCaptureEnabled) {
         mFilePathCallback = callback;
         Activity activity = mContext.getCurrentActivity();
 


### PR DESCRIPTION
## Summary

On Android, a capture-enabled file input silently does nothing when the host app **declares** the `CAMERA` permission but it **hasn't been granted** yet.

### Repro
- App's `AndroidManifest` declares `android.permission.CAMERA` (very common).
- CAMERA is not granted at runtime.
- Web content triggers `<input type="file" accept="image/*" capture>` (or `capture="environment"`).

**Result:** nothing opens. Logcat: `RNCWebViewModule: there is no Camera permission`.

### Root cause
`RNCWebViewModuleImpl.startPhotoPickerIntent` calls `needsCameraPermission()`, which returns `true` precisely when CAMERA is declared-but-not-granted. In that case the camera intent is **not built** (`photoIntent` stays `null`), so for a capture input `chooserIntent` becomes `null` and the picker never launches. The component *detects* it needs the permission but never *requests* it — unlike downloads, which already request `WRITE_EXTERNAL_STORAGE` via `grantFileDownloaderPermissions`.

### Fix
When a capture is requested and `needsCameraPermission()` is `true`, request `CAMERA` through the existing `PermissionAwareActivity` plumbing and launch the picker once the user responds:
- **Granted** → the capture intent is built and the camera opens.
- **Denied** → `needsCameraPermission()` stays `true`, the existing "no Camera permission" branch runs → **no re-request loop**.
- Host `Activity` not `PermissionAwareActivity` → falls back to the previous behaviour (logged, no crash).

The picker-launch body is extracted into `launchPhotoPickerIntent(...)` so it runs both directly and from the permission callback. Mirrors the existing `grantFileDownloaderPermissions` storage-permission flow; no JS API change, Android-only.

## Test Plan
Root cause confirmed on an Android emulator: with an app declaring CAMERA but not granted, tapping `<input capture>` is a no-op and logs `there is no Camera permission`; granting CAMERA out-of-band makes the same input open the camera capture.

With this change, on first capture tap:
1. **Before** — nothing happens; `there is no Camera permission` in logcat.
2. **After** — OS CAMERA prompt appears → **Allow** → camera capture opens. **Deny** → no crash, no loop. Already-granted → opens directly.

Non-capture file inputs and the download permission flow are unaffected.

## Changelog

[Android] [Fixed] - Request the CAMERA permission for `<input capture>` file inputs instead of silently dropping the camera intent