### PR TITLE
fix(ios): forward newSource on legacy view-manager path (fixes #3863)

### DIFF
--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -41,8 +41,15 @@ RCT_EXPORT_MODULE(RNCWebView)
 }
 
 RCT_EXPORT_VIEW_PROPERTY(source, NSDictionary)
-// New arch only
-RCT_CUSTOM_VIEW_PROPERTY(newSource, NSDictionary, RNCWebViewImpl) {}
+// New arch only. Forward newSource on the legacy view-manager fallback path —
+// an empty macro here drops the source and leaves the WebView blank on iOS (#3863).
+RCT_CUSTOM_VIEW_PROPERTY(newSource, NSDictionary, RNCWebViewImpl) {
+  if (json == nil) {
+    [view setSource:@{}];
+  } else {
+    [view setSource:json];
+  }
+}
 RCT_EXPORT_VIEW_PROPERTY(onFileDownload, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoadingStart, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoadingFinish, RCTDirectEventBlock)


### PR DESCRIPTION
## Summary

On some new-architecture configurations, the WebView renders **blank on iOS** because the `source` prop is silently dropped.

With the new architecture, `source` is sent from JS as the `newSource` prop. It is consumed in two places:

- the Fabric component `RNCWebView.mm` (`updateProps`) — implemented, and
- the legacy view manager `RNCWebViewManager.mm` — where `newSource` was an **empty `RCT_CUSTOM_VIEW_PROPERTY` no-op**.

When a project ends up on the legacy view-manager path (see #3863 — several users report this on RN 0.77+ with Fabric enabled), the empty macro drops `newSource`, so `setSource:` is never called and nothing loads.

## Fix

Forward `newSource` to the view's `setSource:` from the legacy manager, mirroring how the Fabric path already builds and sets the source. A `nil` payload clears the source.

```objc
RCT_CUSTOM_VIEW_PROPERTY(newSource, NSDictionary, RNCWebViewImpl) {
  if (json == nil) {
    [view setSource:@{}];
  } else {
    [view setSource:json];
  }
}
```

This is the same approach as the earlier #3880; reopening as a focused, rebased one-commit change since that PR went stale.

## Testing

Verified on an iOS app (RN 0.83, Fabric enabled, React core built from source) where `source` previously rendered blank ~50% of cold launches: with this change the page loads reliably every launch.

Fixes #3863