### PR TITLE
feat(android)!: drop support below Android N

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,10 @@ def getExtOrIntegerDefault(prop) {
   return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : (project.properties['ReactNativeWebView_' + prop]).toInteger()
 }
 
+def getReactNativeWebViewMinSdkVersion() {
+  return Math.max(getExtOrIntegerDefault('minSdkVersion').toInteger(), 24)
+}
+
 static def findNodeModulePath(baseDir, packageName) {
     def basePath = baseDir.toPath().normalize()
     // Node's module resolution algorithm searches up to the root directory,
@@ -72,7 +76,7 @@ android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
     defaultConfig {
-        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
+        minSdkVersion getReactNativeWebViewMinSdkVersion()
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ ReactNativeWebView_kotlinVersion=1.6.0
 ReactNativeWebView_webkitVersion=1.14.0
 ReactNativeWebView_compileSdkVersion=31
 ReactNativeWebView_targetSdkVersion=31
-ReactNativeWebView_minSdkVersion=21
+ReactNativeWebView_minSdkVersion=24

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -1,11 +1,9 @@
 package com.reactnativecommunity.webview;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Message;
 import android.view.Gravity;
 import android.view.View;
@@ -19,7 +17,6 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 
-import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
@@ -315,18 +312,6 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
         return true;
     };
-
-    protected void openFileChooser(ValueCallback<Uri> filePathCallback, String acceptType) {
-      this.mWebView.getThemedReactContext().getNativeModule(RNCWebViewModule.class).startPhotoPickerIntent(filePathCallback, acceptType);
-    }
-
-    protected void openFileChooser(ValueCallback<Uri> filePathCallback) {
-      this.mWebView.getThemedReactContext().getNativeModule(RNCWebViewModule.class).startPhotoPickerIntent(filePathCallback, "");
-    }
-
-    protected void openFileChooser(ValueCallback<Uri> filePathCallback, String acceptType, String capture) {
-      this.mWebView.getThemedReactContext().getNativeModule(RNCWebViewModule.class).startPhotoPickerIntent(filePathCallback, acceptType);
-    }
 
     @Override
     public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -1,6 +1,5 @@
 package com.reactnativecommunity.webview;
 
-import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.net.http.SslError;
 import android.os.Build;
@@ -15,7 +14,6 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.core.util.Pair;
 
 import com.facebook.common.logging.FLog;
@@ -33,7 +31,6 @@ import com.reactnativecommunity.webview.events.TopLoadingStartEvent;
 import com.reactnativecommunity.webview.events.TopRenderProcessGoneEvent;
 import com.reactnativecommunity.webview.events.TopShouldStartLoadWithRequestEvent;
 import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,11 +51,7 @@ public class RNCWebViewClient extends WebViewClient {
         super.onPageFinished(webView, url);
         String cookies = CookieManager.getInstance().getCookie(url);
         if (cookies != null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                CookieManager.getInstance().flush();
-            }else {
-                CookieSyncManager.getInstance().sync();
-            }
+            CookieManager.getInstance().flush();
         }
 
         if (!mLastLoadFailed) {
@@ -139,7 +132,6 @@ public class RNCWebViewClient extends WebViewClient {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.N)
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         final String url = request.getUrl().toString();
@@ -256,7 +248,6 @@ public class RNCWebViewClient extends WebViewClient {
         UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(reactTag, eventData));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     @Override
     public void onReceivedHttpError(
             WebView webView,
@@ -274,7 +265,6 @@ public class RNCWebViewClient extends WebViewClient {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     @Override
     public boolean onRenderProcessGone(WebView webView, RenderProcessGoneDetail detail) {
         // WebViewClient.onRenderProcessGone was added in O.

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -8,12 +8,10 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Environment;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.util.Pair;
@@ -26,11 +24,7 @@ import android.widget.Toast;
 
 import com.facebook.common.activitylistener.ActivityListenerManager;
 import com.facebook.react.bridge.ActivityEventListener;
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
-import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
@@ -48,14 +42,12 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     public static final String NAME = "RNCWebViewModule";
 
     public static final int PICKER = 1;
-    public static final int PICKER_LEGACY = 3;
     public static final int FILE_DOWNLOAD_PERMISSION_REQUEST = 1;
 
     final private ReactApplicationContext mContext;
 
     private DownloadManager.Request mDownloadRequest;
 
-    private ValueCallback<Uri> mFilePathCallbackLegacy;
     private ValueCallback<Uri[]> mFilePathCallback;
     private File mOutputImage;
     private File mOutputVideo;
@@ -67,7 +59,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
 
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        if (mFilePathCallback == null && mFilePathCallbackLegacy == null) {
+        if (mFilePathCallback == null) {
             return;
         }
 
@@ -100,20 +92,6 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
                     }
                 }
                 break;
-            case RNCWebViewModuleImpl.PICKER_LEGACY:
-                if (resultCode != RESULT_OK) {
-                    mFilePathCallbackLegacy.onReceiveValue(null);
-                } else {
-                    if (imageTaken) {
-                        mFilePathCallbackLegacy.onReceiveValue(getOutputUri(mOutputImage));
-                    } else if (videoTaken) {
-                        mFilePathCallbackLegacy.onReceiveValue(getOutputUri(mOutputVideo));
-                    } else {
-                        mFilePathCallbackLegacy.onReceiveValue(data.getData());
-                    }
-                }
-                break;
-
         }
 
         if (mOutputImage != null && !imageTaken) {
@@ -124,7 +102,6 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         }
 
         mFilePathCallback = null;
-        mFilePathCallbackLegacy = null;
         mOutputImage = null;
         mOutputVideo = null;
     }
@@ -197,10 +174,6 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         };
     }
 
