### PR TITLE
fix(windows): honor navigation success/failure + include title in nav events

### DIFF
--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
@@ -319,9 +319,19 @@ bool RCTWebView2ComponentView::Is17763OrHigher() {
     return hasUniversalAPIContract_v7.value();
 }
 
+std::string RCTWebView2ComponentView::CurrentTitle() const noexcept {
+    try {
+        if (m_webView && m_webView.CoreWebView2()) {
+            return winrt::to_string(m_webView.CoreWebView2().DocumentTitle());
+        }
+    } catch (...) {
+    }
+    return {};
+}
+
 void RCTWebView2ComponentView::OnNavigationStarting(
     winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationStartingEventArgs const& /*args*/) {
-    
+
     try {
         if (auto eventEmitter = EventEmitter()) {
             RNCWebViewCodegen::RCTWebView2EventEmitter::OnLoadingStart event;
@@ -329,6 +339,7 @@ void RCTWebView2ComponentView::OnNavigationStarting(
                 event.url = winrt::to_string(m_webView.Source().AbsoluteCanonicalUri());
             }
             event.loading = true;
+            event.title = CurrentTitle();
             event.canGoBack = m_webView ? m_webView.CanGoBack() : false;
             event.canGoForward = m_webView ? m_webView.CanGoForward() : false;
             event.navigationType = "other";
@@ -359,8 +370,43 @@ void RCTWebView2ComponentView::OnNavigationStarting(
 }
 
 void RCTWebView2ComponentView::OnNavigationCompleted(
-    winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationCompletedEventArgs const& /*args*/) {
-    
+    winrt::Microsoft::Web::WebView2::Core::CoreWebView2NavigationCompletedEventArgs const& args) {
+
+    // args.IsSuccess() / args.WebErrorStatus() were previously never
+    // consulted, so DNS failures, TLS errors, and offline states all
+    // reported onLoadingFinish -- indistinguishable from a real successful
+    // load from JS's point of view.
+    bool success = true;
+    int32_t webErrorStatus = 0;
+    try {
+        success = args.IsSuccess();
+        webErrorStatus = static_cast<int32_t>(args.WebErrorStatus());
+    } catch (...) {
+        // Can't read the args; fall back to the previous "assume success"
+        // behavior rather than misreport a failure.
+    }
+
+    if (!success) {
+        try {
+            if (auto eventEmitter = EventEmitter()) {
+                RNCWebViewCodegen::RCTWebView2EventEmitter::OnLoadingError event;
+                if (m_webView && m_webView.Source()) {
+                    event.url = winrt::to_string(m_webView.Source().AbsoluteCanonicalUri());
+                }
+                event.loading = false;
+                event.title = CurrentTitle();
+                event.canGoBack = m_webView ? m_webView.CanGoBack() : false;
+                event.canGoForward = m_webView ? m_webView.CanGoForward() : false;
+                event.code = webErrorStatus;
+                event.description = "WebView2 navigation failed (CoreWebView2WebErrorStatus)";
+                eventEmitter->onLoadingError(event);
+            }
+        } catch (...) {
+            // Event dispatch failure is non-fatal
+        }
+        return; // don't run the message-bridge injection below on a failed load
+    }
+
     try {
         if (auto eventEmitter = EventEmitter()) {
             RNCWebViewCodegen::RCTWebView2EventEmitter::OnLoadingFinish event;
@@ -368,6 +414,7 @@ void RCTWebView2ComponentView::OnNavigationCompleted(
                 event.url = winrt::to_string(m_webView.Source().AbsoluteCanonicalUri());
             }
             event.loading = false;
+            event.title = CurrentTitle();
             event.canGoBack = m_webView ? m_webView.CanGoBack() : false;
             event.canGoForward = m_webView ? m_webView.CanGoForward() : false;
             event.navigationType = "other";
@@ -444,6 +491,7 @@ void RCTWebView2ComponentView::OnCoreWebView2SourceChanged(
             event.url = winrt::to_string(m_webView.Source().AbsoluteCanonicalUri());
         }
         event.loading = false;
+        event.title = CurrentTitle();
         event.canGoBack = m_webView ? m_webView.CanGoBack() : false;
         event.canGoForward = m_webView ? m_webView.CanGoForward() : false;
         event.navigationType = "other";

--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.h
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.h
@@ -80,6 +80,9 @@ private:
     void HandleMessageFromJS(winrt::hstring const& message);
     bool Is17763OrHigher();
     void WriteCookiesToWebView2(std::string const& cookies);
+    // DocumentTitle(), best-effort -- empty string before CoreWebView2 exists
+    // or if the read throws.
+    std::string CurrentTitle() const noexcept;
 
     winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView> m_islandView;
     winrt::Microsoft::UI::Xaml::XamlIsland m_island{nullptr};


### PR DESCRIPTION
Part of the hardening series offered in #3980. This is **WV-2**: honor navigation success/failure, and populate `title` in nav events.

### Problem

`OnNavigationCompleted` never reads `args.IsSuccess()` / `args.WebErrorStatus()` — it unconditionally dispatches `onLoadingFinish`. Separately, every nav-event struct in the codegen (`RCTWebView2.g.h`) already has a `title` field, but nothing on Windows ever sets it.

### Real-world failure mode

A DNS failure, TLS error, or the device going offline mid-navigation all report as `onLoadingFinish` to JS — a page that failed to load looks identical to one that succeeded. Apps that branch on `onLoadingError` to show a retry/offline UI (a common pattern, and one this monorepo's own offline-first FIT app relies on) never see it fire on Windows. Apps that display `nativeEvent.title` (e.g. for a browser-chrome-style header) get an empty string forever on Windows.

### Fix

- `OnNavigationCompleted` branches on `args.IsSuccess()`. On failure it emits `onLoadingError` with `event.code` set from `args.WebErrorStatus()` (cast to `int32_t`) instead of `onLoadingFinish`, and skips the message-bridge injection that follows.
- `CurrentTitle()` (new, best-effort, empty string if `CoreWebView2` isn't ready or the read throws) is wired into `onLoadingStart`, `onLoadingFinish`, `onLoadingError`, and `onSourceChanged`.

### Validation status

**Not compiled against this repo.** No Windows build was run this pass — verified by hand against `RCTWebView2ComponentView.cpp`, not by building.

Both behaviors — checking `IsSuccess()`/`WebErrorStatus()` on nav-completed, and populating `title` from `DocumentTitle()` — are production-proven in a parallel, independently-built Windows new-arch WebView2 Fabric component running in Facilitron FIT (react-native-windows 0.83.2, WinAppSDK 1.8, ARM64) — see the production twin: [FacilitronWorks/react-native-webview-windows](https://github.com/FacilitronWorks/react-native-webview-windows). Renamed symbols, hand-ported to this repo's codegen/class shape — not a copy-paste.

Related: #3980
