### PR TITLE
fix(windows): register message bridge at document-start; support injectedJavaScriptBeforeContentLoaded

### DIFF
--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
@@ -20,6 +20,27 @@
 
 namespace winrt::ReactNativeWebView::implementation {
 
+namespace {
+// Registered once via AddScriptToExecuteOnDocumentCreatedAsync (see
+// RegisterDocumentStartScripts) so window.ReactNativeWebView exists before
+// ANY page script runs -- including a synchronous inline <script> in
+// <head>. Previously this same script was run via ExecuteScriptAsync from
+// NavigationCompleted, i.e. after the page had already finished loading;
+// page scripts that read window.ReactNativeWebView during load never saw
+// it. Contents unchanged from the original NavigationCompleted injection.
+constexpr wchar_t kMessageBridgeScript[] =
+    LR"(
+        window.alert = function (msg) {window.chrome.webview.postMessage(`{"type":"__alert","message":"${msg}"}`)};
+        window.ReactNativeWebView = {postMessage: function (data) {window.chrome.webview.postMessage(String(data))}};
+        const originalPostMessage = globalThis.postMessage;
+        globalThis.postMessage = function (data) { originalPostMessage(data); globalThis.ReactNativeWebView.postMessage(typeof data == 'string' ? data : JSON.stringify(data));};
+        window.chrome.webview.addEventListener('message', function(e) {
+            window.dispatchEvent(new MessageEvent('message', {data: e.data}));
+            document.dispatchEvent(new MessageEvent('message', {data: e.data}));
+        });
+    )";
+} // namespace
+
 void RegisterRCTWebView2ComponentView(
     winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept {
     
@@ -176,7 +197,19 @@ void RCTWebView2ComponentView::UpdateProps(
     if (newProps->injectedJavaScript.has_value()) {
         m_injectedJavascript = winrt::to_hstring(newProps->injectedJavaScript.value());
     }
-    
+
+    // Apply pre-content-load injected JavaScript. This prop already existed
+    // in the codegen'd spec (RCTWebView2Props::injectedJavaScriptBeforeContentLoaded)
+    // but was never read on Windows. Applied once, at CoreWebView2 init (see
+    // RegisterDocumentStartScripts) -- same limitation as the message
+    // bridge script below: WebView2 has no API to swap a document-created
+    // script after the fact, so changing this prop after first mount takes
+    // effect on remount, not immediately.
+    if (newProps->injectedJavaScriptBeforeContentLoaded.has_value()) {
+        m_injectedJavaScriptBeforeContentLoaded =
+            winrt::to_hstring(newProps->injectedJavaScriptBeforeContentLoaded.value());
+    }
+
     // Apply user agent
     if (newProps->userAgent.has_value()) {
         m_userAgent = winrt::to_hstring(newProps->userAgent.value());
@@ -338,24 +371,9 @@ void RCTWebView2ComponentView::OnNavigationStarting(
         // Event dispatch failure is non-fatal
     }
 
-    if (m_messagingEnabled && m_webView) {
-        try {
-            if (m_messageToken) {
-                m_webView.WebMessageReceived(m_messageToken);
-            }
-            m_messageToken = m_webView.WebMessageReceived(
-                [this](auto const& /*sender*/, winrt::Microsoft::Web::WebView2::Core::CoreWebView2WebMessageReceivedEventArgs const& messageArgs) {
-                    try {
-                        auto message = messageArgs.TryGetWebMessageAsString();
-                        OnMessagePosted(message);
-                    } catch (...) {
-                        return;
-                    }
-                });
-        } catch (...) {
-            // WebMessageReceived registration failure
-        }
-    }
+    // WebMessageReceived is now registered once, at CoreWebView2 init (see
+    // OnCoreWebView2Initialized / RegisterDocumentStartScripts), instead of
+    // being re-registered on every navigation start.
 }
 
 void RCTWebView2ComponentView::OnNavigationCompleted(
@@ -377,37 +395,43 @@ void RCTWebView2ComponentView::OnNavigationCompleted(
         // Event dispatch failure is non-fatal
     }
 
-    if (m_messagingEnabled && m_webView) {
-        try {
-            winrt::hstring message = LR"(
-                window.alert = function (msg) {window.chrome.webview.postMessage(`{"type":"__alert","message":"${msg}"}`)};
-                window.ReactNativeWebView = {postMessage: function (data) {window.chrome.webview.postMessage(String(data))}};
-                const originalPostMessage = globalThis.postMessage;
-                globalThis.postMessage = function (data) { originalPostMessage(data); globalThis.ReactNativeWebView.postMessage(typeof data == 'string' ? data : JSON.stringify(data));};
-                window.chrome.webview.addEventListener('message', function(e) {
-                    window.dispatchEvent(new MessageEvent('message', {data: e.data}));
-                    document.dispatchEvent(new MessageEvent('message', {data: e.data}));
-                });
-            )";
-            m_webView.ExecuteScriptAsync(message);
-        } catch (...) {
-            // JS injection failure
-        }
-    }
+    // The message bridge is registered once, at document-creation time (see
+    // RegisterDocumentStartScripts), rather than re-injected here on every
+    // completed navigation -- see kMessageBridgeScript for why.
 }
 
 void RCTWebView2ComponentView::OnCoreWebView2Initialized(
     winrt::Microsoft::UI::Xaml::Controls::CoreWebView2InitializedEventArgs const& /*args*/) {
     
     if (!m_webView || !m_webView.CoreWebView2()) return;
-    
+
     RegisterCoreWebView2Events();
-    
+
+    if (m_messagingEnabled) {
+        // window.ReactNativeWebView + (optional) injectedJavaScriptBeforeContentLoaded.
+        RegisterDocumentStartScripts();
+
+        // WebMessageReceived is registered once here rather than on every
+        // NavigationStarting.
+        if (m_messageToken) {
+            m_webView.WebMessageReceived(m_messageToken);
+        }
+        m_messageToken = m_webView.WebMessageReceived(
+            [this](auto const& /*sender*/, winrt::Microsoft::Web::WebView2::Core::CoreWebView2WebMessageReceivedEventArgs const& messageArgs) {
+                try {
+                    auto message = messageArgs.TryGetWebMessageAsString();
+                    OnMessagePosted(message);
+                } catch (...) {
+                    return;
+                }
+            });
+    }
+
     // Apply user agent if set
     if (!m_userAgent.empty()) {
         m_webView.CoreWebView2().Settings().UserAgent(m_userAgent);
     }
-    
+
     // Navigate to deferred HTML source if pending
     if (!m_pendingHtml.empty()) {
         try {
@@ -416,6 +440,24 @@ void RCTWebView2ComponentView::OnCoreWebView2Initialized(
             // Deferred navigation failed
         }
         m_pendingHtml.clear();
+    }
+}
+
+winrt::fire_and_forget RCTWebView2ComponentView::RegisterDocumentStartScripts() {
+    auto strongThis = get_strong();
+    if (!strongThis->m_webView || !strongThis->m_webView.CoreWebView2()) {
+        co_return;
+    }
+    auto coreWebView = strongThis->m_webView.CoreWebView2();
+    try {
+        co_await coreWebView.AddScriptToExecuteOnDocumentCreatedAsync(kMessageBridgeScript);
+        if (!strongThis->m_injectedJavaScriptBeforeContentLoaded.empty()) {
+            co_await coreWebView.AddScriptToExecuteOnDocumentCreatedAsync(
+                strongThis->m_injectedJavaScriptBeforeContentLoaded);
+        }
+    } catch (...) {
+        // Script registration failure is non-fatal: the page still loads,
+        // just without window.ReactNativeWebView / the pre-content script.
     }
 }
 

--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.h
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.h
@@ -81,6 +81,13 @@ private:
     bool Is17763OrHigher();
     void WriteCookiesToWebView2(std::string const& cookies);
 
+    // Registers the window.ReactNativeWebView message bridge and (if set)
+    // injectedJavaScriptBeforeContentLoaded via
+    // AddScriptToExecuteOnDocumentCreatedAsync, once, when CoreWebView2
+    // becomes available. See OnCoreWebView2Initialized / the .cpp for why
+    // this replaced injecting the bridge in NavigationCompleted.
+    winrt::fire_and_forget RegisterDocumentStartScripts();
+
     winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView> m_islandView;
     winrt::Microsoft::UI::Xaml::XamlIsland m_island{nullptr};
     winrt::Microsoft::UI::Xaml::Controls::WebView2 m_webView{nullptr};
@@ -101,6 +108,7 @@ private:
     bool m_messagingEnabled{true};
     bool m_linkHandlingEnabled{true};
     winrt::hstring m_injectedJavascript{L""};
+    winrt::hstring m_injectedJavaScriptBeforeContentLoaded{L""};
     winrt::hstring m_userAgent{L""};
     bool m_updating{false};
     std::string m_pendingHtml{};


### PR DESCRIPTION
Part of the hardening series offered in #3980. This is **WV-3**: register the message bridge at document-start, and wire up `injectedJavaScriptBeforeContentLoaded`.

### Problem

Two related timing bugs in the messaging path:

- `window.ReactNativeWebView` (plus the `alert()` shim and `postMessage` forwarding) is injected via `ExecuteScriptAsync` from `OnNavigationCompleted` — i.e. *after the page has already finished loading*.
- `WebMessageReceived` is unhooked and re-hooked on every `OnNavigationStarting`.

### Real-world failure mode

Any page script that reads or calls `window.ReactNativeWebView` while the page is still loading — a synchronous inline `<script>` in `<head>`, or a framework's early bootstrap code — sees `undefined` and either throws or silently no-ops, because the bridge doesn't exist until after `NavigationCompleted` fires. This is a real, commonly-hit ordering bug in embedded-web-content integrations generally (it's the reason `injectedJavaScriptBeforeContentLoaded` exists as a concept in this library on other platforms) — Windows has no "before content loaded" injection point at all today.

### Fix

- `kMessageBridgeScript` (contents unchanged from the current `NavigationCompleted` injection — alert shim, `postMessage` forwarding, `chrome.webview` message-event dispatch, all preserved) is registered once via `CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync`, in `OnCoreWebView2Initialized`, instead of re-injected via `ExecuteScriptAsync` on every completed navigation. This makes it exist before any page script runs, on every subsequent navigation in that `CoreWebView2`.
- `WebMessageReceived` is registered once at the same point instead of on every `NavigationStarting`.
- The same `AddScriptToExecuteOnDocumentCreatedAsync` mechanism now applies `injectedJavaScriptBeforeContentLoaded` (the prop already exists in the codegen'd spec — `RCTWebView2Props::injectedJavaScriptBeforeContentLoaded` — but nothing on Windows ever read it).

### Trade-off worth flagging

`messagingEnabled` and `injectedJavaScriptBeforeContentLoaded` are now captured once, at `CoreWebView2` init, rather than re-checked on every navigation. Previously `messagingEnabled` was checked fresh in both `NavigationStarting` and `NavigationCompleted`, so toggling it after mount took effect on the very next navigation; with this change it takes effect on remount instead. WebView2 doesn't offer a clean way to swap a document-created script after the fact short of tracking script IDs and calling `RemoveScriptToExecuteOnDocumentCreated` — happy to add that if the dynamic-toggle behavior matters for your users; flagging as a deliberate scope cut rather than an oversight.

### Validation status

**Not compiled against this repo.** No Windows build was run this pass — verified by hand against `RCTWebView2ComponentView.cpp`, not by building.

Document-start bridge registration via `AddScriptToExecuteOnDocumentCreatedAsync`, and `injectedJavaScriptBeforeContentLoaded` support built the same way, are both production-proven in a parallel, independently-built Windows new-arch WebView2 Fabric component running in Facilitron FIT (react-native-windows 0.83.2, WinAppSDK 1.8, ARM64) — see the production twin: [FacilitronWorks/react-native-webview-windows](https://github.com/FacilitronWorks/react-native-webview-windows). Renamed symbols, hand-ported to this repo's codegen/class shape — not a copy-paste.

Related: #3980
