### PR TITLE
fix(windows): fix javaScriptEnabled lost before core-init; stop re-navigating on unrelated prop changes

### DIFF
--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.cpp
@@ -185,35 +185,58 @@ void RCTWebView2ComponentView::UpdateProps(
         }
     }
     
-    // Handle source navigation
+    // Handle source navigation. UpdateProps is called with the FULL current
+    // prop set whenever ANY prop changes (not just source-related ones), so
+    // re-setting Source() / calling NavigateToString() unconditionally here
+    // re-navigates -- for Source() specifically, possibly reloading the
+    // page -- on every unrelated prop change (e.g. toggling
+    // javaScriptEnabled). Diff against oldProps so navigation only happens
+    // when the source actually changed; oldProps is null on first mount, in
+    // which case we always want to navigate.
+    const bool uriChanged = !oldProps ||
+        oldProps->newSource.uri.value_or(std::string{}) != newProps->newSource.uri.value_or(std::string{});
+    const bool htmlChanged = !oldProps ||
+        oldProps->newSource.html.value_or(std::string{}) != newProps->newSource.html.value_or(std::string{});
+
     if (newProps->newSource.uri.has_value() && !newProps->newSource.uri.value().empty()) {
-        try {
-            auto uri = winrt::Windows::Foundation::Uri(winrt::to_hstring(newProps->newSource.uri.value()));
-            m_webView.Source(uri);
-        } catch (...) {
-            // Invalid URI
+        if (uriChanged) {
+            try {
+                auto uri = winrt::Windows::Foundation::Uri(winrt::to_hstring(newProps->newSource.uri.value()));
+                m_webView.Source(uri);
+            } catch (...) {
+                // Invalid URI
+            }
         }
     } else if (newProps->newSource.html.has_value() && !newProps->newSource.html.value().empty()) {
-        if (m_webView.CoreWebView2()) {
-            try {
-                m_webView.NavigateToString(winrt::to_hstring(newProps->newSource.html.value()));
-            } catch (...) {
-                // Navigation failed
+        if (htmlChanged) {
+            if (m_webView.CoreWebView2()) {
+                try {
+                    m_webView.NavigateToString(winrt::to_hstring(newProps->newSource.html.value()));
+                } catch (...) {
+                    // Navigation failed
+                }
+            } else {
+                // CoreWebView2 not ready yet - save HTML for later navigation in OnCoreWebView2Initialized
+                m_pendingHtml = newProps->newSource.html.value();
             }
-        } else {
-            // CoreWebView2 not ready yet - save HTML for later navigation in OnCoreWebView2Initialized
-            m_pendingHtml = newProps->newSource.html.value();
         }
     }
-    
+
     // Apply debugging enabled
     if (newProps->webviewDebuggingEnabled.has_value() && m_webView.CoreWebView2()) {
         m_webView.CoreWebView2().Settings().AreDevToolsEnabled(newProps->webviewDebuggingEnabled.value());
     }
-    
-    // Apply JavaScript enabled
+
+    // Apply JavaScript enabled. Stored on the instance (m_javaScriptEnabled)
+    // so OnCoreWebView2Initialized can (re)apply it once CoreWebView2 exists
+    // -- previously, javaScriptEnabled={false} set before CoreWebView2 was
+    // ready (e.g. on first render) was silently dropped: this branch was a
+    // no-op because CoreWebView2() was still null, and
+    // OnCoreWebView2Initialized never reapplied it (only userAgent and
+    // pending HTML were reapplied there).
+    m_javaScriptEnabled = newProps->javaScriptEnabled;
     if (m_webView.CoreWebView2()) {
-        m_webView.CoreWebView2().Settings().IsScriptEnabled(newProps->javaScriptEnabled);
+        m_webView.CoreWebView2().Settings().IsScriptEnabled(m_javaScriptEnabled);
     }
 
     m_updating = false;
@@ -402,12 +425,17 @@ void RCTWebView2ComponentView::OnCoreWebView2Initialized(
     if (!m_webView || !m_webView.CoreWebView2()) return;
     
     RegisterCoreWebView2Events();
-    
+
     // Apply user agent if set
     if (!m_userAgent.empty()) {
         m_webView.CoreWebView2().Settings().UserAgent(m_userAgent);
     }
-    
+
+    // Re-apply javaScriptEnabled here too: UpdateProps may have run before
+    // CoreWebView2 existed, in which case the Settings().IsScriptEnabled()
+    // call there was skipped (see UpdateProps).
+    m_webView.CoreWebView2().Settings().IsScriptEnabled(m_javaScriptEnabled);
+
     // Navigate to deferred HTML source if pending
     if (!m_pendingHtml.empty()) {
         try {

--- a/windows/ReactNativeWebView/RCTWebView2ComponentView.h
+++ b/windows/ReactNativeWebView/RCTWebView2ComponentView.h
@@ -102,6 +102,10 @@ private:
     bool m_linkHandlingEnabled{true};
     winrt::hstring m_injectedJavascript{L""};
     winrt::hstring m_userAgent{L""};
+    // Mirrors RCTWebView2Props::javaScriptEnabled (default true). Stored so
+    // OnCoreWebView2Initialized can (re)apply it once CoreWebView2 exists,
+    // even if UpdateProps ran first.
+    bool m_javaScriptEnabled{true};
     bool m_updating{false};
     std::string m_pendingHtml{};
 };


### PR DESCRIPTION
Part of the hardening series offered in #3980. This is **WV-4**: fix `javaScriptEnabled` lost before core-init, and stop re-navigating on unrelated prop changes.

### Problem

Two prop-lifecycle bugs in `UpdateProps`:

- `javaScriptEnabled` is only applied when `m_webView.CoreWebView2()` already exists (`if (m_webView.CoreWebView2()) { ...IsScriptEnabled(...); }`). `OnCoreWebView2Initialized` only reapplies `userAgent` and pending HTML once the core becomes ready — never `javaScriptEnabled`.
- `newSource.uri` / `newSource.html` are applied unconditionally whenever present. `UpdateProps` receives the **full current prop set** on every call (not a diff of what changed), so `m_webView.Source(uri)` / `NavigateToString(html)` re-runs on *any* prop change that happens to co-occur with a still-set source — not just an actual source change.

### Real-world failure mode

- `<WebView javaScriptEnabled={false} source={{uri}} />` set on first render: the prop is captured by `UpdateProps` before `CoreWebView2` exists, the branch is a no-op, and `OnCoreWebView2Initialized` never revisits it — JS ends up enabled despite the prop, silently.
- Any subsequent prop change on the component (toggling `javaScriptEnabled`, changing `userAgent`, anything that triggers a Fabric prop update) re-sets `Source(uri)` with the *same* URI it already has — a real navigation/reload as a side effect of an unrelated prop change. This is a plausible perf/UX regression for any app that re-renders a `<WebView>` with other changing props while `source` stays constant.

### Fix

- `javaScriptEnabled` is now stored on the instance (`m_javaScriptEnabled`) and (re)applied both in `UpdateProps` (when the core already exists) and in `OnCoreWebView2Initialized` (covering the case where `UpdateProps` ran first).
- `newSource.uri` / `newSource.html` are now diffed against `oldProps` (already an `UpdateProps` parameter, previously unused) — `Source()`/`NavigateToString()` only run when the value actually changed. `oldProps` is null on first mount, so the initial navigation is unaffected.

### Question for maintainers

We didn't confirm from source whether WinUI3's `WebView2.Source` setter itself no-ops when set to an unchanged URI (i.e. whether this is a double-fix or the actual fix). Either way the `NavigateToString`/html path had the identical unconditional-re-navigate structure, so the diffing is applied uniformly; if `Source()` already no-ops internally, this PR is still a correctness improvement for the html path and cheap insurance for the uri path.

### Validation status

**Not compiled against this repo.** No Windows build was run this pass — verified by hand against `RCTWebView2ComponentView.cpp`, not by building.

Both the `javaScriptEnabled` lifecycle fix and the applied-source diffing (there tracked via `appliedUri`/`appliedHtml` rather than a raw `oldProps` diff, but same effect) are production-proven in a parallel, independently-built Windows new-arch WebView2 Fabric component running in Facilitron FIT (react-native-windows 0.83.2, WinAppSDK 1.8, ARM64) — see the production twin: [FacilitronWorks/react-native-webview-windows](https://github.com/FacilitronWorks/react-native-webview-windows). Renamed symbols, hand-ported to this repo's codegen/class shape — not a copy-paste.

Related: #3980
