### PR TITLE
chore: modernize examples with hooks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,7 +25,7 @@
     "import/unambiguous": "off",
     "import/no-relative-parent-imports": "off"
   },
-  "ignorePatterns": ["node_modules", "lib", "android", "ios", "macos", "windows", "example"],
+  "ignorePatterns": ["node_modules", "lib", "android", "ios", "macos", "windows"],
   "categories": {
     "correctness": "error",
     "perf": "error",

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import {
   StyleSheet,
   SafeAreaView,
@@ -167,154 +167,6 @@ const TESTS = {
   },
 };
 
-interface State {
-  restarting: boolean;
-  currentTest: (typeof TESTS)[keyof typeof TESTS];
-}
-
-export default class App extends Component<unknown, State> {
-  state = {
-    restarting: false,
-    currentTest: TESTS.Alerts,
-  };
-
-  _simulateRestart = () => {
-    this.setState({ restarting: true }, () => this.setState({ restarting: false }));
-  };
-
-  _changeTest = (testName: keyof typeof TESTS) => {
-    this.setState({ currentTest: TESTS[testName] });
-  };
-
-  render() {
-    const { restarting, currentTest } = this.state;
-    return (
-      <SafeAreaView style={styles.container}>
-        <TouchableOpacity
-          style={styles.closeKeyboardView}
-          onPress={() => Keyboard.dismiss()}
-          testID="closeKeyboard"
-        />
-
-        <TouchableOpacity
-          testID="restart_button"
-          onPress={this._simulateRestart}
-          style={styles.restartButton}
-          activeOpacity={0.6}
-        >
-          <Text>Simulate Restart</Text>
-        </TouchableOpacity>
-
-        <View style={styles.testPickerContainer}>
-          <Button
-            testID="testType_alerts"
-            title="Alerts"
-            onPress={() => this._changeTest('Alerts')}
-          />
-          <Button
-            testID="testType_scrolling"
-            title="Scrolling"
-            onPress={() => this._changeTest('Scrolling')}
-          />
-          <Button
-            testID="testType_background"
-            title="Background"
-            onPress={() => this._changeTest('Background')}
-          />
-          <Button
-            testID="testType_injection"
-            title="Injection"
-            onPress={() => this._changeTest('Injection')}
-          />
-          <Button
-            testID="testType_pageLoad"
-            title="LocalPageLoad"
-            onPress={() => this._changeTest('PageLoad')}
-          />
-          <Button
-            testID="testType_downloads"
-            title="Downloads"
-            onPress={() => this._changeTest('Downloads')}
-          />
-          {(Platform.OS === 'android' || Platform.OS === 'macos') && (
-            <Button
-              testID="testType_uploads"
-              title="Uploads"
-              onPress={() => this._changeTest('Uploads')}
-            />
-          )}
-          <Button
-            testID="testType_messaging"
-            title="Messaging"
-            onPress={() => this._changeTest('Messaging')}
-          />
-          <Button
-            testID="testType_multimessaging"
-            title="MultiMessaging"
-            onPress={() => this._changeTest('MultiMessaging')}
-          />
-          <Button
-            testID="testType_nativeWebpage"
-            title="NativeWebpage"
-            onPress={() => this._changeTest('NativeWebpage')}
-          />
-          {Platform.OS === 'ios' && (
-            <Button
-              testID="testType_applePay"
-              title="ApplePay"
-              onPress={() => this._changeTest('ApplePay')}
-            />
-          )}
-          {Platform.OS === 'android' && (
-            <Button
-              testID="testType_googlePay"
-              title="GooglePay"
-              onPress={() => this._changeTest('GooglePay')}
-            />
-          )}
-          <Button
-            testID="testType_customMenu"
-            title="CustomMenu"
-            onPress={() => this._changeTest('CustomMenu')}
-          />
-          <Button
-            testID="testType_openwindow"
-            title="OpenWindow"
-            onPress={() => this._changeTest('OpenWindow')}
-          />
-          <Button
-            testID="testType_suppressMenuItems"
-            title="SuppressMenuItems"
-            onPress={() => this._changeTest('SuppressMenuItems')}
-          />
-          <Button
-            testID="testType_clearData"
-            title="ClearData"
-            onPress={() => this._changeTest('ClearData')}
-          />
-          <Button
-            testID="testType_sslError"
-            title="SslError"
-            onPress={() => this._changeTest('SslError')}
-          />
-        </View>
-
-        {restarting ? null : (
-          <View
-            testID={`example-${currentTest.testId}`}
-            key={currentTest.title}
-            style={styles.exampleContainer}
-          >
-            <Text style={styles.exampleTitle}>{currentTest.title}</Text>
-            <Text style={styles.exampleDescription}>{currentTest.description}</Text>
-            <View style={styles.exampleInnerContainer}>{currentTest.render()}</View>
-          </View>
-        )}
-      </SafeAreaView>
-    );
-  }
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -360,3 +212,142 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
   },
 });
