### PR TITLE
docs: add Keep Android Open banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![NPM Version](https://img.shields.io/npm/v/react-native-webview.svg?style=flat-square)](https://www.npmjs.com/package/react-native-webview)
 ![Npm Downloads](https://img.shields.io/npm/dm/react-native-webview.svg)
 
+> [!IMPORTANT]
+> **📢 Keep Android Open** — Starting September 2026, Google plans to block apps from unregistered developers on all certified Android devices, threatening sideloading and independent app distribution.
+> Learn more at [keepandroidopen.org](https://keepandroidopen.org/) and add the countdown banner to your own website: [https://keepandroidopen.org/banner/](https://keepandroidopen.org/banner/)
+
 **React Native WebView** is a community-maintained WebView component for React Native. It is intended to be a replacement for the built-in WebView (which was [removed from core](https://github.com/react-native-community/discussions-and-proposals/pull/3)).
 
 ### Maintainers


### PR DESCRIPTION
Adds a Keep Android Open callout to the top of the README, linking to [keepandroidopen.org](https://keepandroidopen.org/) and its [banner page](https://keepandroidopen.org/banner/).

Note: the campaign's banner itself is a JavaScript embed (`banner.js`), which GitHub READMEs can't execute, so this uses a GitHub `[!IMPORTANT]` alert with links instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pWws7t6MSh4sHbUGVFs9h

---
_Generated by [Claude Code](https://claude.ai/code/session_014pWws7t6MSh4sHbUGVFs9h)_