### PR TITLE
fix(ios): honor empty menuItems for system edit menu suppression

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -94,12 +94,33 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   return NO;
 }
 - (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder API_AVAILABLE(ios(13.0))  {
-    if (@available(iOS 16.0, *)) {
-      if(self.menuItems){
-        [builder removeMenuForIdentifier:UIMenuLookup];
-      }
-    }
-    [super buildMenuWithBuilder:builder];
+  // Build the default menu first. Removing system items *before* super is a no-op:
+  // super re-injects Look Up / Translate / Search Web under UIEditMenuInteraction (iOS 16+).
+  [super buildMenuWithBuilder:builder];
+
+  // menuItems non-nil (including an empty array) means the host owns selection menu UX.
+  // Docs: an empty array suppresses the system menu.
+  if (self.menuItems == nil) {
+    return;
+  }
+
+  if (@available(iOS 16.0, *)) {
+    [builder removeMenuForIdentifier:UIMenuStandardEdit];
+    [builder removeMenuForIdentifier:UIMenuLookup];
+    [builder removeMenuForIdentifier:UIMenuShare];
+    [builder removeMenuForIdentifier:UIMenuLearn];
+    [builder removeMenuForIdentifier:UIMenuSpeech];
+    [builder removeMenuForIdentifier:UIMenuSpelling];
+    [builder removeMenuForIdentifier:UIMenuSubstitution];
+    [builder removeMenuForIdentifier:UIMenuTransformation];
+  }
+
+  // Empty menuItems: fully suppress residual items that lack stable identifiers (e.g. Search Web).
+  if (self.menuItems.count == 0) {
+    [builder replaceChildrenOfMenuForIdentifier:UIMenuRoot fromChildrenBlock:^NSArray<UIMenuElement *> *(NSArray<UIMenuElement *> *children) {
+      return @[];
+    }];
+  }
 }
 #else // TARGET_OS_OSX
 - (void)scrollWheel:(NSEvent *)theEvent {
@@ -255,19 +276,21 @@ RCTAutoInsetsProtocol>
     if (pressSender.state != UIGestureRecognizerStateEnded || !self.menuItems) {
         return;
     }
+    // Empty menuItems means fully suppress the system/edit menu — do not present one.
+    if (self.menuItems.count == 0) {
+      if (@available(iOS 13.0, *)) {
+        UIMenuController *menuController = [UIMenuController sharedMenuController];
+        menuController.menuItems = nil;
+        [menuController hideMenu];
+      }
+      return;
+    }
     if (@available(iOS 16.0, *)) {
       CGPoint location = [pressSender locationInView:self];
       UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
       [_editMenuInteraction presentEditMenuWithConfiguration:config];
     } else {
       // When a long press ends, bring up our custom UIMenu if defined
-      if (self.menuItems.count == 0) {
-        UIMenuController *menuController = [UIMenuController sharedMenuController];
-        menuController.menuItems = nil;
-        [menuController showMenuFromView:self rect:self.bounds];
-        return;
-      }
-
       UIMenuController *menuController = [UIMenuController sharedMenuController];
       NSMutableArray *menuControllerItems = [NSMutableArray arrayWithCapacity:self.menuItems.count];
 


### PR DESCRIPTION
## Summary

On iOS 16+, setting `menuItems={[]}` (documented as “suppress the menu”) still leaves the system text selection callout visible (**Look Up**, **Translate**, **Search Web**, etc.).

Root cause in `RNCWKWebView`’s `buildMenuWithBuilder:`:

1. System menu identifiers were removed **before** `[super buildMenuWithBuilder:]`.
2. `super` rebuilds the default edit menu via `UIEditMenuInteraction`, so Look Up / Translate / Search Web reappear.
3. Only `UIMenuLookup` was targeted, so other groups were never stripped.
4. For an empty `menuItems` array, the long-press path could still present a menu controller / edit menu instead of staying silent.

This matches reports that `suppressMenuItems` alone is insufficient for modern system actions (e.g. share / translate), and that empty `menuItems` does not fully suppress the callout.

Related issues:

- #3730 (`suppressMenuItems` does not suppress share / translate and similar)
- #3269 / #2885 (iOS 16+ menu / `UIEditMenuInteraction` behavior)
- #934 / #1183 (desire to hide default selection menu while keeping selection)

## Changes

### `apple/RNCWebViewImpl.m`

- Call `[super buildMenuWithBuilder:]` **first**, then remove system menu groups when `menuItems != nil`.
- Strip standard edit-related groups on iOS 16+: standard edit, lookup, share, learn, speech, spelling, substitution, transformation.
- When `menuItems` is an **empty array**, also clear residual root children (covers items without stable public identifiers such as Search Web).
- When `menuItems` is empty, **do not** present a long-press edit menu; hide any residual `UIMenuController` instead of showing it.

Behavior when `menuItems` is `nil` is unchanged (stock system menu).

## Test plan

- [ ] iOS 16+ device or simulator, React Native app using current `react-native-webview`
- [ ] `<WebView menuItems={[]} source={{ uri: 'https://example.com' }} />`
- [ ] Long-press / select a word
- [ ] **Expect:** no system Look Up / Translate / Search Web callout
- [ ] Custom non-empty `menuItems` + `onCustomMenuSelection` still shows only the provided items
- [ ] Omit `menuItems` entirely and confirm the default system menu still appears
- [ ] Pre-iOS 16 path: empty `menuItems` does not force-show `UIMenuController`

## Notes

- JS-only CSS (`-webkit-touch-callout: none`) / `contextmenu` handlers are not sufficient for the modern `UIEditMenuInteraction` callout; the fix has to live in native menu building.
- This does not expand the public API surface; it makes documented `menuItems={[]}` behavior work as described in `WebViewTypes` / docs.