-    public boolean isFileUploadSupported() {
-        return true;
-    }
-
     public void shouldStartLoadWithLockIdentifier(boolean shouldStart, double lockIdentifier) {
         final AtomicReference<ShouldOverrideUrlLoadingLock.ShouldOverrideCallbackState> lockObject = shouldOverrideUrlLoadingLock.getLock(lockIdentifier);
         if (lockObject != null) {
@@ -227,39 +200,11 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         }
 
         // we have one file selected
-        if (data.getData() != null && resultCode == RESULT_OK && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (data.getData() != null && resultCode == RESULT_OK) {
             return WebChromeClient.FileChooserParams.parseResult(resultCode, data);
         }
 
         return null;
-    }
-
-    public void startPhotoPickerIntent(String acceptType, ValueCallback<Uri> callback) {
-        mFilePathCallbackLegacy = callback;
-        Activity activity = mContext.getCurrentActivity();
-        Intent fileChooserIntent = getFileChooserIntent(acceptType);
-        Intent chooserIntent = Intent.createChooser(fileChooserIntent, "");
-
-        ArrayList<Parcelable> extraIntents = new ArrayList<>();
-        if (acceptsImages(acceptType)) {
-            Intent photoIntent = getPhotoIntent();
-            if (photoIntent != null) {
-                extraIntents.add(photoIntent);
-            }
-        }
-        if (acceptsVideo(acceptType)) {
-            Intent videoIntent = getVideoIntent();
-            if (videoIntent != null) {
-                extraIntents.add(videoIntent);
-            }
-        }
-        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents.toArray(new Parcelable[]{}));
-
-        if (chooserIntent.resolveActivity(activity.getPackageManager()) != null) {
-            activity.startActivityForResult(chooserIntent, PICKER_LEGACY);
-        } else {
-            Log.w("RNCWebViewModule", "there is no Activity to handle this Intent");
-        }
     }
 
     public boolean startPhotoPickerIntent(final String[] acceptTypes, final boolean allowMultiple, final ValueCallback<Uri[]> callback, final boolean isCaptureEnabled) {
@@ -331,7 +276,7 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         }
 
         boolean result = ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
-        if (!result && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (!result) {
             PermissionAwareActivity PAactivity = getPermissionAwareActivity();
             PAactivity.requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, FILE_DOWNLOAD_PERMISSION_REQUEST, getWebviewFileDownloaderPermissionListener(downloadingMessage, lackPermissionToDownloadMessage));
         }
@@ -389,20 +334,6 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         return intent;
     }
 
