### PR TITLE
fix(windows): explicit CoreWebView2 environment + surface init failure to JS

### DIFF
--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
@@ -11,6 +11,7 @@
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Web.Http.h>
+#include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <limits>
@@ -19,6 +20,24 @@
 #include <thread>
 
 namespace winrt::ReactNativeWebView::implementation {
+
+namespace {
+// A packaged app's install directory (Program Files\WindowsApps\...) is
+// read-only, so WebView2's default "<exe-name>.WebView2" user-data folder
+// -- created next to the executable -- fails there. Use the app's writable
+// LocalFolder when packaged, or %TEMP% for unpackaged / loose dev builds
+// (ApplicationData requires package identity and throws without it).
+winrt::hstring DefaultUserDataFolder() noexcept {
+    try {
+        auto folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+        return folder.Path() + L"\\ReactNativeWebView2";
+    } catch (...) {
+    }
+    wchar_t temp[MAX_PATH]{};
+    const DWORD n = ::GetTempPathW(MAX_PATH, temp);
+    return (n ? winrt::hstring{temp, n} : winrt::hstring{L".\\"}) + L"ReactNativeWebView2";
+}
+} // namespace
 
 void RegisterRCTWebView2ComponentView(
     winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept {
@@ -112,9 +131,61 @@ void RCTWebView2ComponentView::InitializeContentIsland(
             }
         });
 
-    // Explicitly trigger CoreWebView2 initialization.
-    // In XamlIsland hosting, the WebView2 won't auto-initialize its browser process.
-    m_webView.EnsureCoreWebView2Async();
+    // Explicitly trigger CoreWebView2 initialization. In XamlIsland hosting,
+    // the WebView2 won't auto-initialize its browser process on its own; see
+    // InitializeCoreWebView2Async for why we pass an explicit environment
+    // instead of calling the parameterless EnsureCoreWebView2Async().
+    InitializeCoreWebView2Async();
+}
+
+winrt::fire_and_forget RCTWebView2ComponentView::InitializeCoreWebView2Async() {
+    auto strongThis = get_strong();
+    try {
+        // Explicit environment with a writable, packaged-safe user-data
+        // folder. The parameterless EnsureCoreWebView2Async() lazily
+        // creates a default environment next to the executable; on a
+        // packaged app that folder is read-only, and on a machine without
+        // the WebView2 Evergreen Runtime installed (stripped/managed
+        // images, some Server SKUs) creation fails with nothing surfaced to
+        // JS -- the view just stays blank. Creating the environment
+        // ourselves lets us catch that failure directly, and gives us a
+        // folder that won't hit ERROR_ACCESS_DENIED.
+        auto environment = co_await winrt::Microsoft::Web::WebView2::Core::CoreWebView2Environment::CreateWithOptionsAsync(
+            L"" /* browserExecutableFolder: use the installed Evergreen Runtime */,
+            DefaultUserDataFolder(),
+            nullptr /* options */);
+
+        if (!strongThis->m_webView) {
+            co_return; // torn down while we were awaiting environment creation
+        }
+        co_await strongThis->m_webView.EnsureCoreWebView2Async(environment);
+        // Success or failure of EnsureCoreWebView2Async is reported via the
+        // CoreWebView2Initialized event -- see OnCoreWebView2Initialized.
+    } catch (winrt::hresult_error const& e) {
+        // CoreWebView2Environment::CreateWithOptionsAsync throws directly
+        // when the WebView2 Runtime isn't present at all. That failure
+        // never reaches CoreWebView2Initialized, because we never got far
+        // enough to call EnsureCoreWebView2Async.
+        strongThis->EmitCoreWebView2InitError(
+            static_cast<int32_t>(e.code().value),
+            "CoreWebView2 environment creation failed (WebView2 Runtime missing?)");
+    }
+}
+
+void RCTWebView2ComponentView::EmitCoreWebView2InitError(int32_t hresult, std::string const& description) noexcept {
+    try {
+        if (auto eventEmitter = EventEmitter()) {
+            RNCWebViewCodegen::RCTWebView2EventEmitter::OnLoadingError event;
+            event.loading = false;
+            event.canGoBack = false;
+            event.canGoForward = false;
+            event.code = hresult;
+            event.description = description;
+            eventEmitter->onLoadingError(event);
+        }
+    } catch (...) {
+        // Event dispatch failure is non-fatal
+    }
 }
 
 void RCTWebView2ComponentView::Cleanup() noexcept {
@@ -397,10 +468,20 @@ void RCTWebView2ComponentView::OnNavigationCompleted(
 }
 
 void RCTWebView2ComponentView::OnCoreWebView2Initialized(
-    winrt::Microsoft::UI::Xaml::Controls::CoreWebView2InitializedEventArgs const& /*args*/) {
-    
+    winrt::Microsoft::UI::Xaml::Controls::CoreWebView2InitializedEventArgs const& args) {
+
+    if (args.Exception()) {
+        // EnsureCoreWebView2Async failed even with an explicit environment
+        // -- e.g. the WebView2 Runtime was removed between environment
+        // creation and controller creation, or the user-data folder became
+        // unwritable. Without this, the view just stays blank and JS never
+        // learns why.
+        EmitCoreWebView2InitError(args.Exception().value, "CoreWebView2 initialization failed");
+        return;
+    }
+
     if (!m_webView || !m_webView.CoreWebView2()) return;
-    
+
     RegisterCoreWebView2Events();
     
     // Apply user agent if set

--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.h
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.h
@@ -59,7 +59,15 @@ private:
     void RefreshSize();
     void RegisterEvents();
     void RegisterCoreWebView2Events();
-    
+
+    // Kicks off CoreWebView2 creation with an explicit environment (see the
+    // .cpp for why) instead of the parameterless EnsureCoreWebView2Async().
+    winrt::fire_and_forget InitializeCoreWebView2Async();
+    // Emits onLoadingError for a CoreWebView2 init failure, whether it came
+    // from environment creation (caught directly) or from
+    // EnsureCoreWebView2Async itself (CoreWebView2Initialized's Exception()).
+    void EmitCoreWebView2InitError(int32_t hresult, std::string const& description) noexcept;
+
     void OnNavigationStarting(winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationStartingEventArgs const& args);
     void OnNavigationCompleted(winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationCompletedEventArgs const& args);
     void OnCoreWebView2Initialized(winrt::Microsoft::UI::Xaml::Controls::CoreWebView2InitializedEventArgs const& args);


### PR DESCRIPTION
Part of the hardening series offered in #3980. This is **WV-1**: explicit `CoreWebView2` environment + surfacing init failure to JS.

### Problem

`InitializeContentIsland` calls `m_webView.EnsureCoreWebView2Async();` with no explicit environment and no failure handling. Two consequences:

- The default user-data folder is created next to the executable. A packaged app's install directory (`Program Files\WindowsApps\...`) is read-only, so this can fail to create there.
- On a machine without the WebView2 Evergreen Runtime installed (stripped/managed images, some Server SKUs), `CoreWebView2` creation fails and the view just stays permanently blank — nothing is surfaced to JS, `OnCoreWebView2Initialized`'s early-return (`if (!m_webView || !m_webView.CoreWebView2()) return;`) silently swallows it.

### Real-world failure mode

An app ships fine in dev/CI (Evergreen Runtime present) but a `<WebView>` silently renders nothing on a subset of user machines or locked-down corporate images — with no error event to build a fallback UI or diagnostics around, and no way to distinguish "runtime missing" from "still loading" from JS.

### Fix

- `InitializeCoreWebView2Async()` creates the environment explicitly via `CoreWebView2Environment::CreateWithOptionsAsync(L"", <writable user-data folder>, nullptr)`, using `ApplicationData.LocalFolder` (falling back to `%TEMP%` for unpackaged/dev builds) instead of the default next-to-exe folder.
- `OnCoreWebView2Initialized` now checks `args.Exception()` and emits `onLoadingError` with the failing HRESULT if set.
- The `catch` around environment creation covers the case where the Runtime is missing entirely (that failure never reaches `CoreWebView2Initialized`, because `EnsureCoreWebView2Async` is never called).

### Questions for maintainers

- User-data-folder policy: is a fixed `ApplicationData.LocalFolder` subfolder (what this PR does) the right default, or would you rather see a prop/static setter so apps can share a profile with their own WebView2 environments?
- We deliberately did not add a retry-after-failure mechanism (re-attempting `EnsureCoreWebView2Async` on a later prop change) to keep this diff focused — happy to add it as a follow-up if useful.

### Validation status

**Not compiled against this repo.** No Windows build was run this pass (no `bun run windows` / MSBuild) — verified by hand, side-by-side against `RCTWebView2ComponentView.cpp`, not by building. The `CoreWebView2InitializedEventArgs.Exception()` API surface in particular needs your Windows CI to confirm.

The explicit-environment + init-error pattern is production-proven in a parallel, independently-built Windows new-arch WebView2 Fabric component running in Facilitron FIT (react-native-windows 0.83.2, WinAppSDK 1.8, ARM64) — see the production twin: [FacilitronWorks/react-native-webview-windows](https://github.com/FacilitronWorks/react-native-webview-windows). Renamed symbols, hand-ported to this repo's codegen/class shape — not a copy-paste.

Related: #3980
