### PR TITLE
fix(ios): add geolocationPermissionGrantType prop

### DIFF
--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -481,6 +481,20 @@ static inline std::string nullSafeStringWithLength(id value) {
             [_view setMediaCapturePermissionGrantType:RNCWebViewPermissionGrantType_GrantIfSameHost_ElseDeny];
         }
     }
+
+    if (oldViewProps.geolocationPermissionGrantType != newViewProps.geolocationPermissionGrantType) {
+        if (newViewProps.geolocationPermissionGrantType == RNCWebViewGeolocationPermissionGrantType::Prompt) {
+            [_view setGeolocationPermissionGrantType:RNCWebViewPermissionGrantType_Prompt];
+        } else if (newViewProps.geolocationPermissionGrantType == RNCWebViewGeolocationPermissionGrantType::Grant) {
+            [_view setGeolocationPermissionGrantType:RNCWebViewPermissionGrantType_Grant];
+        } else if (newViewProps.geolocationPermissionGrantType == RNCWebViewGeolocationPermissionGrantType::Deny) {
+            [_view setGeolocationPermissionGrantType:RNCWebViewPermissionGrantType_Deny];
+        } else if (newViewProps.geolocationPermissionGrantType == RNCWebViewGeolocationPermissionGrantType::GrantIfSameHostElsePrompt) {
+            [_view setGeolocationPermissionGrantType:RNCWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt];
+        } else if (newViewProps.geolocationPermissionGrantType == RNCWebViewGeolocationPermissionGrantType::GrantIfSameHostElseDeny) {
+            [_view setGeolocationPermissionGrantType:RNCWebViewPermissionGrantType_GrantIfSameHost_ElseDeny];
+        }
+    }
 #endif
     if (oldViewProps.indicatorStyle != newViewProps.indicatorStyle) {
         if (newViewProps.indicatorStyle == RNCWebViewIndicatorStyle::Black) {

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -134,6 +134,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
 @property (nonatomic, assign) RNCWebViewPermissionGrantType mediaCapturePermissionGrantType;
+@property (nonatomic, assign) RNCWebViewPermissionGrantType geolocationPermissionGrantType;
 #endif
 
 #if !TARGET_OS_OSX

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -197,6 +197,7 @@ RCTAutoInsetsProtocol>
 #endif
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
+    _geolocationPermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
 #endif
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 /* iOS 15 */
     if (@available(iOS 16.0, *)) {
@@ -1318,6 +1319,29 @@ RCTAutoInsetsProtocol>
   } else if (_mediaCapturePermissionGrantType == RNCWebViewPermissionGrantType_Deny) {
     decisionHandler(WKPermissionDecisionDeny);
   } else if (_mediaCapturePermissionGrantType == RNCWebViewPermissionGrantType_Grant) {
+    decisionHandler(WKPermissionDecisionGrant);
+  } else {
+    decisionHandler(WKPermissionDecisionPrompt);
+  }
+}
+
+/**
+ * Geolocation permissions (prevent hanging forever when unimplemented)
+ */
+- (void)                       webView:(WKWebView *)webView
+  requestGeolocationPermissionForOrigin:(WKSecurityOrigin *)origin
+                        initiatedByFrame:(WKFrameInfo *)frame
+                         decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {
+  if (_geolocationPermissionGrantType == RNCWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt || _geolocationPermissionGrantType == RNCWebViewPermissionGrantType_GrantIfSameHost_ElseDeny) {
+    if ([origin.host isEqualToString:webView.URL.host]) {
+      decisionHandler(WKPermissionDecisionGrant);
+    } else {
+      WKPermissionDecision decision = _geolocationPermissionGrantType == RNCWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt ? WKPermissionDecisionPrompt : WKPermissionDecisionDeny;
+      decisionHandler(decision);
+    }
+  } else if (_geolocationPermissionGrantType == RNCWebViewPermissionGrantType_Deny) {
+    decisionHandler(WKPermissionDecisionDeny);
+  } else if (_geolocationPermissionGrantType == RNCWebViewPermissionGrantType_Grant) {
     decisionHandler(WKPermissionDecisionGrant);
   } else {
     decisionHandler(WKPermissionDecisionPrompt);

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -102,6 +102,7 @@ RCT_EXPORT_VIEW_PROPERTY(textInteractionEnabled, BOOL)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
 RCT_EXPORT_VIEW_PROPERTY(mediaCapturePermissionGrantType, RNCWebViewPermissionGrantType)
+RCT_EXPORT_VIEW_PROPERTY(geolocationPermissionGrantType, RNCWebViewPermissionGrantType)
 #endif
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -208,6 +208,10 @@ export interface NativeProps extends ViewProps {
     'prompt' | 'grant' | 'deny' | 'grantIfSameHostElsePrompt' | 'grantIfSameHostElseDeny',
     'prompt'
   >;
+  geolocationPermissionGrantType?: WithDefault<
+    'prompt' | 'grant' | 'deny' | 'grantIfSameHostElsePrompt' | 'grantIfSameHostElseDeny',
+    'prompt'
+  >;
   pagingEnabled?: boolean;
   pullToRefreshEnabled?: boolean;
   refreshControlLightMode?: boolean;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -322,6 +322,13 @@ export declare type MediaCapturePermissionGrantType =
   | 'grant'
   | 'prompt';
 
+export declare type GeolocationPermissionGrantType =
+  | 'grantIfSameHostElsePrompt'
+  | 'grantIfSameHostElseDeny'
+  | 'deny'
+  | 'grant'
+  | 'prompt';
+
 export declare type ContentMode = 'recommended' | 'mobile' | 'desktop';
 
 export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
@@ -729,6 +736,15 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * Available on iOS 15 and later.
    */
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
+
+  /**
+   * This property specifies how to handle geolocation permission requests.
+   * Without a decision handler, WKWebView leaves `navigator.geolocation`
+   * calls unresolved forever instead of erroring, which can hang pages that
+   * await a location before continuing. Defaults to `prompt`, which lets
+   * WebKit show its native permission alert. Available on iOS 15 and later.
+   */
+  geolocationPermissionGrantType?: GeolocationPermissionGrantType;
 
   /**
    * A Boolean value which, when set to `true`, WebView will be rendered with Apple Pay support.


### PR DESCRIPTION
WKWebView has no default handling for geolocation permission requests. Without a WKUIDelegate decision, calls to navigator.geolocation.getCurrentPosition() inside the WebView never invoke either callback, silently hanging pages that await a location before continuing instead of erroring like on Android. 
Mirrors the existing mediaCapturePermissionGrantType prop/delegate pattern (grant/deny/prompt/grantIfSameHostElsePrompt/ grantIfSameHostElseDeny), defaulting to 'prompt' so WebKit shows its native permission alert and always resolves the promise.