+
+export default function App() {
+  const [restarting, setRestarting] = useState(false);
+  const [currentTest, setCurrentTest] = useState(TESTS.Alerts);
+
+  const simulateRestart = () => {
+    setRestarting(true);
+    requestAnimationFrame(() => setRestarting(false));
+  };
+
+  const changeTest = (testName: keyof typeof TESTS) => {
+    setCurrentTest(TESTS[testName]);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <TouchableOpacity
+        style={styles.closeKeyboardView}
+        onPress={() => Keyboard.dismiss()}
+        testID="closeKeyboard"
+      />
+
+      <TouchableOpacity
+        testID="restart_button"
+        onPress={simulateRestart}
+        style={styles.restartButton}
+        activeOpacity={0.6}
+      >
+        <Text>Simulate Restart</Text>
+      </TouchableOpacity>
+
+      <View style={styles.testPickerContainer}>
+        <Button
+          testID="testType_alerts"
+          title="Alerts"
+          onPress={() => changeTest('Alerts')}
+        />
+        <Button
+          testID="testType_scrolling"
+          title="Scrolling"
+          onPress={() => changeTest('Scrolling')}
+        />
+        <Button
+          testID="testType_background"
+          title="Background"
+          onPress={() => changeTest('Background')}
+        />
+        <Button
+          testID="testType_injection"
+          title="Injection"
+          onPress={() => changeTest('Injection')}
+        />
+        <Button
+          testID="testType_pageLoad"
+          title="LocalPageLoad"
+          onPress={() => changeTest('PageLoad')}
+        />
+        <Button
+          testID="testType_downloads"
+          title="Downloads"
+          onPress={() => changeTest('Downloads')}
+        />
+        {(Platform.OS === 'android' || Platform.OS === 'macos') && (
+          <Button
+            testID="testType_uploads"
+            title="Uploads"
+            onPress={() => changeTest('Uploads')}
+          />
+        )}
+        <Button
+          testID="testType_messaging"
+          title="Messaging"
+          onPress={() => changeTest('Messaging')}
+        />
+        <Button
+          testID="testType_multimessaging"
+          title="MultiMessaging"
+          onPress={() => changeTest('MultiMessaging')}
+        />
+        <Button
+          testID="testType_nativeWebpage"
+          title="NativeWebpage"
+          onPress={() => changeTest('NativeWebpage')}
+        />
+        {Platform.OS === 'ios' && (
+          <Button
+            testID="testType_applePay"
+            title="ApplePay"
+            onPress={() => changeTest('ApplePay')}
+          />
+        )}
+        {Platform.OS === 'android' && (
+          <Button
+            testID="testType_googlePay"
+            title="GooglePay"
+            onPress={() => changeTest('GooglePay')}
+          />
+        )}
+        <Button
+          testID="testType_customMenu"
+          title="CustomMenu"
+          onPress={() => changeTest('CustomMenu')}
+        />
+        <Button
+          testID="testType_openwindow"
+          title="OpenWindow"
+          onPress={() => changeTest('OpenWindow')}
+        />
+        <Button
+          testID="testType_suppressMenuItems"
+          title="SuppressMenuItems"
+          onPress={() => changeTest('SuppressMenuItems')}
+        />
+        <Button
+          testID="testType_clearData"
+          title="ClearData"
+          onPress={() => changeTest('ClearData')}
+        />
+        <Button
+          testID="testType_sslError"
+          title="SslError"
+          onPress={() => changeTest('SslError')}
+        />
+      </View>
+
+      {restarting ? null : (
+        <View
+          testID={`example-${currentTest.testId}`}
+          key={currentTest.title}
+          style={styles.exampleContainer}
+        >
+          <Text style={styles.exampleTitle}>{currentTest.title}</Text>
+          <Text style={styles.exampleDescription}>{currentTest.description}</Text>
+          <View style={styles.exampleInnerContainer}>{currentTest.render()}</View>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}

--- a/example/examples/Alerts.tsx
+++ b/example/examples/Alerts.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { Text, View } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
@@ -53,20 +53,13 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {};
-
-export default class Alerts extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ height: 120 }}>
-        <WebView
-          source={{ html: HTML }}
-          automaticallyAdjustContentInsets={false}
-        />
-      </View>
-    );
-  }
+export default function Alerts() {
+  return (
+    <View style={{ height: 120 }}>
+      <WebView
+        source={{ html: HTML }}
+        automaticallyAdjustContentInsets={false}
+      />
+    </View>
+  );
 }

--- a/example/examples/Alerts.windows.tsx
+++ b/example/examples/Alerts.windows.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { Text, View } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
@@ -53,21 +53,14 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {};
-
-export default class Alerts extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ height: 120 }}>
-        <WebView
-          source={{ html: HTML }}
-          automaticallyAdjustContentInsets={false}
-          useWebView2
-        />
-      </View>
-    );
-  }
+export default function Alerts() {
+  return (
+    <View style={{ height: 120 }}>
+      <WebView
+        source={{ html: HTML }}
+        automaticallyAdjustContentInsets={false}
+        useWebView2
+      />
+    </View>
+  );
 }

--- a/example/examples/ApplePay.tsx
+++ b/example/examples/ApplePay.tsx
@@ -1,23 +1,16 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-type Props = {};
-type State = {};
-
-export default class Alerts extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ flex: 1 }}>
-        <WebView
-          enableApplePay={true}
-          source={{ uri: 'https://applepaydemo.apple.com/' }}
-          automaticallyAdjustContentInsets={false}
-        />
-      </View>
-    );
-  }
+export default function ApplePay() {
+  return (
+    <View style={{ flex: 1 }}>
+      <WebView
+        enableApplePay={true}
+        source={{ uri: 'https://applepaydemo.apple.com/' }}
+        automaticallyAdjustContentInsets={false}
+      />
+    </View>
+  );
 }

