### PR TITLE
fix(types): restore default generic for WebView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export { FileDownload, WebViewMessageEvent, WebViewNavigation } from './lib/WebV
 
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps & WindowsWebViewProps;
 
-declare class WebView<P = undefined> extends Component<WebViewProps & P> {
+declare class WebView<P = {}> extends Component<WebViewProps & P> {
   /**
    * Go back one page in the webview's history.
    */


### PR DESCRIPTION
Fixes #3970

## Summary

Restores the default generic parameter (`P = {}`) for the `WebView` class declaration in `index.d.ts`.

The current declaration causes `WebViewProps & undefined` to resolve to `never` when `WebView` is used in JSX without explicitly specifying `P`, making all props fail type checking.

This restores the behavior that existed before commit b094f92.