### PR TITLE
fix(iOS): support HTTP Digest authentication via basicAuthCredential

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1152,7 +1152,8 @@ RCTAutoInsetsProtocol>
       }
     }
   }
-  if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic) {
+  if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic ||
+      [[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPDigest) {
     NSString *username = [_basicAuthCredential valueForKey:@"username"];
     NSString *password = [_basicAuthCredential valueForKey:@"password"];
     if (username && password) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1667,10 +1667,10 @@ Function called when a custom menu item is selected. It receives a Native event,
 
 ### `basicAuthCredential`[⬆](#props-index)
 
-An object that specifies the credentials of a user to be used for basic authentication.
+An object that specifies the credentials of a user to be used for HTTP authentication. Both Basic and Digest authentication schemes are supported (Android & iOS).
 
-- `username` (string) - A username used for basic authentication.
-- `password` (string) - A password used for basic authentication.
+- `username` (string) - A username used for HTTP authentication.
+- `password` (string) - A password used for HTTP authentication.
 
 | Type   | Required |
 | ------ | -------- |


### PR DESCRIPTION
## Fixes #419

### Problem
`basicAuthCredential` worked for Basic auth but digest-protected resources (e.g. MJPEG streams) still returned `401` on iOS. Passing `Authorization` via `source.headers` doesn't help because WKWebView only sends it on the initial request, not on the challenge/subresource requests.

### Cause
On iOS, `webView:didReceiveAuthenticationChallenge:` only matched `NSURLAuthenticationMethodHTTPBasic`, so digest challenges fell through to `NSURLSessionAuthChallengePerformDefaultHandling` and the credential was never used. Android already handles digest via `HttpAuthHandler.proceed()`.

### Fix
Accept `NSURLAuthenticationMethodHTTPDigest` alongside Basic — the credential creation path is identical (`NSURLCredential` with the supplied username/password).

```objc
if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPBasic ||
    [[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodHTTPDigest) {
```

No API change — existing `basicAuthCredential` prop now covers Basic **and** Digest on both platforms. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)