-    private Intent getFileChooserIntent(String acceptTypes) {
-        String _acceptTypes = acceptTypes;
-        if (acceptTypes.isEmpty()) {
-            _acceptTypes = MimeType.DEFAULT.value;
-        }
-        if (acceptTypes.matches("\\.\\w+")) {
-            _acceptTypes = getMimeTypeFromExtension(acceptTypes.replace(".", ""));
-        }
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType(_acceptTypes);
-        return intent;
-    }
-
     private Intent getFileChooserIntent(String[] acceptTypes, boolean allowMultiple) {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
@@ -412,36 +343,12 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
         return intent;
     }
 
-    private Boolean acceptsImages(String types) {
-        String mimeType = types;
-        if (types.matches("\\.\\w+")) {
-            mimeType = getMimeTypeFromExtension(types.replace(".", ""));
-        }
-        return mimeType.isEmpty() || mimeType.toLowerCase().contains(MimeType.IMAGE.value);
-    }
-
     private Boolean acceptsImages(String[] types) {
         String[] mimeTypes = getAcceptedMimeType(types);
         return arrayContainsString(mimeTypes, MimeType.DEFAULT.value) || arrayContainsString(mimeTypes, MimeType.IMAGE.value);
     }
 
-    private Boolean acceptsVideo(String types) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return false;
-        }
-
-        String mimeType = types;
-        if (types.matches("\\.\\w+")) {
-            mimeType = getMimeTypeFromExtension(types.replace(".", ""));
-        }
-        return mimeType.isEmpty() || mimeType.toLowerCase().contains(MimeType.VIDEO.value);
-    }
-
     private Boolean acceptsVideo(String[] types) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return false;
-        }
-
         String[] mimeTypes = getAcceptedMimeType(types);
         return arrayContainsString(mimeTypes, MimeType.DEFAULT.value) || arrayContainsString(mimeTypes, MimeType.VIDEO.value);
     }
@@ -486,12 +393,6 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     }
 
     public Uri getOutputUri(File capturedFile) {
-        // for versions below 6.0 (23) we use the old File creation & permissions model
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return Uri.fromFile(capturedFile);
-        }
-
-        // for versions 6.0+ (23) we use the FileProvider to avoid runtime permissions
         String packageName = mContext.getPackageName();
         return FileProvider.getUriForFile(mContext, packageName + ".fileprovider", capturedFile);
     }
