### PR TITLE
[iOS] Fix build failure with EXPO_USE_PRECOMPILED_MODULES=1 (React_Core header namespace)

### DIFF
--- a/apple/RCTConvert+WKDataDetectorTypes.h
+++ b/apple/RCTConvert+WKDataDetectorTypes.h
@@ -1,6 +1,10 @@
 #import <WebKit/WebKit.h>
 
+#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
+#else
+#import <React_Core/RCTConvert.h>
+#endif
 
 #if TARGET_OS_IPHONE
 @interface RCTConvert (WKDataDetectorTypes)

--- a/apple/RCTConvert+WKDataDetectorTypes.m
+++ b/apple/RCTConvert+WKDataDetectorTypes.m
@@ -1,6 +1,10 @@
 #import <WebKit/WebKit.h>
 
+#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
+#else
+#import <React_Core/RCTConvert.h>
+#endif
 
 #if TARGET_OS_IPHONE
 

--- a/apple/RNCWebViewDecisionManager.h
+++ b/apple/RNCWebViewDecisionManager.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
+#else
+#import <React_Core/RCTLog.h>
+#endif
 #import <WebKit/WebKit.h>
 
 typedef void (^DecisionBlock)(BOOL);

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -5,8 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if __has_include(<React/RCTView.h>)
 #import <React/RCTView.h>
 #import <React/RCTDefines.h>
+#else
+#import <React_Core/RCTView.h>
+#import <React_Core/RCTDefines.h>
+#endif
 #import <WebKit/WKDataDetectorTypes.h>
 #import <WebKit/WebKit.h>
 

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -6,13 +6,22 @@
  */
 
 #import "RNCWebViewImpl.h"
+#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
 #import <React/RCTAutoInsetsProtocol.h>
+#else
+#import <React_Core/RCTConvert.h>
+#import <React_Core/RCTAutoInsetsProtocol.h>
+#endif
 #import "RNCWKProcessPoolManager.h"
 #if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
 #else
+#if __has_include(<React/RCTUIKit.h>)
 #import <React/RCTUIKit.h>
+#else
+#import <React_Core/RCTUIKit.h>
+#endif
 #endif // !TARGET_OS_OSX
 
 #import "objc/runtime.h"

--- a/apple/RNCWebViewManager.h
+++ b/apple/RNCWebViewManager.h
@@ -1,7 +1,11 @@
 #ifndef RNCWebViewManager_h
 #define RNCWebViewManager_h
 
+#if __has_include(<React/RCTViewManager.h>)
 #import <React/RCTViewManager.h>
+#else
+#import <React_Core/RCTViewManager.h>
+#endif
 
 @interface RNCWebViewManager : RCTViewManager
 @end

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -1,4 +1,8 @@
+#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
+#else
+#import <React_Core/RCTUIManager.h>
+#endif
 
 #import "RNCWebViewManager.h"
 #import "RNCWebViewImpl.h"

--- a/apple/RNCWebViewModule.h
+++ b/apple/RNCWebViewModule.h
@@ -5,7 +5,11 @@
 #import "RNCWebViewSpec/RNCWebViewSpec.h"
 #endif /* RCT_NEW_ARCH_ENABLED */
 
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import <React_Core/RCTBridgeModule.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## Problem

When `EXPO_USE_PRECOMPILED_MODULES=1` is set (enabled by default on EAS Build for Expo SDK 55+), Expo's autolinking downgrades pods that depend on `React-Core` to static libraries. In this mode, React Native's prebuilt xcframework exposes headers under the `React_Core/` module namespace instead of `React/`.

All `#import <React/...>` statements in the `apple/` headers and implementation files fail with:

```
fatal error: 'React/RCTView.h' file not found
```

This affects any Expo project using `react-native-webview` with Expo SDK 55+ or `EXPO_USE_PRECOMPILED_MODULES=1` explicitly set.

## Fix

Replace bare `#import <React/Header.h>` with `#if __has_include` guards that fall back to `<React_Core/Header.h>` when the standard path isn't available. This is the established pattern used across the React Native ecosystem for precompiled module compatibility.

**Files changed:** `RNCWebViewImpl.h`, `RNCWebViewImpl.m`, `RNCWebViewDecisionManager.h`, `RNCWebViewManager.h`, `RNCWebViewManager.mm`, `RNCWebViewModule.h`, `RCTConvert+WKDataDetectorTypes.h`, `RCTConvert+WKDataDetectorTypes.m`

The New Arch-specific imports inside `#ifdef RCT_NEW_ARCH_ENABLED` blocks (`RCTFabricComponentsPlugins`, `RCTViewComponentView`) are left unchanged as their fallback module names differ and require separate investigation.

## Testing

- Built and ran successfully against React Native 0.78.2 with New Architecture enabled
- Tested on iOS Simulator (arm64)
- Existing behaviour with standard (non-precompiled) builds is unaffected — `__has_include` resolves to the `React/` path as before

## Related

Reported at [DataDog/dd-sdk-reactnative#1302](https://github.com/DataDog/dd-sdk-reactnative/issues/1302).