### PR TITLE
fix(android): ignore iOS decelerationRate prop

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -25,6 +25,7 @@ import {
 import {
   AndroidWebViewProps,
   WebViewSourceUri,
+  type IOSWebViewProps,
   type WebViewMessageEvent,
   type ShouldStartLoadRequestEvent,
 } from './WebViewTypes';
@@ -99,6 +100,9 @@ const WebViewComponent = forwardRef<unknown, AndroidWebViewProps>(
     },
     ref,
   ) => {
+    // Strip the iOS-only prop before Android Fabric's generated delegate casts it to a double.
+    const { decelerationRate: _decelerationRate, ...androidProps } =
+      otherProps as typeof otherProps & Pick<IOSWebViewProps, 'decelerationRate'>;
     const messagingModuleName = useRef<string>(`WebViewMessageHandler${(uniqueRef += 1)}`).current;
     const webViewRef = useRef<React.ComponentRef<HostComponent<NativeProps>> | null>(null);
 
@@ -257,10 +261,10 @@ const WebViewComponent = forwardRef<unknown, AndroidWebViewProps>(
     const webView = (
       <NativeWebView
         key="webViewKey"
-        {...otherProps}
+        {...androidProps}
         messagingEnabled={typeof onMessageProp === 'function'}
         messagingModuleName={messagingModuleName}
-        hasOnScroll={!!otherProps.onScroll}
+        hasOnScroll={!!androidProps.onScroll}
         onLoadingError={onLoadingError}
         onLoadingSubResourceError={onLoadingSubResourceError}
         onLoadingFinish={onLoadingFinish}

--- a/src/__tests__/WebView.android-test.js
+++ b/src/__tests__/WebView.android-test.js
@@ -1,0 +1,70 @@
+jest.mock('react', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    ...React,
+    forwardRef: (render) => render,
+    useCallback: (callback) => callback,
+    useEffect: jest.fn(),
+    useImperativeHandle: jest.fn(),
+    useRef: (value) => ({ current: value }),
+  };
+});
+
+jest.mock('../RNCWebViewNativeComponent', () => ({
+  __esModule: true,
+  Commands: {},
+  default: 'RNCWebView',
+}));
+
+jest.mock('../NativeRNCWebViewModule', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../WebViewShared', () => ({
+  defaultOriginWhitelist: ['http://*', 'https://*'],
+  defaultRenderError: jest.fn(),
+  defaultRenderLoading: jest.fn(),
+  useWebViewLogic: () => ({
+    lastErrorEvent: null,
+    onHttpError: jest.fn(),
+    onLoadingError: jest.fn(),
+    onLoadingFinish: jest.fn(),
+    onLoadingProgress: jest.fn(),
+    onLoadingStart: jest.fn(),
+    onLoadingSubResourceError: jest.fn(),
+    onMessage: jest.fn(),
+    onOpenWindow: jest.fn(),
+    onRenderProcessGone: jest.fn(),
+    onShouldStartLoadWithRequest: jest.fn(),
+    setViewState: jest.fn(),
+    viewState: 'IDLE',
+  }),
+}));
+
+import WebView from '../WebView.android';
+
+describe('WebView.android', () => {
+  it.each(['fast', 'normal', 0.95])(
+    'does not forward the iOS-only decelerationRate value %p',
+    (decelerationRate) => {
+      const onScroll = jest.fn();
+      const rendered = WebView(
+        {
+          decelerationRate,
+          onScroll,
+          source: { html: '<html />' },
+          testID: 'webview',
+        },
+        null,
+      );
+      const [nativeWebView] = rendered.props.children;
+
+      expect(nativeWebView.props).not.toHaveProperty('decelerationRate');
+      expect(nativeWebView.props.onScroll).toBe(onScroll);
+      expect(nativeWebView.props.hasOnScroll).toBe(true);
+      expect(nativeWebView.props.testID).toBe('webview');
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Stop the Android wrapper from forwarding the iOS-only `decelerationRate` prop to the native component.
- Prevent the generated Fabric delegate from casting the string aliases `fast` and `normal` to `Double`.
- Add Android regression coverage for both string aliases and a numeric value while checking that unrelated native props are preserved.

Fixes #3935

## Why

The public cross-platform WebView props accept the iOS `decelerationRate` values, and the Android wrapper previously included the value in its rest-prop spread. Under Fabric, the generated delegate recognizes the native spec field as a `Double` and performs that cast before the Android no-op setter can ignore it. Filtering the iOS-only prop at the Android JavaScript boundary makes the behavior match the expected platform-specific no-op.

## Test plan

- `bun run lint:ci`
- `bun run jest src --runInBand` (3 suites, 17 tests)
- `bun run prepare`
- `bun pm pack --dry-run`
- `./gradlew --no-daemon clean build check test` from `example/android` (356 tasks, including debug, debugOptimized, release, codegen, CMake, lint, and tests)
- Android API 34 emulator using the new architecture (`fabric: true`) with the exact `decelerationRate="fast"` repro: the WebView rendered and logcat contained no `ClassCastException`, fatal exception, or Fabric property-update error.