@@ -499,39 +400,24 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     public File getCapturedFile(MimeType mimeType) throws IOException {
         String prefix = "";
         String suffix = "";
-        String dir = "";
 
         switch (mimeType) {
             case IMAGE:
                 prefix = "image-";
                 suffix = ".jpg";
-                dir = Environment.DIRECTORY_PICTURES;
                 break;
             case VIDEO:
                 prefix = "video-";
                 suffix = ".mp4";
-                dir = Environment.DIRECTORY_MOVIES;
                 break;
 
             default:
                 break;
         }
 
-        String filename = prefix + String.valueOf(System.currentTimeMillis()) + suffix;
-        File outputFile = null;
+        File storageDir = mContext.getExternalFilesDir(null);
 
-        // for versions below 6.0 (23) we use the old File creation & permissions model
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            // only this Directory works on all tested Android versions
-            // ctx.getExternalFilesDir(dir) was failing on Android 5.0 (sdk 21)
-            File storageDir = Environment.getExternalStoragePublicDirectory(dir);
-            outputFile = new File(storageDir, filename);
-        } else {
-            File storageDir = mContext.getExternalFilesDir(null);
-            outputFile = File.createTempFile(prefix, suffix, storageDir);
-        }
-
-        return outputFile;
+        return File.createTempFile(prefix, suffix, storageDir);
     }
 
     private Boolean noAcceptTypesSet(String[] types) {

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -6,7 +6,6 @@ import android.webkit.ValueCallback;
 
 import androidx.annotation.NonNull;
 
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
 
@@ -20,17 +19,8 @@ public class RNCWebViewModule extends NativeRNCWebViewModuleSpec {
     }
 
     @Override
-    public void isFileUploadSupported(final Promise promise) {
-        promise.resolve(mRNCWebViewModuleImpl.isFileUploadSupported());
-    }
-
-    @Override
     public void shouldStartLoadWithLockIdentifier(boolean shouldStart, double lockIdentifier) {
         mRNCWebViewModuleImpl.shouldStartLoadWithLockIdentifier(shouldStart, lockIdentifier);
-    }
-
-    public void startPhotoPickerIntent(ValueCallback<Uri> filePathCallback, String acceptType) {
-        mRNCWebViewModuleImpl.startPhotoPickerIntent(acceptType, filePathCallback);
     }
 
     public boolean startPhotoPickerIntent(final ValueCallback<Uri[]> callback, final String[] acceptTypes, final boolean allowMultiple, final boolean isCaptureEnabled) {

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -2,11 +2,10 @@ package com.reactnativecommunity.webview;
 
 import android.app.DownloadManager;
 import android.net.Uri;
-
-import androidx.annotation.NonNull;
 import android.webkit.ValueCallback;
 
-import com.facebook.react.bridge.Promise;
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,17 +21,8 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void isFileUploadSupported(final Promise promise) {
-        promise.resolve(mRNCWebViewModuleImpl.isFileUploadSupported());
-    }
-
-    @ReactMethod
     public void shouldStartLoadWithLockIdentifier(boolean shouldStart, double lockIdentifier) {
         mRNCWebViewModuleImpl.shouldStartLoadWithLockIdentifier(shouldStart, lockIdentifier);
-    }
-
-    public void startPhotoPickerIntent(ValueCallback<Uri> filePathCallback, String acceptType) {
-        mRNCWebViewModuleImpl.startPhotoPickerIntent(acceptType, filePathCallback);
     }
 
     public boolean startPhotoPickerIntent(final ValueCallback<Uri[]> callback, final String[] acceptTypes, final boolean allowMultiple, final boolean isCaptureEnabled) {

--- a/docs/Guide.italian.md
+++ b/docs/Guide.italian.md
@@ -179,18 +179,7 @@ Registra video:
 
 ##### Android
 
-Aggiungi i permessi nel file AndroidManifest.xml:
-
-```xml
-<manifest ...>
-  ......
-
-  <!-- Questo è richiesto solo per Android 4.1-5.1 (API 16-22)  -->
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-  ......
-</manifest>
-```
+Il caricamento dei file non richiede permessi di archiviazione sulle versioni Android supportate.
 
 ###### L'opzione della fotocamera per l'upload è disponibile su Android.
 
@@ -200,7 +189,7 @@ Normalmente, le app che non hanno il permesso di accesso alla fotocamera possono
 
 ##### Verifica la compatibilità del caricamento dei file utilizzando il metodo `static isFileUploadSupported()`.
 
-Il caricamento dei file tramite l'elemento `<input type="file" />` non è supportato su Android 4.4 KitKat (vedi [dettagli](https://github.com/delight-im/Android-AdvancedWebView/issues/4#issuecomment-70372146)):
+Il caricamento dei file tramite l'elemento `<input type="file" />` è supportato su Android:
 
 ```jsx
 import { WebView } from 'react-native-webview';
@@ -367,7 +356,7 @@ Impostando `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, l'ini
 
 > Su iOS, ~~`injectedJavaScriptBeforeContentLoaded` esegue un metodo su WebView chiamato `evaluateJavaScript:completionHandler:`~~ - questo non è più vero a partire dalla versione `8.2.0`. Invece, utilizziamo un `WKUserScript` con il tempo di iniezione `WKUserScriptInjectionTimeAtDocumentStart`. Di conseguenza, `injectedJavaScriptBeforeContentLoaded` non restituisce più un valore di valutazione né registra un avviso nella console. Nel caso improbabile che la tua app dipenda da questo comportamento, consulta i passaggi di migrazione [qui](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-574919464) per mantenere un comportamento equivalente.
 > Su Android, `injectedJavaScript` esegue un metodo sul WebView di Android chiamato `evaluateJavascriptWithFallback`.
-> Nota sulla compatibilità di Android: per le applicazioni che mirano a `Build.VERSION_CODES.N` o versioni successive, lo state JavaScript da una WebView vuota non viene più mantenuto tra le navigazioni come `loadUrl(java.lang.String)`. Ad esempio, le variabili globali e le funzioni definite prima di chiamare `loadUrl(java.lang.String)` non esisteranno nella pagina caricata. Le applicazioni devono utilizzare l'API nativa di Android `addJavascriptInterface(Object, String)` per mantenere gli oggetti JavaScript tra le navigazioni.
+> Nota sulla compatibilità di Android: lo state JavaScript da una WebView vuota non viene mantenuto tra le navigazioni come `loadUrl(java.lang.String)`. Ad esempio, le variabili globali e le funzioni definite prima di chiamare `loadUrl(java.lang.String)` non esisteranno nella pagina caricata. Le applicazioni devono utilizzare l'API nativa di Android `addJavascriptInterface(Object, String)` per mantenere gli oggetti JavaScript tra le navigazioni.
 
 #### Il metodo `injectJavaScript`
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -179,18 +179,7 @@ Video recording:
 
 ##### Android
 
-Add permission in AndroidManifest.xml:
-
-```xml
-<manifest ...>
-  ......
-
-  <!-- this is required only for Android 4.1-5.1 (api 16-22)  -->
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-  ......
-</manifest>
-```
+File uploads do not require storage permissions on supported Android versions.
 
 ###### Camera option availability in uploading for Android
 
@@ -210,7 +199,7 @@ Normally, apps that do not have permission to use the camera can prompt the user
 
 ##### Check for File Upload support, with `static isFileUploadSupported()`
 
-File Upload using `<input type="file" />` is not supported for Android 4.4 KitKat (see [details](https://github.com/delight-im/Android-AdvancedWebView/issues/4#issuecomment-70372146)):
+File Upload using `<input type="file" />` is supported on Android:
 
 ```jsx
 import { WebView } from 'react-native-webview';
@@ -379,7 +368,7 @@ By setting `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, the J
 
 > On iOS, ~~`injectedJavaScriptBeforeContentLoaded` runs a method on WebView called `evaluateJavaScript:completionHandler:`~~ – this is no longer true as of version `8.2.0`. Instead, we use a `WKUserScript` with injection time `WKUserScriptInjectionTimeAtDocumentStart`. As a consequence, `injectedJavaScriptBeforeContentLoaded` no longer returns an evaluation value nor logs a warning to the console. In the unlikely event that your app depended upon this behaviour, please see migration steps [here](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-574919464) to retain equivalent behaviour.
 > On Android, `injectedJavaScript` runs a method on the Android WebView called `evaluateJavascriptWithFallback`
-> Note on Android Compatibility: For applications targeting `Build.VERSION_CODES.N` or later, JavaScript state from an empty WebView is no longer persisted across navigations like `loadUrl(java.lang.String)`. For example, global variables and functions defined before calling `loadUrl(java.lang.String)` will not exist in the loaded page. Applications should use the Android Native API `addJavascriptInterface(Object, String)` instead to persist JavaScript objects across navigations.
+> Note on Android Compatibility: JavaScript state from an empty WebView is not persisted across navigations like `loadUrl(java.lang.String)`. For example, global variables and functions defined before calling `loadUrl(java.lang.String)` will not exist in the loaded page. Applications should use the Android Native API `addJavascriptInterface(Object, String)` instead to persist JavaScript objects across navigations.
 
 #### The `injectedJavaScriptObject` prop
 

--- a/docs/Guide.portuguese.md
+++ b/docs/Guide.portuguese.md
@@ -178,18 +178,7 @@ Gravação de vídeo:
 
 ##### Android
 
-Adicione permissão no AndroidManifest.xml:
-
-```xml
-<manifest ...>
-  ......
-
- <!-- isso é necessário apenas para Android 4.1-5.1 (api 16-22) -->
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-  ......
-</manifest>
-```
+O upload de arquivos não requer permissões de armazenamento nas versões Android compatíveis.
 
 ###### Disponibilidade da opção de câmera no upload para Android
 
@@ -199,7 +188,7 @@ Normalmente, os aplicativos que não têm permissão para usar a câmera podem s
 
 ##### Verifique se há suporte para upload de arquivos, com `static isFileUploadSupported()`
 
-O upload de arquivo usando `<input type="file" />` não é compatível com o Android 4.4 KitKat (consulte os [detalhes](https://github.com/delight-im/Android-AdvancedWebView/issues/4#issuecomment-70372146)):
+O upload de arquivo usando `<input type="file" />` é compatível com Android:
 
 ```javascript
 import { WebView } from 'react-native-webview';
@@ -355,7 +344,7 @@ Ao definir `injectedJavaScriptBeforeContentLoadedForMainFrameOnly: false`, a inj
 
 > No iOS, ~~`injectedJavaScriptBeforeContentLoaded` executa um método no WebView chamado `evaluateJavaScript:completionHandler:`~~ – isso não é mais verdade a partir da versão `8.2.0`. Em vez disso, usamos um `WKUserScript` com tempo de injeção `WKUserScriptInjectionTimeAtDocumentStart`. Como consequência, `injectedJavaScriptBeforeContentLoaded` não retorna mais um valor de avaliação nem registra um aviso no console. No caso improvável de seu aplicativo depender desse comportamento, consulte as etapas de migração [aqui](https://github.com/react-native-webview/react-native-webview/pull/1119#issuecomment-574919464) para manter comportamento equivalente.
 > No Android, `injectedJavaScript` executa um método no Android WebView chamado `evaluateJavascriptWithFallback`
-> Observação sobre compatibilidade com Android: para aplicativos direcionados a `Build.VERSION_CODES.N` ou posterior, o estado JavaScript de um WebView vazio não é mais mantido em navegações como `loadUrl(java.lang.String)`. Por exemplo, variáveis ​​globais e funções definidas antes de chamar `loadUrl(java.lang.String)` não existirão na página carregada. Os aplicativos devem usar a API nativa do Android `addJavascriptInterface(Object, String)` para persistir objetos JavaScript nas navegações.
+> Observação sobre compatibilidade com Android: o estado JavaScript de um WebView vazio não é mantido em navegações como `loadUrl(java.lang.String)`. Por exemplo, variáveis ​​globais e funções definidas antes de chamar `loadUrl(java.lang.String)` não existirão na página carregada. Os aplicativos devem usar a API nativa do Android `addJavascriptInterface(Object, String)` para persistir objetos JavaScript nas navegações.
 
 #### O método `injectJavaScript`
 

--- a/docs/Reference.italian.md
+++ b/docs/Reference.italian.md
@@ -455,9 +455,6 @@ url
 
 Funzione che viene invocata quando la `WebView` riceve un errore HTTP.
 
-> **_Nota_**
-> Versione minima dell'API Android 23.
-
 | Tipo     | Obbligatorio |
 | -------- | ------------ |
 | function | No           |
@@ -876,7 +873,7 @@ I possibili valori per `mixedContentMode` sono:
 
 ### `thirdPartyCookiesEnabled`[⬆](#props-index)
 
-Boolean che abilita i cookie di terze parti nella WebView. Utilizzato solo su Android Lollipop e versioni successive, poiché i cookie di terze parti sono abilitati per impostazione predefinita su Android Kitkat e versioni precedenti e su iOS. Il valore predefinito è `true`. Per ulteriori informazioni sui cookie, leggi la [guida per come gestire i cookie](Guide.italian.md#gestione-dei-cookie).
+Boolean che abilita i cookie di terze parti nella WebView. Il valore predefinito è `true`. Per ulteriori informazioni sui cookie, leggi la [guida per come gestire i cookie](Guide.italian.md#gestione-dei-cookie).
 
 | Tipo | Obbligatorio | Piattaforma |
 | ---- | ------------ | ----------- |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -502,9 +502,6 @@ url
 
 Function that is invoked when the `WebView` receives an http error.
 
-> **_Note_**
-> Android API minimum level 23.
-
 | Type     | Required |
 | -------- | -------- |
 | function | No       |
@@ -957,7 +954,7 @@ Possible values for `mixedContentMode` are:
 
 ### `thirdPartyCookiesEnabled`[⬆](#props-index)
 
-Boolean value to enable third party cookies in the `WebView`. Used on Android Lollipop and above only as third party cookies are enabled by default on Android Kitkat and below and on iOS. The default value is `true`. For more on cookies, read the [Guide](Guide.md#Managing-Cookies)
+Boolean value to enable third party cookies in the `WebView`. The default value is `true`. For more on cookies, read the [Guide](Guide.md#Managing-Cookies)
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -449,9 +449,6 @@ url
 
 Função que é invocada quando a `WebView` recebe um erro http.
 
-> **_Observação_**
-> API Android nível mínimo 23.
-
 | Tipo     | Requerido |
 | -------- | --------- |
 | function | Não       |
@@ -868,7 +865,7 @@ Os valores possíveis para `mixedContentMode` são:
 
 ### `thirdPartyCookiesEnabled`[⬆](#props-index)<!-- Link gerado com jump2header -->
 
-Valor booleano para habilitar cookies de terceiros na `WebView`. Usado no Android Lollipop e acima apenas porque os cookies de terceiros são ativados por padrão no Android Kitkat e abaixo e no iOS. O valor padrão é `true`. Para saber mais sobre cookies, leia o [Guia](Guide.portuguese.md#Managing-Cookies)
+Valor booleano para habilitar cookies de terceiros na `WebView`. O valor padrão é `true`. Para saber mais sobre cookies, leia o [Guia](Guide.portuguese.md#Managing-Cookies)
 
 | Tipo | Requerido | Plataforma |
 | ---- | --------- | ---------- |

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -13,3 +13,14 @@ buildscript {
         }
     }
 }
+
+subprojects {
+    def useNougatMinSdk = {
+        if (project.ext.has("minSdkVersion")) {
+            project.ext.minSdkVersion = Math.max(project.ext.minSdkVersion as int, 24)
+        }
+    }
+
+    plugins.withId("com.android.application", useNougatMinSdk)
+    plugins.withId("com.android.library", useNougatMinSdk)
+}

--- a/src/NativeRNCWebViewModule.ts
+++ b/src/NativeRNCWebViewModule.ts
@@ -3,7 +3,6 @@ import { TurboModuleRegistry } from 'react-native';
 import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
-  isFileUploadSupported(): Promise<boolean>;
   shouldStartLoadWithLockIdentifier(shouldStart: boolean, lockIdentifier: Double): void;
 }
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -305,8 +305,7 @@ const WebViewComponent = forwardRef<unknown, AndroidWebViewProps>(
   },
 );
 
-// native implementation should return "true" only for Android 5+
-const isFileUploadSupported = async () => RNCWebViewModule.isFileUploadSupported();
+const isFileUploadSupported = async () => true;
 
 const WebView = Object.assign(WebViewComponent, { isFileUploadSupported });
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1052,9 +1052,8 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   androidLayerType?: AndroidLayerType;
 
   /**
-   * Boolean value to enable third party cookies in the `WebView`. Used on
-   * Android Lollipop and above only as third party cookies are enabled by
-   * default on Android Kitkat and below and on iOS. The default value is `true`.
+   * Boolean value to enable third party cookies in the `WebView`.
+   * The default value is `true`.
    * @platform android
    */
   thirdPartyCookiesEnabled?: boolean;
@@ -1237,7 +1236,7 @@ export interface WebViewSharedProps extends ViewProps {
 
   /**
    * Function that is invoked when the `WebView` receives an error status code.
-   * Works on iOS and Android (minimum API level 23).
+   * Works on iOS and Android.
    */
   onHttpError?: (event: WebViewHttpErrorEvent) => void;
 


### PR DESCRIPTION
## Summary

- Raise the Android minimum SDK to API 24 and clamp consuming Gradle config to Android N or newer.
- Remove legacy Android compatibility branches for file upload, cookies, storage, and HTTP error docs.
- Remove the Android native `isFileUploadSupported` bridge implementation while keeping the public JS API returning `true` on Android.

## Breaking change

BREAKING CHANGE: Android now requires API 24 (Android 7.0 Nougat) or newer. Legacy native file upload paths and compatibility code for older Android versions have been removed.

## Validation

- `git diff --check`
- `./gradlew --no-daemon clean build check test`
- `./gradlew -PnewArchEnabled=true --no-daemon :react-native-webview:generateCodegenArtifactsFromSchema build check test`

Note: the new-arch `clean` variant hit a stale generated native clean artifact for `android/build/generated/source/codegen/jni/CMakeLists.txt`; regenerating codegen and running build/check/test passed.