--- a/example/examples/Background.tsx
+++ b/example/examples/Background.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -25,30 +25,19 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {
-  backgroundColor: string;
-};
-
-export default class Background extends Component<Props, State> {
-  state = {
-    backgroundColor: '#FF00FF00',
-  };
-
-  render() {
-    return (
-      <View>
-        <View style={{ backgroundColor: 'red' }}>
-          <View style={{ height: 120 }}>
-            <WebView
-              source={{ html: HTML }}
-              automaticallyAdjustContentInsets={false}
-              style={{ backgroundColor: '#00000000' }}
-            />
-          </View>
+export default function Background() {
+  return (
+    <View>
+      <View style={{ backgroundColor: 'red' }}>
+        <View style={{ height: 120 }}>
+          <WebView
+            source={{ html: HTML }}
+            automaticallyAdjustContentInsets={false}
+            style={{ backgroundColor: '#00000000' }}
+          />
         </View>
-        <Text>WebView is transparent contained in a View with a red backgroundColor</Text>
       </View>
-    );
-  }
+      <Text>WebView is transparent contained in a View with a red backgroundColor</Text>
+    </View>
+  );
 }

--- a/example/examples/ClearData.tsx
+++ b/example/examples/ClearData.tsx
@@ -1,49 +1,39 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import { View, Button } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-type Props = {};
-type State = {};
+export default function ClearData() {
+  const webView = useRef<WebView | null>(null);
 
-export default class ClearData extends Component<Props, State> {
-  state = {};
-
-  constructor(props) {
-    super(props);
-    this.webView = React.createRef();
-  }
-
-  clearCacheAndReload = (includeDiskFiles: boolean) => {
-    this.webView.current.clearCache(includeDiskFiles);
-    this.webView.current.reload();
+  const clearCacheAndReload = (includeDiskFiles: boolean) => {
+    webView.current?.clearCache(includeDiskFiles);
+    webView.current?.reload();
   };
 
-  reload = () => {
-    this.webView.current.reload();
+  const reload = () => {
+    webView.current?.reload();
   };
 
-  render() {
-    return (
-      <View style={{ height: 1000 }}>
-        <Button
-          title="Clear cache (diskFiles)"
-          onPress={() => this.clearCacheAndReload(true)}
-        />
-        <Button
-          title="Clear cache (no diskFiles)"
-          onPress={() => this.clearCacheAndReload(false)}
-        />
-        <Button
-          title="Reload"
-          onPress={this.reload}
-        />
-        <WebView
-          ref={this.webView}
-          source={{ uri: 'https://www.theguardian.com/international' }}
-          incognito={false}
-        />
-      </View>
-    );
-  }
+  return (
+    <View style={{ height: 1000 }}>
+      <Button
+        title="Clear cache (diskFiles)"
+        onPress={() => clearCacheAndReload(true)}
+      />
+      <Button
+        title="Clear cache (no diskFiles)"
+        onPress={() => clearCacheAndReload(false)}
+      />
+      <Button
+        title="Reload"
+        onPress={reload}
+      />
+      <WebView
+        ref={webView}
+        source={{ uri: 'https://www.theguardian.com/international' }}
+        incognito={false}
+      />
+    </View>
+  );
 }

--- a/example/examples/CustomMenu.tsx
+++ b/example/examples/CustomMenu.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { Button, Linking, Text, View } from 'react-native';
+import React, { useRef, useState } from 'react';
+import { Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
@@ -51,13 +51,19 @@ const HTML = `
 </html>
 `;
 
-interface Props {}
-interface State {}
+type CustomMenuSelection = {
+  key?: string;
+  label?: string;
+  selectedText?: string;
+};
 
-// export default class CustomMenu extends Component<Props, State> {
-export default (CustomMenu = () => {
-  const [selectionInfo, setSelectionInfo] = React.useState(null);
-  const webviewRef = React.useRef();
+type CustomMenuSelectionEvent = {
+  nativeEvent: CustomMenuSelection;
+};
+
+export default function CustomMenu() {
+  const [selectionInfo, setSelectionInfo] = useState<CustomMenuSelection | null>(null);
+  const webviewRef = useRef<WebView | null>(null);
 
   return (
     <View>
@@ -70,7 +76,7 @@ export default (CustomMenu = () => {
             { label: 'Highlight', key: 'highlight' },
             { label: 'Strikethrough', key: 'strikethrough' },
           ]}
-          onCustomMenuSelection={(webViewEvent) => {
+          onCustomMenuSelection={(webViewEvent: CustomMenuSelectionEvent) => {
             const { label, key, selectedText } = webViewEvent.nativeEvent;
             setSelectionInfo(webViewEvent.nativeEvent);
             // clearing the selection by sending a message. This would need a script on the source page to listen to the message.
@@ -87,4 +93,4 @@ export default (CustomMenu = () => {
       )}
     </View>
   );
-});
+}

--- a/example/examples/Downloads.tsx
+++ b/example/examples/Downloads.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Alert, Platform, View } from 'react-native';
 
 import WebView, { FileDownload } from 'react-native-webview';
@@ -27,31 +27,22 @@ const HTML = `
 </html>
 `;
 
-interface Props {}
-interface State {}
-
-export default class Downloads extends Component<Props, State> {
-  state = {};
-
-  onFileDownload = ({ nativeEvent }: { nativeEvent: FileDownload }) => {
-    Alert.alert('File download detected', nativeEvent.downloadUrl);
-  };
-
-  render() {
-    const platformProps = Platform.select({
-      ios: {
-        onFileDownload: this.onFileDownload,
+export default function Downloads() {
+  const platformProps = Platform.select({
+    ios: {
+      onFileDownload: ({ nativeEvent }: { nativeEvent: FileDownload }) => {
+        Alert.alert('File download detected', nativeEvent.downloadUrl);
       },
-    });
+    },
+  });
 
-    return (
-      <View style={{ height: 120 }}>
-        <WebView
-          source={{ html: HTML }}
-          automaticallyAdjustContentInsets={false}
-          {...platformProps}
-        />
-      </View>
-    );
-  }
+  return (
+    <View style={{ height: 120 }}>
+      <WebView
+        source={{ html: HTML }}
+        automaticallyAdjustContentInsets={false}
+        {...platformProps}
+      />
+    </View>
+  );
 }

--- a/example/examples/GooglePay.tsx
+++ b/example/examples/GooglePay.tsx
@@ -1,22 +1,15 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-type Props = {};
-type State = {};
-
-export default class Alerts extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ flex: 1 }}>
-        <WebView
-          source={{ uri: 'https://rsolomakhin.github.io/pr/gp2-test' }}
-          paymentRequestEnabled={true}
-        />
-      </View>
-    );
-  }
+export default function GooglePay() {
+  return (
+    <View style={{ flex: 1 }}>
+      <WebView
+        source={{ uri: 'https://rsolomakhin.github.io/pr/gp2-test' }}
+        paymentRequestEnabled={true}
+      />
+    </View>
+  );
 }

--- a/example/examples/Injection.tsx
+++ b/example/examples/Injection.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Text, View, ScrollView } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -21,42 +21,32 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {
-  backgroundColor: string;
-};
-
-export default class Injection extends Component<Props, State> {
-  state = {
-    backgroundColor: '#FF00FF00',
-  };
-
-  render() {
-    return (
-      <ScrollView>
-        <View style={{}}>
-          <View style={{ height: 400 }}>
-            <WebView
-              /**
-               * This HTML is a copy of the hosted multi-frame JS injection test.
-               * I have found that Android doesn't support beforeContentLoaded for a hosted HTML webpage, yet does for a static source.
-               * The cause of this is unresolved.
-               */
-              // source={{ html: HTML }}
-              source={{
-                uri: 'https://birchlabs.co.uk/linguabrowse/infopages/obsol/rnw_iframe_test.html',
-              }}
-              automaticallyAdjustContentInsets={false}
-              style={{ backgroundColor: '#00000000' }}
-              /* Must be populated in order for `messagingEnabled` to be `true` to activate the
-               * JS injection user scripts, consistent with current behaviour. This is undesirable,
-               * so needs addressing in a follow-up PR. */
-              onMessage={() => {}}
-              injectedJavaScriptBeforeContentLoadedForMainFrameOnly={false}
-              injectedJavaScriptForMainFrameOnly={false}
-              injectedJavaScriptObject={{ hello: 'world' }}
-              /* We set this property in each frame */
-              injectedJavaScriptBeforeContentLoaded={`
+export default function Injection() {
+  return (
+    <ScrollView>
+      <View style={{}}>
+        <View style={{ height: 400 }}>
+          <WebView
+            /**
+             * This HTML is a copy of the hosted multi-frame JS injection test.
+             * I have found that Android doesn't support beforeContentLoaded for a hosted HTML webpage, yet does for a static source.
+             * The cause of this is unresolved.
+             */
+            // source={{ html: HTML }}
+            source={{
+              uri: 'https://birchlabs.co.uk/linguabrowse/infopages/obsol/rnw_iframe_test.html',
+            }}
+            automaticallyAdjustContentInsets={false}
+            style={{ backgroundColor: '#00000000' }}
+            /* Must be populated in order for `messagingEnabled` to be `true` to activate the
+             * JS injection user scripts, consistent with current behaviour. This is undesirable,
+             * so needs addressing in a follow-up PR. */
+            onMessage={(_event: unknown): void => {}}
+            injectedJavaScriptBeforeContentLoadedForMainFrameOnly={false}
+            injectedJavaScriptForMainFrameOnly={false}
+            injectedJavaScriptObject={{ hello: 'world' }}
+            /* We set this property in each frame */
+            injectedJavaScriptBeforeContentLoaded={`
               console.log("executing injectedJavaScriptBeforeContentLoaded... " + (new Date()).toString());
               if(typeof window.top.injectedIframesBeforeContentLoaded === "undefined"){
                 window.top.injectedIframesBeforeContentLoaded = [];
@@ -88,8 +78,8 @@ export default class Injection extends Component<Props, State> {
                 console.log("wasn't window.top. Still going...");
               }
               `}
-              /* We read the colourToUse property in each frame to recolour each frame */
-              injectedJavaScript={`
+            /* We read the colourToUse property in each frame to recolour each frame */
+            injectedJavaScript={`
               console.log("executing injectedJavaScript... " + (new Date()).toString());
               if(typeof window.top.injectedIframesAfterContentLoaded === "undefined"){
                 window.top.injectedIframesAfterContentLoaded = [];
@@ -149,62 +139,59 @@ export default class Injection extends Component<Props, State> {
                 window.top.document.getElementById('namedFramesAtAfterContentLoadedEle').textContent = "Names of iframes that called afterContentLoaded: " + JSON.stringify(window.top.injectedIframesAfterContentLoaded);
               }
               `}
-            />
-          </View>
+          />
         </View>
-        <Text>
-          This test presents three iframes: iframe_0 (yellow); iframe_1 (pink); and iframe_2
-          (transparent, because its 'X-Frame-Options' is set to 'SAMEORIGIN').
-        </Text>
-        <Text>
-          Before injection, the main frame's background is the browser's default value (transparent
-          or white) and each frame has its natural colour.
-        </Text>
-        {/*<Text>1a) At injection time "beforeContentLoaded", a variable will be set in each frame to set 'orange' as the "colour to be used".</Text>*/}
-        {/*<Text>1b) Also upon "beforeContentLoaded", a style element to change the text "beforeContentLoaded failed" -> "beforeContentLoaded succeeded" will be applied as soon as the head has loaded.</Text>*/}
-        {/*<Text>2a) At injection time "afterContentLoaded", that variable will be read – if present, the colour orange will be injected into all frames. Otherwise, cyan.</Text>*/}
-        {/*<Text>2b) Also upon "afterContentLoaded", a style element to change the text "afterContentLoaded failed" -> "afterContentLoaded succeeded" will be applied as soon as the head has loaded.</Text>*/}
-        <Text>
-          ✅ If the main frame becomes orange, then top-frame injection both beforeContentLoaded and
-          afterContentLoaded is supported.
-        </Text>
-        <Text>
-          ✅ If iframe_0, and iframe_1 become orange, then multi-frame injection beforeContentLoaded
-          and afterContentLoaded is supported.
-        </Text>
-        <Text>
-          ✅ If the two texts say "beforeContentLoaded on the top frame succeeded!" and
-          "afterContentLoaded on the top frame succeeded!", then both injection times are supported
-          at least on the main frame.
-        </Text>
-        <Text>
-          ❌ If either of the two iframes become coloured cyan, then for that given frame, JS
-          injection succeeded after the content loaded, but didn't occur before the content loaded.
-        </Text>
-        <Text>
-          ❌ If "Names of iframes that called beforeContentLoaded: " is [], then see above.
-        </Text>
-        <Text>
-          ❌ If "Names of iframes that called afterContentLoaded: " is [], then afterContentLoaded
-          is not supported in iframes.
-        </Text>
-        <Text>
-          ❌ If the main frame becomes coloured cyan, then JS injection succeeded after the content
-          loaded, but didn't occur before the content loaded.
-        </Text>
-        <Text>
-          ❌ If the text "beforeContentLoaded on the top frame failed" remains unchanged, then JS
-          injection has failed on the main frame before the content loaded.
-        </Text>
-        <Text>
-          ❌ If the text "afterContentLoaded on the top frame failed" remains unchanged, then JS
-          injection has failed on the main frame after the content loaded.
-        </Text>
-        <Text>
-          ❌ If the iframes remain their original colours (yellow and pink), then multi-frame
-          injection is not supported at all.
-        </Text>
-      </ScrollView>
-    );
-  }
+      </View>
+      <Text>
+        This test presents three iframes: iframe_0 (yellow); iframe_1 (pink); and iframe_2
+        (transparent, because its 'X-Frame-Options' is set to 'SAMEORIGIN').
+      </Text>
+      <Text>
+        Before injection, the main frame's background is the browser's default value (transparent or
+        white) and each frame has its natural colour.
+      </Text>
+      {/*<Text>1a) At injection time "beforeContentLoaded", a variable will be set in each frame to set 'orange' as the "colour to be used".</Text>*/}
+      {/*<Text>1b) Also upon "beforeContentLoaded", a style element to change the text "beforeContentLoaded failed" -> "beforeContentLoaded succeeded" will be applied as soon as the head has loaded.</Text>*/}
+      {/*<Text>2a) At injection time "afterContentLoaded", that variable will be read – if present, the colour orange will be injected into all frames. Otherwise, cyan.</Text>*/}
+      {/*<Text>2b) Also upon "afterContentLoaded", a style element to change the text "afterContentLoaded failed" -> "afterContentLoaded succeeded" will be applied as soon as the head has loaded.</Text>*/}
+      <Text>
+        ✅ If the main frame becomes orange, then top-frame injection both beforeContentLoaded and
+        afterContentLoaded is supported.
+      </Text>
+      <Text>
+        ✅ If iframe_0, and iframe_1 become orange, then multi-frame injection beforeContentLoaded
+        and afterContentLoaded is supported.
+      </Text>
+      <Text>
+        ✅ If the two texts say "beforeContentLoaded on the top frame succeeded!" and
+        "afterContentLoaded on the top frame succeeded!", then both injection times are supported at
+        least on the main frame.
+      </Text>
+      <Text>
+        ❌ If either of the two iframes become coloured cyan, then for that given frame, JS
+        injection succeeded after the content loaded, but didn't occur before the content loaded.
+      </Text>
+      <Text>❌ If "Names of iframes that called beforeContentLoaded: " is [], then see above.</Text>
+      <Text>
+        ❌ If "Names of iframes that called afterContentLoaded: " is [], then afterContentLoaded is
+        not supported in iframes.
+      </Text>
+      <Text>
+        ❌ If the main frame becomes coloured cyan, then JS injection succeeded after the content
+        loaded, but didn't occur before the content loaded.
+      </Text>
+      <Text>
+        ❌ If the text "beforeContentLoaded on the top frame failed" remains unchanged, then JS
+        injection has failed on the main frame before the content loaded.
+      </Text>
+      <Text>
+        ❌ If the text "afterContentLoaded on the top frame failed" remains unchanged, then JS
+        injection has failed on the main frame after the content loaded.
+      </Text>
+      <Text>
+        ❌ If the iframes remain their original colours (yellow and pink), then multi-frame
+        injection is not supported at all.
+      </Text>
+    </ScrollView>
+  );
 }

--- a/example/examples/LocalPageLoad.tsx
+++ b/example/examples/LocalPageLoad.tsx
@@ -1,16 +1,15 @@
-import React, { Component } from 'react';
-import { View, Text, Alert, TextInput, Button } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 import WebView from 'react-native-webview';
+
 const localHtmlFile = require('../assets/test.html');
 
-export default class LocalPageLoad extends Component<Props, State> {
-  render() {
-    return (
-      <View>
-        <View style={{ width: '100%', height: '100%' }}>
-          <WebView source={localHtmlFile} />
-        </View>
+export default function LocalPageLoad() {
+  return (
+    <View>
+      <View style={{ width: '100%', height: '100%' }}>
+        <WebView source={localHtmlFile} />
       </View>
-    );
-  }
+    </View>
+  );
 }

--- a/example/examples/Messaging.tsx
+++ b/example/examples/Messaging.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import { View, Alert, TextInput } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -41,37 +41,27 @@ const HTML = `<!DOCTYPE html>\n
   </body>
 </html>`;
 
-type Props = {};
-type State = {};
+export default function Messaging() {
+  const webView = useRef<WebView | null>(null);
 
-export default class Messaging extends Component<Props, State> {
-  state = {};
-
-  constructor(props) {
-    super(props);
-    this.webView = React.createRef();
-  }
-
-  render() {
-    return (
-      <View style={{ height: 120 }}>
-        <TextInput
-          onSubmitEditing={(e) => {
-            this.webView.current.postMessage(e.nativeEvent.text);
-          }}
-        />
-        <WebView
-          ref={this.webView}
-          source={{ html: HTML }}
-          onLoadEnd={() => {
-            this.webView.current.postMessage('Hello from RN');
-          }}
-          automaticallyAdjustContentInsets={false}
-          onMessage={(e: { nativeEvent: { data?: string } }) => {
-            Alert.alert('Message received from JS: ', e.nativeEvent.data);
-          }}
-        />
-      </View>
-    );
-  }
+  return (
+    <View style={{ height: 120 }}>
+      <TextInput
+        onSubmitEditing={(e) => {
+          webView.current?.postMessage(e.nativeEvent.text);
+        }}
+      />
+      <WebView
+        ref={webView}
+        source={{ html: HTML }}
+        onLoadEnd={() => {
+          webView.current?.postMessage('Hello from RN');
+        }}
+        automaticallyAdjustContentInsets={false}
+        onMessage={(e: { nativeEvent: { data?: string } }) => {
+          Alert.alert('Message received from JS: ', e.nativeEvent.data);
+        }}
+      />
+    </View>
+  );
 }

--- a/example/examples/Messaging.windows.tsx
+++ b/example/examples/Messaging.windows.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import { View, Alert, TextInput } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -41,38 +41,28 @@ const HTML = `<!DOCTYPE html>\n
   </body>
 </html>`;
 
-type Props = {};
-type State = {};
+export default function Messaging() {
+  const webView = useRef<WebView | null>(null);
 
-export default class Messaging extends Component<Props, State> {
-  state = {};
-
-  constructor(props) {
-    super(props);
-    this.webView = React.createRef();
-  }
-
-  render() {
-    return (
-      <View style={{ height: 120 }}>
-        <TextInput
-          onSubmitEditing={(e) => {
-            this.webView.current.postMessage(e.nativeEvent.text);
-          }}
-        />
-        <WebView
-          ref={this.webView}
-          source={{ html: HTML }}
-          onLoadEnd={() => {
-            this.webView.current.postMessage('Hello from RN');
-          }}
-          automaticallyAdjustContentInsets={false}
-          onMessage={(e: { nativeEvent: { data?: string } }) => {
-            Alert.alert('Message received from JS: ', e.nativeEvent.data);
-          }}
-          useWebView2
-        />
-      </View>
-    );
-  }
+  return (
+    <View style={{ height: 120 }}>
+      <TextInput
+        onSubmitEditing={(e) => {
+          webView.current?.postMessage(e.nativeEvent.text);
+        }}
+      />
+      <WebView
+        ref={webView}
+        source={{ html: HTML }}
+        onLoadEnd={() => {
+          webView.current?.postMessage('Hello from RN');
+        }}
+        automaticallyAdjustContentInsets={false}
+        onMessage={(e: { nativeEvent: { data?: string } }) => {
+          Alert.alert('Message received from JS: ', e.nativeEvent.data);
+        }}
+        useWebView2
+      />
+    </View>
+  );
 }

--- a/example/examples/MultiMessaging.tsx
+++ b/example/examples/MultiMessaging.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React from 'react';
+import React, { useRef } from 'react';
 import { View, Alert, TextInput } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -43,8 +43,8 @@ const HTML = `<!DOCTYPE html>\n
 </html>`;
 
 export default function MultiMessaging() {
-  const webView = React.useRef<WebView | null>(null);
-  const webView2 = React.useRef<WebView | null>(null);
+  const webView = useRef<WebView | null>(null);
+  const webView2 = useRef<WebView | null>(null);
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>

--- a/example/examples/MultiMessaging.windows.tsx
+++ b/example/examples/MultiMessaging.windows.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React from 'react';
+import React, { useRef } from 'react';
 import { View, Alert, TextInput } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -43,8 +43,8 @@ const HTML = `<!DOCTYPE html>\n
 </html>`;
 
 export default function MultiMessaging() {
-  const webView = React.useRef<WebView | null>(null);
-  const webView2 = React.useRef<WebView | null>(null);
+  const webView = useRef<WebView | null>(null);
+  const webView2 = useRef<WebView | null>(null);
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>

--- a/example/examples/NativeWebpage.tsx
+++ b/example/examples/NativeWebpage.tsx
@@ -1,29 +1,26 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-interface Props {}
-interface State {}
+type LoadStartEvent = {
+  nativeEvent: unknown;
+};
 
-export default class NativeWebpage extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ height: 400 }}>
-        <WebView
-          source={{ uri: 'https://infinite.red' }}
-          style={{ width: '100%', height: '100%' }}
-          onShouldStartLoadWithRequest={(event) => {
-            console.log('onShouldStartLoadWithRequest', event);
-            return true;
-          }}
-          onLoadStart={(event) => {
-            console.log('onLoadStart', event.nativeEvent);
-          }}
-        />
-      </View>
-    );
-  }
+export default function NativeWebpage() {
+  return (
+    <View style={{ height: 400 }}>
+      <WebView
+        source={{ uri: 'https://infinite.red' }}
+        style={{ width: '100%', height: '100%' }}
+        onShouldStartLoadWithRequest={(event: unknown) => {
+          console.log('onShouldStartLoadWithRequest', event);
+          return true;
+        }}
+        onLoadStart={(event: LoadStartEvent) => {
+          console.log('onLoadStart', event.nativeEvent);
+        }}
+      />
+    </View>
+  );
 }

--- a/example/examples/OpenWindow.tsx
+++ b/example/examples/OpenWindow.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { Button, Switch, StyleSheet, Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -51,69 +51,9 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {
-  shouldInterceptOpenWindow: boolean;
-  text: string;
-  webViewKey: number;
-};
-
-export default class OpenWindow extends Component<Props, State> {
-  state = {
-    shouldInterceptOpenWindow: true,
-    text: 'No OpenWindow event intercepted yet',
-    webViewKey: 1,
-  };
-
-  interceptOpenWindow = (syntheticEvent) => {
-    const { nativeEvent } = syntheticEvent;
-    const { targetUrl } = nativeEvent;
-    this.setState({
-      text: `Intercepted OpenWindow event for ${targetUrl} at ${Date.now()}`,
-    });
-  };
-
-  toggleShouldInterceptOpenWindow = () => {
-    this.setState((prevState) => ({
-      shouldInterceptOpenWindow: !prevState.shouldInterceptOpenWindow,
-    }));
-  };
-
-  resetWebView = () => {
-    this.setState((prevState) => ({
-      webViewKey: prevState.webViewKey + 1,
-    }));
-  };
-
-  render() {
-    const onOpenWindow = this.state.shouldInterceptOpenWindow
-      ? this.interceptOpenWindow
-      : undefined;
-
-    return (
-      <View style={styles.container}>
-        <View style={styles.interceptSection}>
-          <Text style={styles.text}>Intercept OpenWindow event</Text>
-          <Switch
-            onValueChange={this.toggleShouldInterceptOpenWindow}
-            value={this.state.shouldInterceptOpenWindow}
-          />
-        </View>
-        <WebView
-          key={this.state.webViewKey}
-          source={{ html: HTML }}
-          automaticallyAdjustContentInsets={false}
-          onOpenWindow={onOpenWindow}
-        />
-        <Text style={styles.text}>{this.state.text}</Text>
-        <Button
-          title="Reset webview"
-          onPress={this.resetWebView}
-        />
-      </View>
-    );
-  }
-}
+type OpenWindowEvent = Parameters<
+  NonNullable<React.ComponentProps<typeof WebView>['onOpenWindow']>
+>[0];
 
 const styles = StyleSheet.create({
   container: {
@@ -129,3 +69,48 @@ const styles = StyleSheet.create({
     color: 'black',
   },
 });
+
+export default function OpenWindow() {
+  const [shouldInterceptOpenWindow, setShouldInterceptOpenWindow] = useState(true);
+  const [text, setText] = useState('No OpenWindow event intercepted yet');
+  const [webViewKey, setWebViewKey] = useState(1);
+
+  const interceptOpenWindow = (syntheticEvent: OpenWindowEvent) => {
+    const { nativeEvent } = syntheticEvent;
+    const { targetUrl } = nativeEvent;
+    setText(`Intercepted OpenWindow event for ${targetUrl} at ${Date.now()}`);
+  };
+
+  const toggleShouldInterceptOpenWindow = () => {
+    setShouldInterceptOpenWindow((value) => !value);
+  };
+
+  const resetWebView = () => {
+    setWebViewKey((value) => value + 1);
+  };
+
+  const onOpenWindow = shouldInterceptOpenWindow ? interceptOpenWindow : undefined;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.interceptSection}>
+        <Text style={styles.text}>Intercept OpenWindow event</Text>
+        <Switch
+          onValueChange={toggleShouldInterceptOpenWindow}
+          value={shouldInterceptOpenWindow}
+        />
+      </View>
+      <WebView
+        key={webViewKey}
+        source={{ html: HTML }}
+        automaticallyAdjustContentInsets={false}
+        onOpenWindow={onOpenWindow}
+      />
+      <Text style={styles.text}>{text}</Text>
+      <Button
+        title="Reset webview"
+        onPress={resetWebView}
+      />
+    </View>
+  );
+}

--- a/example/examples/OpenWindow.windows.tsx
+++ b/example/examples/OpenWindow.windows.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { Button, Switch, StyleSheet, Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -51,70 +51,9 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {
-  shouldInterceptOpenWindow: boolean;
-  text: string;
-  webViewKey: number;
-};
-
-export default class OpenWindow extends Component<Props, State> {
-  state = {
-    shouldInterceptOpenWindow: true,
-    text: 'No OpenWindow event intercepted yet',
-    webViewKey: 1,
-  };
-
-  interceptOpenWindow = (syntheticEvent) => {
-    const { nativeEvent } = syntheticEvent;
-    const { targetUrl } = nativeEvent;
-    this.setState({
-      text: `Intercepted OpenWindow event for ${targetUrl} at ${Date.now()}`,
-    });
-  };
-
-  toggleShouldInterceptOpenWindow = () => {
-    this.setState((prevState) => ({
-      shouldInterceptOpenWindow: !prevState.shouldInterceptOpenWindow,
-    }));
-  };
-
-  resetWebView = () => {
-    this.setState((prevState) => ({
-      webViewKey: prevState.webViewKey + 1,
-    }));
-  };
-
-  render() {
-    const onOpenWindow = this.state.shouldInterceptOpenWindow
-      ? this.interceptOpenWindow
-      : undefined;
-
-    return (
-      <View style={styles.container}>
-        <View style={styles.interceptSection}>
-          <Text style={styles.text}>Intercept OpenWindow event</Text>
-          <Switch
-            onValueChange={this.toggleShouldInterceptOpenWindow}
-            value={this.state.shouldInterceptOpenWindow}
-          />
-        </View>
-        <WebView
-          key={this.state.webViewKey}
-          source={{ html: HTML }}
-          automaticallyAdjustContentInsets={false}
-          useWebView2
-          onOpenWindow={onOpenWindow}
-        />
-        <Text style={styles.text}>{this.state.text}</Text>
-        <Button
-          title="Reset webview"
-          onPress={this.resetWebView}
-        />
-      </View>
-    );
-  }
-}
+type OpenWindowEvent = Parameters<
+  NonNullable<React.ComponentProps<typeof WebView>['onOpenWindow']>
+>[0];
 
 const styles = StyleSheet.create({
   container: {
@@ -130,3 +69,49 @@ const styles = StyleSheet.create({
     color: 'black',
   },
 });
+
+export default function OpenWindow() {
+  const [shouldInterceptOpenWindow, setShouldInterceptOpenWindow] = useState(true);
+  const [text, setText] = useState('No OpenWindow event intercepted yet');
+  const [webViewKey, setWebViewKey] = useState(1);
+
+  const interceptOpenWindow = (syntheticEvent: OpenWindowEvent) => {
+    const { nativeEvent } = syntheticEvent;
+    const { targetUrl } = nativeEvent;
+    setText(`Intercepted OpenWindow event for ${targetUrl} at ${Date.now()}`);
+  };
+
+  const toggleShouldInterceptOpenWindow = () => {
+    setShouldInterceptOpenWindow((value) => !value);
+  };
+
+  const resetWebView = () => {
+    setWebViewKey((value) => value + 1);
+  };
+
+  const onOpenWindow = shouldInterceptOpenWindow ? interceptOpenWindow : undefined;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.interceptSection}>
+        <Text style={styles.text}>Intercept OpenWindow event</Text>
+        <Switch
+          onValueChange={toggleShouldInterceptOpenWindow}
+          value={shouldInterceptOpenWindow}
+        />
+      </View>
+      <WebView
+        key={webViewKey}
+        source={{ html: HTML }}
+        automaticallyAdjustContentInsets={false}
+        useWebView2
+        onOpenWindow={onOpenWindow}
+      />
+      <Text style={styles.text}>{text}</Text>
+      <Button
+        title="Reset webview"
+        onPress={resetWebView}
+      />
+    </View>
+  );
+}

--- a/example/examples/Scrolling.tsx
+++ b/example/examples/Scrolling.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { Button, Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -29,40 +29,32 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {
-  scrollEnabled: boolean;
-  lastScrollEvent: string;
-};
+type ScrollEvent = Parameters<NonNullable<React.ComponentProps<typeof WebView>['onScroll']>>[0];
 
-export default class Scrolling extends Component<Props, State> {
-  state = {
-    scrollEnabled: true,
-    lastScrollEvent: '',
+export default function Scrolling() {
+  const [scrollEnabled, setScrollEnabled] = useState(true);
+  const [lastScrollEvent, setLastScrollEvent] = useState('');
+
+  const onScroll = (event: ScrollEvent) => {
+    setLastScrollEvent(JSON.stringify(event.nativeEvent));
   };
 
-  render() {
-    return (
-      <View>
-        <View style={{ height: 120 }}>
-          <WebView
-            source={{ html: HTML }}
-            automaticallyAdjustContentInsets={false}
-            onScroll={this._onScroll}
-            scrollEnabled={this.state.scrollEnabled}
-          />
-        </View>
-        <Button
-          title={this.state.scrollEnabled ? 'Scroll enabled' : 'Scroll disabled'}
-          onPress={() => this.setState({ scrollEnabled: !this.state.scrollEnabled })}
+  return (
+    <View>
+      <View style={{ height: 120 }}>
+        <WebView
+          source={{ html: HTML }}
+          automaticallyAdjustContentInsets={false}
+          onScroll={onScroll}
+          scrollEnabled={scrollEnabled}
         />
-        <Text>Last scroll event:</Text>
-        <Text>{this.state.lastScrollEvent}</Text>
       </View>
-    );
-  }
-
-  _onScroll = (event) => {
-    this.setState({ lastScrollEvent: JSON.stringify(event.nativeEvent) });
-  };
+      <Button
+        title={scrollEnabled ? 'Scroll enabled' : 'Scroll disabled'}
+        onPress={() => setScrollEnabled((value) => !value)}
+      />
+      <Text>Last scroll event:</Text>
+      <Text>{lastScrollEvent}</Text>
+    </View>
+  );
 }

--- a/example/examples/SslError.tsx
+++ b/example/examples/SslError.tsx
@@ -1,24 +1,23 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-type Props = {};
-type State = {};
+type LoadSubResourceErrorEvent = {
+  nativeEvent: {
+    description?: string;
+  };
+};
 
-export default class SslError extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ flex: 1 }}>
-        <WebView
-          source={{ uri: 'https://badssl.com/' }}
-          onLoadSubResourceError={(event) => {
-            console.log('onLoadSubResourceError', event.nativeEvent.description);
-          }}
-        />
-      </View>
-    );
-  }
+export default function SslError() {
+  return (
+    <View style={{ flex: 1 }}>
+      <WebView
+        source={{ uri: 'https://badssl.com/' }}
+        onLoadSubResourceError={(event: LoadSubResourceErrorEvent) => {
+          console.log('onLoadSubResourceError', event.nativeEvent.description);
+        }}
+      />
+    </View>
+  );
 }

--- a/example/examples/Suppress.tsx
+++ b/example/examples/Suppress.tsx
@@ -1,10 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import WebView from 'react-native-webview';
 
-interface Props {}
-interface State {}
+type LoadStartEvent = {
+  nativeEvent: unknown;
+};
 
 const HTML = `
 <!DOCTYPE html>
@@ -22,36 +23,32 @@ const HTML = `
 </html>
 `;
 
-export default class NativeWebpage extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View style={{ height: 400 }}>
-        <WebView
-          source={{ html: HTML }}
-          style={{ width: '100%', height: '100%' }}
-          onShouldStartLoadWithRequest={(event) => {
-            console.log('onShouldStartLoadWithRequest', event);
-            return true;
-          }}
-          onLoadStart={(event) => {
-            console.log('onLoadStart', event.nativeEvent);
-          }}
-          suppressMenuItems={[
-            'cut',
-            'copy',
-            'paste',
-            'replace',
-            'bold',
-            'italic',
-            'underline',
-            'select',
-            'share',
-            'lookup',
-          ]}
-        />
-      </View>
-    );
-  }
+export default function SuppressMenuItems() {
+  return (
+    <View style={{ height: 400 }}>
+      <WebView
+        source={{ html: HTML }}
+        style={{ width: '100%', height: '100%' }}
+        onShouldStartLoadWithRequest={(event: unknown) => {
+          console.log('onShouldStartLoadWithRequest', event);
+          return true;
+        }}
+        onLoadStart={(event: LoadStartEvent) => {
+          console.log('onLoadStart', event.nativeEvent);
+        }}
+        suppressMenuItems={[
+          'cut',
+          'copy',
+          'paste',
+          'replace',
+          'bold',
+          'italic',
+          'underline',
+          'select',
+          'share',
+          'lookup',
+        ]}
+      />
+    </View>
+  );
 }

--- a/example/examples/Uploads.tsx
+++ b/example/examples/Uploads.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Button, Linking, Text, View } from 'react-native';
 
 import WebView from 'react-native-webview';
@@ -36,34 +36,26 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {};
-
-export default class Uploads extends Component<Props, State> {
-  state = {};
-
-  render() {
-    return (
-      <View>
-        <View style={{ height: 120 }}>
-          <WebView
-            source={{ html: HTML }}
-            automaticallyAdjustContentInsets={false}
-          />
-        </View>
-        <Text>
-          Android limitation: If the file input should show camera options for the user, and the app
-          has the ability to request the camera permission, then the user must grant permission
-          first in order to see the options. Since this example app does have the permission
-          declared, you must allow it in settings to be able to see camera options. If your app does
-          not have the camera permission declared, then there is no restriction to showing the
-          camera options.
-        </Text>
-        <Button
-          title="Open settings"
-          onPress={() => Linking.openSettings()}
+export default function Uploads() {
+  return (
+    <View>
+      <View style={{ height: 120 }}>
+        <WebView
+          source={{ html: HTML }}
+          automaticallyAdjustContentInsets={false}
         />
       </View>
-    );
-  }
+      <Text>
+        Android limitation: If the file input should show camera options for the user, and the app
+        has the ability to request the camera permission, then the user must grant permission first
+        in order to see the options. Since this example app does have the permission declared, you
+        must allow it in settings to be able to see camera options. If your app does not have the
+        camera permission declared, then there is no restriction to showing the camera options.
+      </Text>
+      <Button
+        title="Open settings"
+        onPress={() => Linking.openSettings()}
+      />
+    </View>
+  );
 }

--- a/example/types/react-native-webview.d.ts
+++ b/example/types/react-native-webview.d.ts
@@ -1,0 +1,30 @@
+declare module 'react-native-webview' {
+  import { Component } from 'react';
+  import type {
+    AndroidWebViewProps,
+    FileDownload,
+    IOSWebViewProps,
+    WebViewMessageEvent,
+    WebViewNavigation,
+    WindowsWebViewProps,
+  } from '../../src/WebViewTypes';
+
+  export { FileDownload, WebViewMessageEvent, WebViewNavigation };
+
+  export type WebViewProps = IOSWebViewProps & AndroidWebViewProps & WindowsWebViewProps;
+
+  export class WebView<P = unknown> extends Component<WebViewProps & P> {
+    goBack: () => void;
+    goForward: () => void;
+    reload: () => void;
+    stopLoading: () => void;
+    injectJavaScript: (script: string) => void;
+    requestFocus: () => void;
+    postMessage: (message: string) => void;
+    clearFormData?: () => void;
+    clearCache: (includeDiskFiles: boolean) => void;
+    clearHistory?: () => void;
+  }
+
+  export default WebView;
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "react-native start",
     "windows": "install-windows-test-app --project-directory example/windows && react-native run-windows --root example --arch x64",
     "ci:publish": "bun run semantic-release",
-    "lint:tsgo": "bun run --bun tsgo --noEmit",
+    "lint:tsgo": "bun run --bun tsgo --noEmit && bun run --bun tsgo --noEmit --project tsconfig.example.json",
     "lint:oxlint": "bun run --bun oxlint",
     "lint:oxlint:ci": "bun run --bun oxlint --format=github",
     "lint:oxfmt": "bun run oxfmt",

--- a/tsconfig.example.json
+++ b/tsconfig.example.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["example/**/*.d.ts", "example/**/*.ts", "example/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary

- Convert the example app and WebView examples from class components to function components with hooks.
- Keep the examples compiler-ready without enabling React Compiler or adding memoization boilerplate.
- Include the example sources in linting by removing the oxlint ignore and adding an isolated example TypeScript config.

## Notes

The example typecheck uses an example-local `react-native-webview` module declaration so the package's root TypeScript config and public `index.d.ts` are not changed by this PR.

## Validation

- `bun run lint`
- `bun run lint:ci`
- Babel transpile of the example tree